### PR TITLE
VIX-2223 The .NET serial port enumeration has stop bits none as and o…

### DIFF
--- a/Common/Controls/SerialPortConfig.cs
+++ b/Common/Controls/SerialPortConfig.cs
@@ -56,7 +56,9 @@ namespace Common.Controls
 			comboBoxStopBits.Enabled = allowStopEdit;
 
 			comboBoxParity.Items.AddRange(Enum.GetValues(typeof (Parity)).Cast<object>().ToArray());
-			comboBoxStopBits.Items.AddRange(Enum.GetValues(typeof (StopBits)).Cast<object>().ToArray());
+			var stopBits = Enum.GetValues(typeof(StopBits)).Cast<object>().ToList();
+			stopBits.Remove(StopBits.None);
+			comboBoxStopBits.Items.AddRange(stopBits.ToArray());
 
 			//set our text value
 			if (serialPort != null) {


### PR DESCRIPTION
…ption, but it is not a valid choice and throws an exception if used. This is documented in the API docs. https://docs.microsoft.com/en-us/dotnet/api/system.io.ports.serialport?view=netframework-4.7.2 Added logic to exclude that from being a choice to prevent unintended crashes. This affects the Renard and the Generic Serial controllers.