### PR TITLE
VIX-2258 Add some logic to prevent the main timeline from being close…

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -5370,7 +5370,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			toolStripMenuItemColorLibrary.Checked = !(_colorLibraryForm == null || _colorLibraryForm.DockState == DockState.Unknown);
 			toolStripMenuItemGradientLibrary.Checked = !(_gradientLibraryForm == null || _gradientLibraryForm.DockState == DockState.Unknown);
 			toolStripMenuItemCurveLibrary.Checked = !(_curveLibraryForm == null || _curveLibraryForm.DockState == DockState.Unknown);
-			gridWindowToolStripMenuItem.Checked = !GridForm.IsHidden;
+			gridWindowToolStripMenuItem.Checked = !(GridForm.IsHidden || GridForm.DockState == DockState.Unknown);
 			effectEditorWindowToolStripMenuItem.Checked =
 				!(_effectEditorForm == null || EffectEditorForm.DockState == DockState.Unknown);
 		}

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Menu.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Menu.cs
@@ -345,8 +345,15 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		private void gridWindowToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			HandleDockContentToolStripMenuClick(GridForm, DockState.Document);
+			//Gridform or the main timeline should not be closed.
+			if (!GridForm.IsDisposed)
+			{
+				if (GridForm.IsHidden || GridForm.DockState == DockState.Unknown)
+				{
+					GridForm.Show(dockPanel, DockState.Document);
+				}
 			}
+		}
 			
 		private void effectEditorWindowToolStripMenuItem_Click(object sender, EventArgs e)
 		{


### PR DESCRIPTION
…d. The View menu should only allow restoring a hidden timeline, not closing it. There is no good reason for the timeline to be closed.