### PR TITLE
VIX-2719 Fix an issue that can cause a crash it the user right clicks…

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_ContextMenu.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_ContextMenu.cs
@@ -244,7 +244,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			contextMenuItemAlignment.DropDown.Items.Add(contextMenuItemAlignEndToMark);
 			contextMenuItemAlignment.DropDown.Items.Add(contextMenuItemAlignBothToMark);
 
-			if (TimelineControl.SelectedElements.Count() > 1 || (TimelineControl.SelectedElements.Any() && !element.Selected))
+			if (TimelineControl.SelectedElements.Count() > 1 || TimelineControl.SelectedElements.Any() && element != null && !element.Selected)
 			{
 				contextMenuItemDistributeEqually.Enabled = true;
 				contextMenuItemDistDialog.Enabled = true;


### PR DESCRIPTION
… with a single selected effect while holding the shift key. There was a property call on a null item that was not checked properly.