### PR TITLE
VIX-2537 Add logic to select a reasonable Mark collection.

### DIFF
--- a/Modules/Effect/LipSync/LipSync.cs
+++ b/Modules/Effect/LipSync/LipSync.cs
@@ -519,6 +519,17 @@ namespace VixenModules.Effect.LipSync
 					SetLipsyncModeBrowsables();
 					IsDirty = true;
 					OnPropertyChanged();
+					if (_data.LipSyncMode == LipSyncMode.MarkCollection && _data.MarkCollectionId == Guid.Empty)
+					{
+						if (MarkCollections.Any())
+						{
+							var mc = MarkCollections.FirstOrDefault(x => x.CollectionType == MarkCollectionType.Phoneme);
+							if (mc != null)
+							{
+								MarkCollectionId = mc.Name;
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The logic will look for the first collection that is designated as a Phoneme and select it automatically if there is not a collection already set. This will save some step to selecting something that will initially work.