### PR TITLE
VIX-2758 - Shapes Effect - Fix Shapes Output path in Debug X86 config…

### DIFF
--- a/Modules/Effect/Shapes/Shapes.csproj
+++ b/Modules/Effect/Shapes/Shapes.csproj
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>..\..\..\Debug\Modules\Effect\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
… as its incorrect and Shapes effect is not displayed in Sequencer.