### PR TITLE
VIX-2774 Add logic to flush the filter chain after an export session …

### DIFF
--- a/Vixen.System/Cache/Sequence/SequenceIntervalGenerator.cs
+++ b/Vixen.System/Cache/Sequence/SequenceIntervalGenerator.cs
@@ -137,6 +137,7 @@ namespace Vixen.Cache.Sequence
 		{
 			TimingSource.Stop();
 			VixenSystem.Elements.ClearStates();
+			VixenSystem.Filters.Update();
 			if (_context != null)
 			{
 				VixenSystem.Contexts.ReleaseContext(_context);


### PR DESCRIPTION
…after the elements are cleared. This will ensure a clean state throughout the system.