### PR TITLE
VIX-2783 Fix the refresh issue with imported props in the Preview ele…

### DIFF
--- a/Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -743,11 +743,15 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 			var dependencyResolver = this.GetDependencyResolver();
 			var openFileService = dependencyResolver.Resolve<IOpenFileService>();
 			openFileService.IsMultiSelect = false;
-			openFileService.InitialDirectory = Environment.SpecialFolder.MyDocuments.ToString();
+			if (openFileService.InitialDirectory == null)
+			{
+				openFileService.InitialDirectory = Paths.DataRootPath;
+			}
 			openFileService.Filter = "xModel (*.xmodel)|*.xmodel";
 			if (await openFileService.DetermineFileAsync())
 			{
-				string path = openFileService.FileNames.First();
+				string path = openFileService.FileName;
+				openFileService.InitialDirectory = Path.GetDirectoryName(path);
 				if (!string.IsNullOrEmpty(path))
 				{
 					IModelImport import = new XModelImport();

--- a/Modules/Preview/VixenPreview/PreviewCustomPropBuilder.cs
+++ b/Modules/Preview/VixenPreview/PreviewCustomPropBuilder.cs
@@ -37,9 +37,9 @@ namespace VixenModules.Preview.VixenPreview
 
 		public PreviewCustomProp PreviewCustomProp { get; private set; }
 
-		public async Task CreateAsync()
+		public async Task<ElementNode> CreateAsync()
 		{
-			Task t = Task.Factory.StartNew(() =>
+			return await Task.Factory.StartNew(() =>
 			{
 				_elementModelMap = new Dictionary<Guid, ElementNode>();
 				//Optimize the name check for performance. We know we are going to create a bunch of them and we can handle it ourselves more efficiently
@@ -79,11 +79,9 @@ namespace VixenModules.Preview.VixenPreview
 				PreviewCustomProp.UpdateColorType();
 				
 				PreviewCustomProp.Layout();
-				
+
+				return rootElementNode;
 			});
-
-			await t;
-
 		}
 
 		private string TokenizeName(string name)

--- a/Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -1845,11 +1845,15 @@ namespace VixenModules.Preview.VixenPreview
 			var dependencyResolver = this.GetDependencyResolver();
 			var openFileService = dependencyResolver.Resolve<IOpenFileService>();
 			openFileService.IsMultiSelect = false;
-			openFileService.InitialDirectory = PropModelServices.Instance().ModelsFolder;
+			if (openFileService.InitialDirectory == null)
+			{
+				openFileService.InitialDirectory = Paths.DataRootPath;
+			}
 			openFileService.Filter = "Prop Files(*.prp)|*.prp";
 			if (await openFileService.DetermineFileAsync())
 			{
-				string path = openFileService.FileNames.First();
+				openFileService.InitialDirectory = Path.GetDirectoryName(openFileService.FileName);
+				string path = openFileService.FileName;
 				await ImportCustomPropFromFile(path);
 			}
 		}
@@ -1911,9 +1915,8 @@ namespace VixenModules.Preview.VixenPreview
 		internal async Task AddPropToPreviewAsync(Prop p, Point location)
 		{
 			PreviewCustomPropBuilder builder = new PreviewCustomPropBuilder(p, ZoomLevel, this);
-			await builder.CreateAsync();
-			OnElementsChanged?.Invoke(this, EventArgs.Empty);
-
+			var newElement = await builder.CreateAsync();
+			elementsForm.AddNodeToTree(newElement);
 			var newDisplayItem = new DisplayItem();
 			newDisplayItem.Shape = builder.PreviewCustomProp;
 			//Ensure a reasonable size.

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
@@ -131,10 +131,16 @@ namespace VixenModules.Preview.VixenPreview
 						messageBox.ShowDialog();
 						return;
 					}
-					treeElements.AddNodePathToTree(new[] { createdElements.First() });
-					treeElements.UpdateScrollPosition();
+					AddNodeToTree(createdElements.First());
 				}
 			}
+		}
+
+		internal void AddNodeToTree(ElementNode node)
+		{
+			if (node == null) return;
+			treeElements.AddNodePathToTree(new[] { node });
+			treeElements.UpdateScrollPosition();
 		}
 
 		private void ComboBoxNewItemType_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
…ment tree.

When the element tree was switched to use the one from the display setup, the refresh mechanism that was in the preview was no longer working. Wire up a new mechanism to manage that.

Set the initial directory path to be the profile if it is not already set for imports.