### PR TITLE
VIX-2789 Add support for Face Mapping in the Custom Prop Editor.

### DIFF
--- a/Common/WPFCommon/Theme/Theme.xaml
+++ b/Common/WPFCommon/Theme/Theme.xaml
@@ -1710,6 +1710,10 @@
 		</Setter>
 	</Style>
 
+	<Style TargetType="{x:Type TabControl}">
+		<Setter Property="Background" Value="{DynamicResource BackColorBrush}"/>
+	</Style>
+
 	<!--<Style TargetType="{x:Type TabControl}">
 		<Setter Property="OverridesDefaultStyle" Value="True" />
 		<Setter Property="SnapsToDevicePixels" Value="True" />

--- a/Modules/App/CustomPropEditor/CustomPropEditor.csproj
+++ b/Modules/App/CustomPropEditor/CustomPropEditor.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Model\ColorMode.cs" />
     <Compile Include="Model\Configuration.cs" />
     <Compile Include="Model\ElementType.cs" />
+    <Compile Include="Model\FaceComponent.cs" />
     <Compile Include="Model\InformationMetadata.cs" />
     <Compile Include="Model\InternalVendorInventory\Category.cs" />
     <Compile Include="Model\InternalVendorInventory\ModelInventory.cs" />

--- a/Modules/App/CustomPropEditor/Import/XLights/FaceInfo.cs
+++ b/Modules/App/CustomPropEditor/Import/XLights/FaceInfo.cs
@@ -1,18 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using VixenModules.App.CustomPropEditor.Model;
 
 namespace VixenModules.App.CustomPropEditor.Import.XLights
 {
 	public class FaceInfo
 	{
-		public static string[] Attributes = new[]
+		public static Dictionary<string,FaceComponent> Attributes = new Dictionary<string, FaceComponent>()
 		{
-			"Eyes-Closed", "Eyes-Open", "FaceOutline", "Mouth-AI", "Mouth-E", "Mouth-FV", "Mouth-L", "Mouth-MBP",
-			"Mouth-O", "Mouth-U", "Mouth-WQ", "Mouth-etc", "Mouth-rest",
+			{ "Eyes-Closed", Model.FaceComponent.EyesClosed},
+			{ "Eyes-Open", Model.FaceComponent.EyesOpen},
+			{ "FaceOutline", Model.FaceComponent.Outlines },
+			{ "Mouth-AI", Model.FaceComponent.AI},
+			{ "Mouth-FV", Model.FaceComponent.FV},
+			{ "Mouth-MBP",Model.FaceComponent.MBP},
+			{ "Mouth-E", Model.FaceComponent.E},
+			{ "Mouth-L", Model.FaceComponent.L},
+			{ "Mouth-O", Model.FaceComponent.O},
+			{ "Mouth-U", Model.FaceComponent.U},
+			{ "Mouth-WQ", Model.FaceComponent.WQ},
+			{ "Mouth-etc", Model.FaceComponent.ETC},
+			{ "Mouth-rest", Model.FaceComponent.REST}
 		};
+
+		public FaceInfo()
+		{
+			FaceComponent = Model.FaceComponent.None;
+		}
+
+		public FaceInfo(FaceComponent faceComponent)
+		{
+			FaceComponent = faceComponent;
+		}
+
+		public FaceComponent FaceComponent { get;}
 
 	}
 }

--- a/Modules/App/CustomPropEditor/Import/XLights/SubModel.cs
+++ b/Modules/App/CustomPropEditor/Import/XLights/SubModel.cs
@@ -1,9 +1,14 @@
 ﻿using System.Collections.Generic;
+using VixenModules.App.CustomPropEditor.Model;
 
 namespace VixenModules.App.CustomPropEditor.Import.XLights
 {
 	public class SubModel
 	{
+		public SubModel()
+		{
+			FaceInfo = new FaceInfo(FaceComponent.None);
+		}
 		public string Name { get; set; }
 
 		public string Layout { get; set; }
@@ -11,6 +16,8 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 		public SubModelType Type { get; set; }
 
 		public List<Range> Ranges { get; set; }
+
+		public FaceInfo FaceInfo { get; set; }
 	}
 
 	public class Range

--- a/Modules/App/CustomPropEditor/Import/XLights/XModelImport.cs
+++ b/Modules/App/CustomPropEditor/Import/XLights/XModelImport.cs
@@ -78,13 +78,14 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 							{
 								foreach (var attribute in FaceInfo.Attributes)
 								{
-									var range = reader.GetAttribute(attribute);
+									var range = reader.GetAttribute(attribute.Key);
 									if (!string.IsNullOrEmpty(range))
 									{
 										SubModel sm = new SubModel();
-										sm.Name = attribute;
+										sm.Name = attribute.Key;
 										sm.Type = SubModelType.Ranges;
 										sm.Ranges = ParseRanges(range);
+										sm.FaceInfo = new FaceInfo(attribute.Value);
 										subModels.Add(sm);
 									}
 								}
@@ -132,6 +133,10 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 			foreach (var subModel in subModels)
 			{
 				var group = PropModelServices.Instance().CreateNode(subModel.Name);
+				if (subModel.FaceInfo.FaceComponent != FaceComponent.None)
+				{
+					group.FaceComponent = subModel.FaceInfo.FaceComponent;
+				}
 				foreach (var smRange in subModel.Ranges)
 				{
 					var start = smRange.Start < smRange.End ? smRange.Start : smRange.End;
@@ -143,7 +148,7 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 							var modelNode = modelNodes[i];
 							modelNodes.Remove(i);
 							var lightNode = PropModelServices.Instance().AddLightNode(group, new Point(modelNode.X + Offset, modelNode.Y + Offset), modelNode.Order, nodeSize);
-							if(!lightNodes.ContainsKey(modelNode.Order))
+							if (!lightNodes.ContainsKey(modelNode.Order))
 							{
 								lightNodes.Add(modelNode.Order, lightNode);
 							}

--- a/Modules/App/CustomPropEditor/Model/ElementModel.cs
+++ b/Modules/App/CustomPropEditor/Model/ElementModel.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Catel.Collections;
 using Common.WPFCommon.ViewModel;
-using VixenModules.App.CustomPropEditor.Services;
 
 namespace VixenModules.App.CustomPropEditor.Model
 {
@@ -21,6 +20,7 @@ namespace VixenModules.App.CustomPropEditor.Model
 		private int _order;
 		private string _name;
 		private int _lightSize;
+		private FaceComponent _faceComponent;
 
 		#region Constructors
 
@@ -31,6 +31,7 @@ namespace VixenModules.App.CustomPropEditor.Model
 			Parents = new ObservableCollection<Guid>();
 			Id = Guid.NewGuid();
 			LightSize = DefaultLightSize;
+			FaceComponent = FaceComponent.None;
 		}
 
 		public ElementModel(string name) : this()
@@ -153,6 +154,21 @@ namespace VixenModules.App.CustomPropEditor.Model
 
 		#endregion
 
+		#region Face Component
+
+		public FaceComponent FaceComponent
+		{
+			get => _faceComponent;
+			set
+			{
+				if (Equals(value, _faceComponent)) return;
+				_faceComponent = value;
+				OnPropertyChanged(nameof(FaceComponent));
+			}
+		}
+
+		#endregion
+
 		#region IsLeaf
 
 		public bool IsLeaf => !Children.Any();
@@ -231,6 +247,20 @@ namespace VixenModules.App.CustomPropEditor.Model
 		}
 
 		#endregion
+
+		public static bool IsPhoneme(FaceComponent faceComponent)
+		{
+			switch (faceComponent)
+			{
+				case FaceComponent.None:
+				case FaceComponent.EyesClosed:
+				case FaceComponent.EyesOpen:
+				case FaceComponent.Outlines:
+					return false;
+				default:
+					return true;
+			}
+		}
 
 		public bool RemoveParent(ElementModel parent)
 		{

--- a/Modules/App/CustomPropEditor/Model/FaceComponent.cs
+++ b/Modules/App/CustomPropEditor/Model/FaceComponent.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace VixenModules.App.CustomPropEditor.Model
+{
+	public enum FaceComponent
+	{
+		None,
+		[Description("Eyes Closed")]
+		EyesClosed,
+		[Description("Eyes Open")]
+		EyesOpen,
+		[Description("Outline")]
+		Outlines,
+		AI,
+		E,
+		FV,
+		L,
+		MBP,
+		O,
+		U,
+		WQ,
+		ETC,
+		REST
+	}
+}

--- a/Modules/App/CustomPropEditor/Services/PropModelServices.cs
+++ b/Modules/App/CustomPropEditor/Services/PropModelServices.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Media.Imaging;
 using Catel.Collections;
 using NLog;
+using Vixen.Sys;
 using VixenModules.App.CustomPropEditor.Model;
 using Point = System.Windows.Point;
 
@@ -19,7 +20,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 		
 		private PropModelServices()
 		{
-			ModelsFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			ModelsFolder = Paths.DataRootPath;
 		}
 
 		public static PropModelServices Instance()

--- a/Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Windows.Controls.WpfPropertyGrid;
 using Catel.Data;
 using Catel.MVVM;
 using VixenModules.App.CustomPropEditor.Model;
@@ -176,13 +177,14 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Gets or sets the IsLightNode value.
 		/// </summary>
-		
+		[Browsable(false)]
 		public bool IsLightNode => ElementModel.IsLightNode;
 
 		#endregion
 
 		#region Name Property
 
+		[PropertyOrder(0)]
 		public string Name
 		{
 			get { return ElementModel.Name; }
@@ -194,6 +196,39 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				RaisePropertyChanged(nameof(Name), oldValue , value);
 			}
 		}
+
+		#endregion
+
+		#region FaceComponent property
+
+		/// <summary>
+		/// Gets or sets the FaceComponent value.
+		/// </summary>
+		[PropertyOrder(1)]
+		[DisplayName("Face Component")]
+		[Description("Face component associated with this element for Lip-Sync.")]
+		public FaceComponent FaceComponent
+		{
+			get { return ElementModel.FaceComponent; }
+			set {
+				object oldValue = ElementModel.FaceComponent;
+				ElementModel.FaceComponent = value;
+				IsDirty = true;
+				RaisePropertyChanged(nameof(FaceComponent), oldValue, value);
+			}
+		}
+
+		#endregion
+
+		#region ChildCount property
+
+		/// <summary>
+		/// Gets or sets the ChildCount value.
+		/// </summary>
+		[DisplayName("Child Elements")]
+		[Description("Number of child elements associated with this element.")]
+		[PropertyOrder(3)]
+		public int ChildCount => ElementModel.Children.Count;
 
 		#endregion
 
@@ -259,6 +294,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Gets the CancelEditing command.
 		/// </summary>
+		[Browsable(false)]
 		public Command CancelEditingCommand
 		{
 			get { return _cancelEditingCommand ?? (_cancelEditingCommand = new Command(CancelEditing)); }

--- a/Modules/App/CustomPropEditor/Views/CustomPropEditorWindow.xaml
+++ b/Modules/App/CustomPropEditor/Views/CustomPropEditorWindow.xaml
@@ -144,13 +144,53 @@
 				</Grid.RowDefinitions>
 
 				<views1:ElementTree Grid.Column="0" Grid.Row="0" />
-				
-				<TabControl Background="{StaticResource BackColorBrush}"
-				            Grid.Row="2" Grid.Column="0"
-				            Width="Auto" Margin="5,5,10,5">
-					<TabItem Header="General">
-						<wpfPropertyGrid:PropertyGrid Background="{StaticResource DisabledShadow}"
+
+				<TabControl  Grid.Row="2" Grid.Column="0" Background="{DynamicResource BackColorBrush}"
+				             Width="Auto" Margin="5,5,10,5">
+					<TabItem Header="Prop Info">
+						<TabControl Width="Auto">
+							<TabItem Header="General">
+								<wpfPropertyGrid:PropertyGrid Background="{StaticResource DisabledShadow}"
 						                              ItemSource="{Binding}"
+						                              ShowAttachedProperties="False"
+						                              ShowReadOnlyProperties="True"
+						                              PropertyFilterVisibility="Collapsed"
+						                              Margin="5">
+									<wpfPropertyGrid:PropertyGrid.Resources>
+										<ResourceDictionary>
+											<ResourceDictionary.MergedDictionaries>
+												<wpfPropertyGrid:KaxamlTheme/>
+											</ResourceDictionary.MergedDictionaries>
+										</ResourceDictionary>
+									</wpfPropertyGrid:PropertyGrid.Resources>
+								</wpfPropertyGrid:PropertyGrid>
+							</TabItem>
+							<TabItem Header="Physical">
+								<views1:PhysicalMetadataView DataContext="{Binding PhysicalMetadata}"/>
+							</TabItem>
+							<TabItem Header="Vendor">
+								<views1:VendorMetadataView DataContext="{Binding VendorMetadata}"/>
+							</TabItem>
+							<TabItem Header="Notes">
+								<TabPanel Name="Panel" Background="{StaticResource DisabledShadow}">
+									<TextBox Text="{Binding InformationMetadata.Notes}"
+									        Margin="5,5,0,0"
+									        TextWrapping="Wrap" 
+									        AcceptsReturn="True" 
+									        AcceptsTab="True" 
+									        SpellCheck.IsEnabled="True" 
+									        Height="{Binding Path=ActualHeight, ElementName=Panel, Converter={StaticResource AdditionConverter}, ConverterParameter=-10}"
+									        Width="{Binding Path=ActualWidth, ElementName=Panel, Converter={StaticResource AdditionConverter}, ConverterParameter=-10}"
+											VerticalScrollBarVisibility="Auto"
+											HorizontalScrollBarVisibility="Disabled"/>
+
+								</TabPanel>
+							</TabItem>
+						</TabControl>
+					</TabItem>
+					<TabItem Header="Element Info">
+						<wpfPropertyGrid:PropertyGrid Background="{StaticResource DisabledShadow}"
+						                              ItemSource="{Binding ElementTreeViewModel.SelectedItem}"
 						                              ShowAttachedProperties="False"
 						                              ShowReadOnlyProperties="True"
 						                              PropertyFilterVisibility="Collapsed"
@@ -164,28 +204,9 @@
 							</wpfPropertyGrid:PropertyGrid.Resources>
 						</wpfPropertyGrid:PropertyGrid>
 					</TabItem>
-					<TabItem Header="Physical">
-						<views1:PhysicalMetadataView DataContext="{Binding PhysicalMetadata}"/>
-					</TabItem>
-					<TabItem Header="Vendor">
-						<views1:VendorMetadataView DataContext="{Binding VendorMetadata}"/>
-					</TabItem>
-					<TabItem Header="Notes">
-						<TabPanel Name="Panel" Background="{StaticResource DisabledShadow}">
-							<TextBox Text="{Binding InformationMetadata.Notes}"
-									        Margin="5,5,0,0"
-									        TextWrapping="Wrap" 
-									        AcceptsReturn="True" 
-									        AcceptsTab="True" 
-									        SpellCheck.IsEnabled="True" 
-									        Height="{Binding Path=ActualHeight, ElementName=Panel, Converter={StaticResource AdditionConverter}, ConverterParameter=-10}"
-									        Width="{Binding Path=ActualWidth, ElementName=Panel, Converter={StaticResource AdditionConverter}, ConverterParameter=-10}"
-											VerticalScrollBarVisibility="Auto"
-											HorizontalScrollBarVisibility="Disabled"/>
-
-						</TabPanel>
-					</TabItem>
 				</TabControl>
+				
+				
 					
 				<!--</Border>-->
 

--- a/Modules/Preview/VixenPreview/PreviewCustomPropBuilder.cs
+++ b/Modules/Preview/VixenPreview/PreviewCustomPropBuilder.cs
@@ -6,10 +6,13 @@ using System.Threading.Tasks;
 using Vixen.Services;
 using Vixen.Sys;
 using Vixen.Utility;
+using VixenModules.App.CustomPropEditor.Import.XLights;
 using VixenModules.App.CustomPropEditor.Model;
 using VixenModules.Preview.VixenPreview.Shapes;
 using VixenModules.Property.Color;
+using VixenModules.Property.Face;
 using VixenModules.Property.Order;
+using FaceComponent = VixenModules.App.CustomPropEditor.Model.FaceComponent;
 
 namespace VixenModules.Preview.VixenPreview
 {
@@ -129,10 +132,41 @@ namespace VixenModules.Preview.VixenPreview
 					NamingUtilities.Uniquify(_elementNames, TokenizeName(elementModel.Name)));
 				_elementModelMap.Add(elementModel.Id, node);
 				_elementNames.Add(node.Name);
+				if (elementModel.FaceComponent != FaceComponent.None)
+				{
+					FaceModule fm = null;
+					if (node.Properties.Contains(FaceDescriptor.ModuleId))
+					{
+						fm = node.Properties.Get(FaceDescriptor.ModuleId) as FaceModule;
+					}
+					else
+					{
+						fm = node.Properties.Add(FaceDescriptor.ModuleId) as FaceModule;
+					}
+
+					if (ElementModel.IsPhoneme(elementModel.FaceComponent))
+					{
+						fm.PhonemeList.Add(elementModel.FaceComponent.ToString(), true);
+					}
+					else
+					{
+						switch (elementModel.FaceComponent)
+						{
+							case FaceComponent.EyesOpen:
+								fm.FaceComponents.Add(Property.Face.FaceComponent.EyesOpen, true);
+								break;
+							case FaceComponent.EyesClosed:
+								fm.FaceComponents.Add(Property.Face.FaceComponent.EyesClosed, true);
+								break;
+							case FaceComponent.Outlines:
+								fm.FaceComponents.Add(Property.Face.FaceComponent.Outlines, true);
+								break;
+						}
+					}
+				}
 				if (elementModel.IsLightNode)
 				{
-					var order = node.Properties.Add(OrderDescriptor.ModuleId) as OrderModule;
-					if (order != null)
+					if (node.Properties.Add(OrderDescriptor.ModuleId) is OrderModule order)
 					{
 						order.Order = elementModel.Order;
 					}

--- a/Modules/Preview/VixenPreview/VixenPreview.csproj
+++ b/Modules/Preview/VixenPreview/VixenPreview.csproj
@@ -100,6 +100,11 @@
       <Name>FastPixel</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\Property\Face\Face.csproj">
+      <Project>{5FCC5484-8894-4E36-BA81-B2F1B9008404}</Project>
+      <Name>Face</Name>
+      <Private>False</Private>
+    </ProjectReference>
     <ProjectReference Include="..\..\Property\Location\Location.csproj">
       <Project>{7d5d4be4-576a-4092-a3e2-1a6f27cdc213}</Project>
       <Name>Location</Name>

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
@@ -59,9 +59,11 @@ namespace VixenModules.Preview.VixenPreview
 		private void HighlightNode(ElementNode node)
 		{
 			// Is this a group?
-			if (!node.IsLeaf) {
+			if (!node.IsLeaf)
+			{
 				// If so, iterate through children and highlight them
-				foreach (var childNode in node.Children) {
+				foreach (var childNode in node.Children)
+				{
 					HighlightNode(childNode);
 				}
 			}


### PR DESCRIPTION
Added a tab to manage Element properties into the prop editor. Separated the general prop info from a Element info tab. This tab provides the ability to see more details on the Element. Added a Face Component property to Elements and gave the ability for the user to assign a face component to an element or most likely group.

Added the ability to map the new Face Component property on the model to the Face Property upon loading a prop into the preview. This sets up the mapping according to the model definition.

Added the ability to import the xModel face definitions and map them to the new Face Component when importing a model. Now if the model is setup correctly the user will have very little additional work to do. They can alter that mapping with the mechanism above in the prop editor to suit their needs if necessary.