### PR TITLE
VIX-2792 Fix an issue in the where the set level effect fails to work.

### DIFF
--- a/Vixen.System/Data/Value/DiscreteValue.cs
+++ b/Vixen.System/Data/Value/DiscreteValue.cs
@@ -20,6 +20,12 @@ namespace Vixen.Data.Value
 			_intensity = XYZ.ClipValue(intensity, 0, 1);
 		}
 
+		public DiscreteValue(DiscreteValue dv)
+		{
+			_color = dv.Color;
+			_intensity = dv.Intensity;
+		}
+
 		public Color Color
 		{
 			get { return _color; }

--- a/Vixen.System/Data/Value/LightingValue.cs
+++ b/Vixen.System/Data/Value/LightingValue.cs
@@ -30,6 +30,12 @@ namespace Vixen.Data.Value
 			Intensity = i;
 		}
 
+		public LightingValue(LightingValue lv)
+		{
+			Color = lv.Color;
+			Intensity = lv.Intensity;
+		}
+
 		/// <summary>
 		/// The Intensity or brightness of this color in the range 0.0 -> 1.0 (from 0% to 100%).
 		/// </summary>

--- a/Vixen.System/Intent/StaticDiscreteLightingIntent.cs
+++ b/Vixen.System/Intent/StaticDiscreteLightingIntent.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using Vixen.Data.Value;
+using Vixen.Interpolator;
 
 namespace Vixen.Intent
 {
-	public class StaticDiscreteLightingIntent: StaticIntent<DiscreteValue>
+	public class StaticDiscreteLightingIntent: NonSegmentedLinearIntent<DiscreteValue>
 	{
+		private static readonly StaticDiscreteValueInterpolator Interpolator = new StaticDiscreteValueInterpolator();
 		/// <inheritdoc />
-		public StaticDiscreteLightingIntent(DiscreteValue value, TimeSpan timeSpan) : base(value, timeSpan)
+		public StaticDiscreteLightingIntent(DiscreteValue value, TimeSpan timeSpan) : base(value,value, timeSpan, Interpolator)
 		{
 		}
 	}

--- a/Vixen.System/Intent/StaticLightingIntent.cs
+++ b/Vixen.System/Intent/StaticLightingIntent.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using Vixen.Data.Value;
+using Vixen.Interpolator;
 
 namespace Vixen.Intent
 {
-	public class StaticLightingIntent:StaticIntent<LightingValue>
+	public class StaticLightingIntent:NonSegmentedLinearIntent<LightingValue>
 	{
+		private static readonly StaticLightingValueInterpolator Interpolator = new StaticLightingValueInterpolator();
+
 		/// <inheritdoc />
-		public StaticLightingIntent(LightingValue value, TimeSpan timeSpan) : base(value, timeSpan)
+		public StaticLightingIntent(LightingValue value, TimeSpan timeSpan) : base(value,value, timeSpan, Interpolator)
 		{
 		}
 	}

--- a/Vixen.System/Interpolator/StaticDiscreteValueInterpolator.cs
+++ b/Vixen.System/Interpolator/StaticDiscreteValueInterpolator.cs
@@ -1,0 +1,17 @@
+﻿using Vixen.Data.Value;
+
+namespace Vixen.Interpolator
+{
+	internal class StaticDiscreteValueInterpolator: StaticValueInterpolator<DiscreteValue>
+	{
+		#region Overrides of Interpolator<DiscreteValue>
+
+		/// <inheritdoc />
+		protected override DiscreteValue InterpolateValue(double percent, DiscreteValue startValue, DiscreteValue endValue)
+		{
+			return new DiscreteValue(startValue.Color, startValue.Intensity);
+		}
+
+		#endregion
+	}
+}

--- a/Vixen.System/Interpolator/StaticLightingValueInterpolator.cs
+++ b/Vixen.System/Interpolator/StaticLightingValueInterpolator.cs
@@ -1,0 +1,17 @@
+﻿using Vixen.Data.Value;
+
+namespace Vixen.Interpolator
+{
+	internal class StaticLightingValueInterpolator: StaticValueInterpolator<LightingValue>
+	{
+		#region Overrides of StaticValueInterpolator<LightingValue>
+
+		/// <inheritdoc />
+		protected override LightingValue InterpolateValue(double percent, LightingValue startValue, LightingValue endValue)
+		{
+			return new LightingValue(startValue);
+		}
+
+		#endregion
+	}
+}

--- a/Vixen.System/Vixen.csproj
+++ b/Vixen.System/Vixen.csproj
@@ -254,6 +254,8 @@
     <Compile Include="Interpolator\DiscreteValueInterpolator.cs" />
     <Compile Include="Interpolator\LightingValueInterpolator.cs" />
     <Compile Include="Interpolator\PositionValueInterpolator.cs" />
+    <Compile Include="Interpolator\StaticDiscreteValueInterpolator.cs" />
+    <Compile Include="Interpolator\StaticLightingValueInterpolator.cs" />
     <Compile Include="Interpolator\StaticValueInterpolator.cs" />
     <Compile Include="IO\Binary\BinaryFileReader.cs" />
     <Compile Include="IO\Binary\BinaryFileWriter.cs" />


### PR DESCRIPTION
The Set Level was changed to use a static intent instead of interpolating, but it needs a minimal interpolator that returns a copy of the value so that i tcan be modified downstream. Create interpolators for the discrete and lighting value types that return a copy of the value as the point in time intent.