### PR TITLE
VIX-2802 Add the logic to enable he user to enable compression on FPP…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ Debug64
 Debug
 /.vs
 /Common/Box2D/x64
+/Common/Box2D/Win32
 /Modules/Effect/Liquid/LiquidFunWrapper/x64
 /x64

--- a/Modules/App/ExportWizard/BulkExportOutputFormatStage.Designer.cs
+++ b/Modules/App/ExportWizard/BulkExportOutputFormatStage.Designer.cs
@@ -45,6 +45,7 @@
 			this.lblAudioExportPath = new System.Windows.Forms.Label();
 			this.btnAudioOutputFolder = new System.Windows.Forms.Button();
 			this.grpFalcon = new System.Windows.Forms.GroupBox();
+			this.chkCompress = new System.Windows.Forms.CheckBox();
 			this.txtFalconInfo = new System.Windows.Forms.TextBox();
 			this.chkFppIncludeAudio = new System.Windows.Forms.CheckBox();
 			this.chkBackupUniverseFile = new System.Windows.Forms.CheckBox();
@@ -251,6 +252,7 @@
 			// grpFalcon
 			// 
 			this.grpFalcon.AutoSize = true;
+			this.grpFalcon.Controls.Add(this.chkCompress);
 			this.grpFalcon.Controls.Add(this.txtFalconInfo);
 			this.grpFalcon.Controls.Add(this.chkFppIncludeAudio);
 			this.grpFalcon.Controls.Add(this.chkBackupUniverseFile);
@@ -265,6 +267,18 @@
 			this.grpFalcon.TabStop = false;
 			this.grpFalcon.Text = "Falcon Pi Player 2.x";
 			this.grpFalcon.Paint += new System.Windows.Forms.PaintEventHandler(this.groupBoxes_Paint);
+			// 
+			// chkCompress
+			// 
+			this.chkCompress.AutoSize = true;
+			this.chkCompress.Enabled = false;
+			this.chkCompress.Location = new System.Drawing.Point(179, 47);
+			this.chkCompress.Name = "chkCompress";
+			this.chkCompress.Size = new System.Drawing.Size(134, 19);
+			this.chkCompress.TabIndex = 28;
+			this.chkCompress.Text = "Enable Compression";
+			this.chkCompress.UseVisualStyleBackColor = true;
+			this.chkCompress.CheckedChanged += new System.EventHandler(this.chkCompress_CheckedChanged);
 			// 
 			// txtFalconInfo
 			// 
@@ -352,7 +366,7 @@
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(509, 510);
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(510, 510);
 			this.tableLayoutPanel1.TabIndex = 24;
 			// 
 			// BulkExportOutputFormatStage
@@ -362,7 +376,7 @@
 			this.AutoSize = true;
 			this.Controls.Add(this.tableLayoutPanel1);
 			this.Name = "BulkExportOutputFormatStage";
-			this.Size = new System.Drawing.Size(509, 510);
+			this.Size = new System.Drawing.Size(510, 510);
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox1.PerformLayout();
 			this.grpSequence.ResumeLayout(false);
@@ -404,5 +418,6 @@
 		private System.Windows.Forms.CheckBox chkBackupUniverseFile;
 		private System.Windows.Forms.CheckBox chkFppIncludeAudio;
 		private System.Windows.Forms.TextBox txtFalconInfo;
+		private System.Windows.Forms.CheckBox chkCompress;
 	}
 }

--- a/Modules/App/ExportWizard/BulkExportOutputFormatStage.cs
+++ b/Modules/App/ExportWizard/BulkExportOutputFormatStage.cs
@@ -65,8 +65,9 @@ namespace VixenModules.App.ExportWizard
 			chkFppIncludeAudio.Checked = chkIncludeAudio.Checked = _data.ActiveProfile.IncludeAudio;
 			chkRenameAudio.Enabled = btnAudioOutputFolder.Enabled = lblAudioExportPath.Enabled = txtAudioOutputFolder.Enabled = _data.ActiveProfile.IncludeAudio;
 			chkRenameAudio.Checked = _data.ActiveProfile.RenameAudio;
+			chkCompress.Checked = _data.ActiveProfile.EnableCompression;
 			
-			grpFalcon.Visible = _data.ActiveProfile.IsFalconFormat;
+			grpFalcon.Visible = chkCompress.Enabled = _data.Export.IsFalconFormat(_data.ActiveProfile.Format); 
 			grpAudio.Visible = grpSequence.Visible = !grpFalcon.Visible;
 			chkCreateUniverseFile.Checked = _data.ActiveProfile.CreateUniverseFile;
 			chkBackupUniverseFile.Checked = _data.ActiveProfile.BackupUniverseFile;
@@ -298,8 +299,9 @@ namespace VixenModules.App.ExportWizard
 		{
 			ComboBox comboBox = (ComboBox)sender;
 			_data.ActiveProfile.Format = comboBox.SelectedItem.ToString();
-			grpFalcon.Visible = _data.ActiveProfile.IsFalconFormat;
+			grpFalcon.Visible = _data.Export.IsFalconFormat(_data.ActiveProfile.Format);
 			grpAudio.Visible = grpSequence.Visible = !grpFalcon.Visible;
+			chkCompress.Enabled =  _data.Export.CanCompress(_data.ActiveProfile.Format);
 			if (_data.ActiveProfile.IsFalconFormat)
 			{
 				UpdateFalconPaths(_data.ActiveProfile.FalconOutputFolder);
@@ -352,6 +354,11 @@ namespace VixenModules.App.ExportWizard
 		private void txtFalconOutputFolder_TextChanged(object sender, EventArgs e)
 		{
 			//UpdateFalconPaths(txtFalconOutputFolder.Text);
+		}
+
+		private void chkCompress_CheckedChanged(object sender, EventArgs e)
+		{
+			_data.ActiveProfile.EnableCompression = chkCompress.Checked;
 		}
 	}
 }

--- a/Modules/App/ExportWizard/BulkExportSummaryStage.cs
+++ b/Modules/App/ExportWizard/BulkExportSummaryStage.cs
@@ -278,7 +278,7 @@ namespace VixenModules.App.ExportWizard
 			if (canOutput)
 			{
 				_data.Export.OutFileName = Path.Combine(_data.ActiveProfile.OutputFolder, sequence.Name + "." + _data.Export.ExportFileTypes[_data.ActiveProfile.Format]);
-				await _data.Export.DoExport(sequence, _data.ActiveProfile.Format, progress, _data.ActiveProfile.RenameAudio);
+				await _data.Export.DoExport(sequence, _data.ActiveProfile.Format, _data.ActiveProfile.EnableCompression, progress, _data.ActiveProfile.RenameAudio);
 			}
 			
 		}

--- a/Modules/App/ExportWizard/BulkExportWizardData.cs
+++ b/Modules/App/ExportWizard/BulkExportWizardData.cs
@@ -25,7 +25,7 @@ namespace VixenModules.App.ExportWizard
 
 		internal ExportProfile CreateDefaultProfile()
 		{
-			return new ExportProfile("Default", Export.DefaultFormatType(), Export.ExportDir, Export.ExportDir);
+			return new ExportProfile("Default", Export.DefaultFormatType(), Export.ExportDir, Export.ExportDir, true);
 		}
 
 		public Export Export

--- a/Modules/App/ExportWizard/ExportProfile.cs
+++ b/Modules/App/ExportWizard/ExportProfile.cs
@@ -15,7 +15,7 @@ namespace VixenModules.App.ExportWizard
 	{
 		private string _name;
 
-		public ExportProfile(string name, string format, string sequenceFolder, string audioFolder)
+		public ExportProfile(string name, string format, string sequenceFolder, string audioFolder, bool enableCompression = false)
 		{
 			SequenceFiles = new List<string>();
 			Interval = 50;
@@ -24,6 +24,7 @@ namespace VixenModules.App.ExportWizard
 			AudioOutputFolder = audioFolder;
 			Id = Guid.NewGuid();
 			Name = name;
+			EnableCompression = enableCompression;
 			SyncronizeControllerInfo();
 		}
 
@@ -79,8 +80,13 @@ namespace VixenModules.App.ExportWizard
 		[DataMember]
 		public List<Controller> Controllers { get; private set; }
 
+		[DataMember(EmitDefaultValue = false)]
+		public bool EnableCompression { get; set; }
+
 		public bool IsFalconFormat => Format.Contains("Falcon");
-		
+
+		public bool IsFalcon2xFormat => Format.Contains("Falcon Player Sequence 2.6+");
+
 		public bool IsFalconEffectFormat => Format.Equals("Falcon Player Effect");
 		
 		public override string ToString()
@@ -138,7 +144,8 @@ namespace VixenModules.App.ExportWizard
 				AudioOutputFolder = AudioOutputFolder,
 				FalconOutputFolder = FalconOutputFolder,
 				CreateUniverseFile = CreateUniverseFile,
-				BackupUniverseFile = BackupUniverseFile
+				BackupUniverseFile = BackupUniverseFile,
+				EnableCompression = EnableCompression
 				
 			};
 			return data;

--- a/Modules/Editor/TimedSequenceEditor/ExportDialog.Designer.cs
+++ b/Modules/Editor/TimedSequenceEditor/ExportDialog.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-			System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("Test");
+			System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("Test");
 			this.buttonStart = new System.Windows.Forms.Button();
 			this.label3 = new System.Windows.Forms.Label();
 			this.outputFormatComboBox = new System.Windows.Forms.ComboBox();
@@ -54,6 +54,7 @@
 			this.radio2x = new System.Windows.Forms.RadioButton();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.panel1 = new System.Windows.Forms.Panel();
+			this.chkCompress = new System.Windows.Forms.CheckBox();
 			this.groupBox1.SuspendLayout();
 			this.statusStrip1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -72,7 +73,7 @@
 			this.buttonStart.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonStart.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonStart.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.buttonStart.Location = new System.Drawing.Point(17, 453);
+			this.buttonStart.Location = new System.Drawing.Point(19, 490);
 			this.buttonStart.Name = "buttonStart";
 			this.buttonStart.Size = new System.Drawing.Size(104, 27);
 			this.buttonStart.TabIndex = 8;
@@ -160,7 +161,7 @@
             this.progressLabel,
             this.exportProgressBar,
             this.currentTimeLabel});
-			this.statusStrip1.Location = new System.Drawing.Point(0, 498);
+			this.statusStrip1.Location = new System.Drawing.Point(0, 520);
 			this.statusStrip1.Name = "statusStrip1";
 			this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
 			this.statusStrip1.Size = new System.Drawing.Size(516, 24);
@@ -199,7 +200,7 @@
 			this.buttonStop.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonStop.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonStop.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.buttonStop.Location = new System.Drawing.Point(127, 453);
+			this.buttonStop.Location = new System.Drawing.Point(129, 490);
 			this.buttonStop.Name = "buttonStop";
 			this.buttonStop.Size = new System.Drawing.Size(104, 27);
 			this.buttonStop.TabIndex = 15;
@@ -220,7 +221,7 @@
 			this.groupBox2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
 			this.groupBox2.Location = new System.Drawing.Point(12, 88);
 			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(488, 259);
+			this.groupBox2.Size = new System.Drawing.Size(488, 281);
 			this.groupBox2.TabIndex = 16;
 			this.groupBox2.TabStop = false;
 			this.groupBox2.Text = "Network";
@@ -243,14 +244,14 @@
             this.endColumn});
 			this.networkListView.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
 			this.networkListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-			listViewItem1.StateImageIndex = 0;
+			listViewItem2.StateImageIndex = 0;
 			this.networkListView.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
-            listViewItem1});
+            listViewItem2});
 			this.networkListView.Location = new System.Drawing.Point(7, 22);
 			this.networkListView.MultiSelect = false;
 			this.networkListView.Name = "networkListView";
 			this.networkListView.OwnerDraw = true;
-			this.networkListView.Size = new System.Drawing.Size(473, 228);
+			this.networkListView.Size = new System.Drawing.Size(473, 254);
 			this.networkListView.TabIndex = 1;
 			this.networkListView.UseCompatibleStateImageBehavior = false;
 			this.networkListView.View = System.Windows.Forms.View.Details;
@@ -285,7 +286,7 @@
 			this.textBox1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(68)))), ((int)(((byte)(68)))), ((int)(((byte)(68)))));
 			this.textBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
 			this.textBox1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.textBox1.Location = new System.Drawing.Point(12, 358);
+			this.textBox1.Location = new System.Drawing.Point(12, 370);
 			this.textBox1.Multiline = true;
 			this.textBox1.Name = "textBox1";
 			this.textBox1.Size = new System.Drawing.Size(488, 36);
@@ -305,7 +306,7 @@
 			this.btnUserCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.btnUserCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.btnUserCancel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.btnUserCancel.Location = new System.Drawing.Point(373, 453);
+			this.btnUserCancel.Location = new System.Drawing.Point(375, 490);
 			this.btnUserCancel.Name = "btnUserCancel";
 			this.btnUserCancel.Size = new System.Drawing.Size(104, 27);
 			this.btnUserCancel.TabIndex = 18;
@@ -356,7 +357,7 @@
 			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
 			this.tableLayoutPanel1.Controls.Add(this.chkGenerateControllerInfo, 0, 0);
 			this.tableLayoutPanel1.Controls.Add(this.panel1, 1, 0);
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(19, 400);
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(19, 412);
 			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
 			this.tableLayoutPanel1.RowCount = 1;
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -372,6 +373,16 @@
 			this.panel1.Size = new System.Drawing.Size(314, 26);
 			this.panel1.TabIndex = 20;
 			// 
+			// chkCompress
+			// 
+			this.chkCompress.AutoSize = true;
+			this.chkCompress.Location = new System.Drawing.Point(22, 450);
+			this.chkCompress.Name = "chkCompress";
+			this.chkCompress.Size = new System.Drawing.Size(134, 19);
+			this.chkCompress.TabIndex = 24;
+			this.chkCompress.Text = "Enable Compression";
+			this.chkCompress.UseVisualStyleBackColor = true;
+			// 
 			// ExportDialog
 			// 
 			this.AcceptButton = this.buttonStart;
@@ -380,7 +391,8 @@
 			this.AutoSize = true;
 			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(68)))), ((int)(((byte)(68)))), ((int)(((byte)(68)))));
 			this.CancelButton = this.btnUserCancel;
-			this.ClientSize = new System.Drawing.Size(516, 522);
+			this.ClientSize = new System.Drawing.Size(516, 544);
+			this.Controls.Add(this.chkCompress);
 			this.Controls.Add(this.tableLayoutPanel1);
 			this.Controls.Add(this.btnUserCancel);
 			this.Controls.Add(this.textBox1);
@@ -437,5 +449,6 @@
 		private System.Windows.Forms.RadioButton radio2x;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 		private System.Windows.Forms.Panel panel1;
+		private System.Windows.Forms.CheckBox chkCompress;
 	}
 }

--- a/Modules/Editor/TimedSequenceEditor/ExportDialog.cs
+++ b/Modules/Editor/TimedSequenceEditor/ExportDialog.cs
@@ -86,6 +86,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			chkGenerateControllerInfo.Checked = _profile.GetSetting(XMLProfileSettings.SettingType.AppSettings, $"{Name}/GenerateUniverse", false);
 			radio2x.Checked = _profile.GetSetting(XMLProfileSettings.SettingType.AppSettings, $"{Name}/Universe2x", true);
 	        radio1x.Checked = !radio2x.Checked;
+	        chkCompress.Checked = _profile.GetSetting(XMLProfileSettings.SettingType.AppSettings, $"{Name}/Compress", true);
+	        chkCompress.Enabled = _exportOps.CanCompress(outputFormatComboBox.SelectedItem.ToString());
 
 			buttonStop.Enabled = false;
 	        UpdateNetworkList();
@@ -153,7 +155,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 			var progress = new Progress<ExportProgressStatus>(ReportExportProgress);
 	        _exportOps.AudioFilename = _audioFileName;
-			await _exportOps.DoExport(_sequence, outputFormatComboBox.SelectedItem.ToString(), progress);
+			await _exportOps.DoExport(_sequence, outputFormatComboBox.SelectedItem.ToString(), chkCompress.Checked, progress);
 
 	        if (outputFormatComboBox.SelectedItem.ToString().Contains("Falcon"))
 	        {
@@ -443,7 +445,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
         {
             ComboBox comboBox = (ComboBox)sender;
             _profile.PutSetting(XMLProfileSettings.SettingType.AppSettings, string.Format("{0}/ExportFormat", Name), (int)comboBox.SelectedIndex);
-
+            chkCompress.Enabled = _exportOps.CanCompress(outputFormatComboBox.SelectedItem.ToString());
 			SetUniverseVersionEnabled();
         }
 
@@ -451,7 +453,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 	    {
 		    if (chkGenerateControllerInfo.Checked)
 		    {
-			    if (outputFormatComboBox.SelectedItem.ToString().StartsWith("Falcon")) //Ewww...
+			    if (_exportOps.IsFalconFormat(outputFormatComboBox.SelectedItem.ToString())) 
 			    {
 				    radio2x.Enabled = radio1x.Enabled = true;
 			    }
@@ -463,7 +465,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		    else
 		    {
 			    radio2x.Enabled = radio1x.Enabled = false;
-			}
+		    }
 		    
 	    }
 
@@ -482,7 +484,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		private void radio2x_CheckedChanged(object sender, EventArgs e)
 		{
+			chkCompress.Enabled = radio2x.Checked;
 			_profile.PutSetting(XMLProfileSettings.SettingType.AppSettings, $"{Name}/Universe2x", radio2x.Checked);
+		}
+
+		private void chkCompress_CheckedChanged(object sender, EventArgs e)
+		{
+			_profile.PutSetting(XMLProfileSettings.SettingType.AppSettings, $"{Name}/Compress", chkCompress.Checked);
 		}
 	}
 }

--- a/Vixen.System/Export/CSVWriter.cs
+++ b/Vixen.System/Export/CSVWriter.cs
@@ -2,18 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using Vixen.Commands;
-using Vixen.Execution;
-using Vixen.Execution.Context;
-using Vixen.Module.Controller;
-using Vixen.Module.Timing;
-using Vixen.Sys;
 
 namespace Vixen.Export
 {
-    public class CSVWriter : IExportWriter
+    public sealed class CSVWriter : ExportWriterBase
     {
         private Int32 _seqNumChannels = 0;
         private Int32 _seqNumPeriods = 0;
@@ -24,22 +16,11 @@ namespace Vixen.Export
         public CSVWriter()
         {
             SeqPeriodTime = 50;  //Default to 50ms
+            FileType = "csv";
+            FileTypeDescr = "CSV File";
         }
 
-
-        public int SeqPeriodTime { get; set; }
-
-        public void WriteFileHeader()
-        {
-
-        }
-
-        public void WriteFileFooter()
-        {
-
-        }
-
-        public void OpenSession(SequenceSessionData data)
+        public override void OpenSession(SequenceSessionData data)
         {
             OpenSession(data.OutFileName, data.NumPeriods, data.ChannelNames.Count());
         }
@@ -66,7 +47,7 @@ namespace Vixen.Export
             _dataOut.Seek(0, SeekOrigin.Begin);
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             if (_dataOut != null)
             {
@@ -89,7 +70,7 @@ namespace Vixen.Export
         }
 
 
-        public void CloseSession()
+        public override void CloseSession()
         {
             if (_dataOut != null)
             {
@@ -112,20 +93,5 @@ namespace Vixen.Export
             }
         }
 
-        public string FileType
-        {
-            get
-            {
-                return "csv";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "CSV File";
-            }
-        }
     }
 }

--- a/Vixen.System/Export/ESEQWriter.cs
+++ b/Vixen.System/Export/ESEQWriter.cs
@@ -2,18 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using Vixen.Commands;
-using Vixen.Execution;
-using Vixen.Execution.Context;
-using Vixen.Module.Controller;
-using Vixen.Module.Timing;
-using Vixen.Sys;
 
 namespace Vixen.Export
 {
-    public class ESEQWriter : IExportWriter
+    public sealed class ESEQWriter : ExportWriterBase
     {
         private const UInt32 _dataOffset = 20;
         private const UInt16 _fixedHeaderLength = 20;
@@ -34,12 +26,12 @@ namespace Vixen.Export
         public ESEQWriter()
         {
             SeqPeriodTime = 50;  //Default to 50ms
+            IsFalconFormat = true;
+			FileTypeDescr = "Falcon Player Effect";
+			FileType = "eseq";
         }
 
-
-        public int SeqPeriodTime { get; set; }
-
-        public void WriteFileHeader()
+		public void WriteFileHeader()
         {
             if (_dataOut != null)
             {
@@ -80,12 +72,7 @@ namespace Vixen.Export
             }
         }
 
-        public void WriteFileFooter()
-        {
-
-        }
-
-        public void OpenSession(SequenceSessionData data)
+        public override void OpenSession(SequenceSessionData data)
         {
             this.SeqPeriodTime = data.PeriodMS;
             OpenSession(data.OutFileName, data.NumPeriods, data.ChannelNames.Count());
@@ -118,7 +105,7 @@ namespace Vixen.Export
             }
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             if (_dataOut != null)
             {
@@ -142,7 +129,7 @@ namespace Vixen.Export
             }
         }
 
-        public void CloseSession()
+        public override void CloseSession()
         {
             if (_dataOut != null)
             {
@@ -165,21 +152,6 @@ namespace Vixen.Export
                 }
             }
         }
-
-        public string FileType
-        {
-            get
-            {
-                return "eseq";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "Falcon Player Effect";
-            }
-        }
+		
     }
 }

--- a/Vixen.System/Export/ExportWriterBase.cs
+++ b/Vixen.System/Export/ExportWriterBase.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace Vixen.Export
+{
+	public abstract class ExportWriterBase:IExportWriter
+	{
+		/// <inheritdoc />
+		public int SeqPeriodTime { get; set; }
+
+		/// <inheritdoc />
+		public abstract void OpenSession(SequenceSessionData sessionData);
+
+		/// <inheritdoc />
+		public abstract void WriteNextPeriodData(List<byte> periodData);
+
+		/// <inheritdoc />
+		public abstract void CloseSession();
+
+		/// <inheritdoc />
+		public string FileType { get; protected set; }
+
+		/// <inheritdoc />
+		public string FileTypeDescr { get; protected set; }
+
+		/// <inheritdoc />
+		public bool CanCompress { get; protected set; } 
+
+		/// <inheritdoc />
+		public bool EnableCompression { get; set; }
+
+		/// <inheritdoc />
+		public bool IsFalconFormat { get; protected set; }
+
+		/// <inheritdoc />
+		public string Version { get; protected set; } = "1.0";
+	}
+}

--- a/Vixen.System/Export/FSEQWriter.cs
+++ b/Vixen.System/Export/FSEQWriter.cs
@@ -2,19 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using Vixen.Commands;
-using Vixen.Execution;
-using Vixen.Execution.Context;
 using Vixen.Export.FPP;
-using Vixen.Module.Controller;
-using Vixen.Module.Timing;
-using Vixen.Sys;
 
 namespace Vixen.Export
 {
-    public class FSEQWriter : IExportWriter
+    public sealed class FSEQWriter : ExportWriterBase
     {
         private const Byte _vMinor = 0;
         private const Byte _vMajor = 1;
@@ -26,8 +18,6 @@ namespace Vixen.Export
         private UInt16 _universeSize = 0;    //Ignored by Pi Player
         private Byte _gamma = 1;             //0=encoded, 1=linear, 2=RGB Ignored by FPP
 		private Byte _colorEncoding = 2;
-        private String _audioFileName = "";
-        private UInt32 _fileNamePadding = 0;
         private readonly List<VariableHeader> _variableHeaders;
 
 		private FileStream _outfs = null;
@@ -41,13 +31,12 @@ namespace Vixen.Export
         public FSEQWriter()
         {
             SeqPeriodTime = 50;  //Default to 50ms
+            FileTypeDescr = "Falcon Player Sequence";
+            FileType = "fseq";
 			_variableHeaders = new List<VariableHeader>(1);
         }
 
-
-        public int SeqPeriodTime { get; set; }
-
-        public void WriteFileHeader()
+		public void WriteFileHeader()
         {
             if (_dataOut != null)
             {
@@ -115,12 +104,7 @@ namespace Vixen.Export
 			}
         }
 
-        public void WriteFileFooter()
-        {
-
-        }
-
-        public void OpenSession(SequenceSessionData data)
+        public override void OpenSession(SequenceSessionData data)
         {
 			_variableHeaders.Clear();
 	        _dataOffset = _fixedHeaderLength;
@@ -162,7 +146,7 @@ namespace Vixen.Export
             }
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             if (_dataOut != null)
             {
@@ -187,7 +171,7 @@ namespace Vixen.Export
 
         }
 
-        public void CloseSession()
+        public override void CloseSession()
         {
             if (_dataOut != null)
             {
@@ -212,20 +196,5 @@ namespace Vixen.Export
             }
         }
 
-        public string FileType
-        {
-            get
-            {
-                return "fseq";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "Falcon Player Sequence";
-            }
-        }
     }
 }

--- a/Vixen.System/Export/HelixWriter.cs
+++ b/Vixen.System/Export/HelixWriter.cs
@@ -1,19 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Xml;
 using System.Xml.Serialization;
-using Vixen.Module.Controller;
-using Vixen.Sys;
-using Vixen.Execution;
-using Vixen.Commands;
 
 
 namespace Vixen.Export
 {
-    public class HelixWriter : IExportWriter
+	public sealed class HelixWriter : ExportWriterBase
     {
         private Vix2XMLData _xmlData;
         private Byte[] _periodData;
@@ -22,19 +17,12 @@ namespace Vixen.Export
         private FileStream _outfs = null;
         private int _adder;
 
-        public int SeqPeriodTime { get; set; }
-        
-        public void WriteFileHeader()
+        public HelixWriter()
         {
-
+	        FileTypeDescr = "Helix File";
+	        FileType = "vix";
         }
-        
-        public void WriteFileFooter()
-        {
-
-        }
-
-        public void OpenSession(SequenceSessionData sessionData)
+        public override void OpenSession(SequenceSessionData sessionData)
         {
 
             _curPeriod = 0;
@@ -71,7 +59,7 @@ namespace Vixen.Export
 
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             int numPeriods =  _sessionData.NumPeriods + _adder;
 
@@ -83,7 +71,7 @@ namespace Vixen.Export
             _curPeriod++;
         }
 
-        public void CloseSession()
+        public override void CloseSession()
         {
             int count = 0;
             XmlWriterSettings settings = new XmlWriterSettings();
@@ -140,21 +128,7 @@ namespace Vixen.Export
             }
 
         }
-        public string FileType
-        {
-            get
-            {
-                return "vix";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "Helix File";
-            }
-        }
+        
     }
 
 }

--- a/Vixen.System/Export/IExport.cs
+++ b/Vixen.System/Export/IExport.cs
@@ -13,6 +13,10 @@ namespace Vixen.Export
         void CloseSession();
         string FileType { get; }
         string FileTypeDescr { get; }
+		bool CanCompress { get; }
+		bool EnableCompression { get; set; }
+		bool IsFalconFormat { get; }
+		string Version { get; }
     }
 
 }

--- a/Vixen.System/Export/Vir2Writer.cs
+++ b/Vixen.System/Export/Vir2Writer.cs
@@ -1,42 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
-using Vixen.Module.Controller;
-using Vixen.Sys;
-using Vixen.Execution;
-using Vixen.Commands;
 
 
 namespace Vixen.Export
 {
-    public class Vir2Writer : IExportWriter
+    public sealed class Vir2Writer : ExportWriterBase
     {
-        private Vix2XMLData _xmlData;
-        private List<Byte> _eventData;
-        private Byte[] _periodData;
+	    private Byte[] _periodData;
         private int _curPeriod;
         private SequenceSessionData _sessionData;
         private FileStream _outfs = null;
         private BinaryWriter _dataOut = null;
 
-
-        public int SeqPeriodTime { get; set; }
-
-        public void WriteFileHeader()
+        public Vir2Writer()
         {
-
+	        FileType = "vir";
+	        FileTypeDescr = "Vixen 2 Routine";
         }
 
-        public void WriteFileFooter()
-        {
-
-        }
-
-        public void OpenSession(SequenceSessionData sessionData)
+        public override void OpenSession(SequenceSessionData sessionData)
         {
 
             _curPeriod = 0;
@@ -56,7 +39,7 @@ namespace Vixen.Export
             _periodData = new Byte[sessionData.ChannelNames.Count * _sessionData.NumPeriods];
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             for (int j = 0; j < periodData.Count; j++)
             {
@@ -66,7 +49,7 @@ namespace Vixen.Export
             _curPeriod++;
         }
 
-        public void CloseSession()
+        public override void CloseSession()
         {
 
             try
@@ -106,21 +89,6 @@ namespace Vixen.Export
                 catch (Exception e)
                 {
                 }
-            }
-        }
-        public string FileType
-        {
-            get
-            {
-                return "vir";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "Vixen 2 Routine";
             }
         }
     }

--- a/Vixen.System/Export/Vix2Writer.cs
+++ b/Vixen.System/Export/Vix2Writer.cs
@@ -1,19 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
-using Vixen.Module.Controller;
-using Vixen.Sys;
-using Vixen.Execution;
-using Vixen.Commands;
 
 
 namespace Vixen.Export
 {
-    public class Vix2Writer : IExportWriter
+    public sealed class Vix2Writer : ExportWriterBase
     {
         private Vix2XMLData _xmlData;
         private Byte[] _periodData;
@@ -22,20 +16,13 @@ namespace Vixen.Export
         private FileStream _outfs = null;
         private int _adder;
 
-
-        public int SeqPeriodTime { get; set; }
-        
-        public void WriteFileHeader()
+        public Vix2Writer()
         {
-
-        }
-        
-        public void WriteFileFooter()
-        {
-
+	        FileTypeDescr = "Vixen 2.1 Sequence";
+	        FileType = "vix";
         }
 
-        public void OpenSession(SequenceSessionData sessionData)
+        public override void OpenSession(SequenceSessionData sessionData)
         {
 
             _curPeriod = 0;
@@ -71,7 +58,7 @@ namespace Vixen.Export
 
         }
 
-        public void WriteNextPeriodData(List<Byte> periodData)
+        public override void WriteNextPeriodData(List<Byte> periodData)
         {
             int numPeriods =  _sessionData.NumPeriods + _adder;
 
@@ -83,7 +70,7 @@ namespace Vixen.Export
             _curPeriod++;
         }
 
-        public void CloseSession()
+        public override void CloseSession()
         {
             int count = 0;
             XmlWriterSettings settings = new XmlWriterSettings();
@@ -140,21 +127,6 @@ namespace Vixen.Export
                 throw e;
             }
 
-        }
-        public string FileType
-        {
-            get
-            {
-                return "vix";
-            }
-        }
-
-        public string FileTypeDescr
-        {
-            get
-            {
-                return "Vixen 2.1 Sequence";
-            }
         }
     }
 

--- a/Vixen.System/Vixen.csproj
+++ b/Vixen.System/Vixen.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Export\ExportCommandHandler.cs" />
     <Compile Include="Export\ESEQWriter.cs" />
     <Compile Include="Export\ExportProgressStatus.cs" />
+    <Compile Include="Export\ExportWriterBase.cs" />
     <Compile Include="Export\FPP\BoolConverter.cs" />
     <Compile Include="Export\FPP\ChannelOutputs.cs" />
     <Compile Include="Export\FPP\ConfigWriter.cs" />


### PR DESCRIPTION
… Export.

Add a check box to the single export and the wizard format stage to allow the user to enable exporting with compression enabled in the new format.

Add some members to the export writer interface to better support detecting what the export format supports. Falcon, compression. Create a base class that has a lot of boiler plate stuff in it to lighten the content of the implementing classes. This helps get rid of some magic string stuff that was questionable at best.