### PR TITLE
VIX-2693 Improve some aspects of the scheduler.

### DIFF
--- a/Modules/App/Shows/Actions/Action.cs
+++ b/Modules/App/Shows/Actions/Action.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using Timer = System.Timers.Timer;
 
 namespace VixenModules.App.Shows
 {
@@ -14,7 +10,10 @@ namespace VixenModules.App.Shows
 		public Action(ShowItem showItem)
 		{
 			ShowItem = showItem;
+			Id = Guid.NewGuid();
 		}
+
+		public Guid Id { get; }
 
 		// Properties
 		public ShowItem ShowItem { get; set; }

--- a/Modules/App/Shows/Actions/SequenceAction.cs
+++ b/Modules/App/Shows/Actions/SequenceAction.cs
@@ -6,8 +6,7 @@ using Vixen.Execution;
 using Vixen.Execution.Context;
 using Vixen.Module.Media;
 using Vixen.Sys;
-using Vixen.Services;
-using VixenModules.Sequence.Timed;
+using Vixen.Sys.State.Execution;
 
 namespace VixenModules.App.Shows
 {
@@ -16,6 +15,8 @@ namespace VixenModules.App.Shows
 		private ISequenceContext _sequenceContext = null;
 		private static readonly NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();
 		private ISequence _sequence;
+		private bool _canExecute = true;
+		private bool _preProcessingCompleted;
 		
 		public SequenceAction(ShowItem showItem)
 			: base(showItem)
@@ -24,48 +25,50 @@ namespace VixenModules.App.Shows
 
 		public override void Execute()
 		{
-			try
+			IsRunning = true;
+			if (_canExecute)
 			{
-				IsRunning = true;
-				PreProcess();
-				_sequenceContext.Start();
+				try
+				{
+					if (!_preProcessingCompleted)
+					{
+						PreProcess();
+					}
+					_sequenceContext?.Start();
+				}
+				catch (Exception ex)
+				{
+					Logging.Error("Could not execute sequence. " + ShowItem.SequencePath + "; " + ex.Message);
+					_canExecute = false;
+					Complete();
+				}
 			}
-			catch (Exception ex)
+			else
 			{
-			    Logging.Error("Could not execute sequence " + ShowItem.SequencePath + "; " + ex.Message);
+				Logging.Error($"Could not execute sequence. {ShowItem.SequencePath}");
+				Complete();
 			}
+			
 		}
-
-		//public override TimeSpan Duration()
-		//{
-		//	if (_sequenceContext != null) 
-		//		return _sequenceContext.Sequence.Length;
-		//	else
-		//		return TimeSpan.Zero;
-		//}
 
 		public override void Stop()
 		{
-			if (_sequenceContext != null)
-				_sequenceContext.Stop();
+			_sequenceContext?.Stop();
 			base.Stop();
 		}
 
-		bool _preProcessingCompleted = false;
 		public override bool PreProcessingCompleted
 		{
 			get
 			{
-				bool changed = SequenceChanged();
-				bool complete = _preProcessingCompleted && !changed;
-				//Console.WriteLine("Get PreProcessingCompleted" + ShowItem.Name + "=" + complete + ":" + !changed + ":" + _preProcessingCompleted);
-				return complete;
+				if (SequenceManager.IsSequenceStale(ShowItem.SequencePath))
+				{
+					_preProcessingCompleted = false;
+					_canExecute = true;
+				}
+				return _preProcessingCompleted;
 			}
-			set
-			{
-				//Console.WriteLine("Set PreProcessingCompleted" + ShowItem.Name + "=" + value);
-				_preProcessingCompleted = value;
-			}
+			set => _preProcessingCompleted = value;
 		}
 
 		public override void PreProcess(CancellationTokenSource cancellationTokenSource = null)
@@ -75,26 +78,27 @@ namespace VixenModules.App.Shows
 
 			try
 			{
-				if (_sequenceContext == null || SequenceChanged() || _sequence == null)
+				if (!_preProcessingCompleted || _sequenceContext == null || _sequence == null)
 				{
 					if (_sequenceContext != null)
 					{
 						DisposeCurrentContext();
 					}
 
-					var entry = SequenceManager.GetSequenceAsync(ShowItem.SequencePath);
+					var entry = SequenceManager.GetSequenceAsync(ShowItem.SequencePath, Id);
 					entry.Wait();
 					var sequenceEntry = entry.Result;
 
 					if (sequenceEntry == null)
 					{
-						Logging.Error("Failed to preprocess sequence {1} because it could not be loaded.", ShowItem.Name);
+						Logging.Error("Failed to preprocess sequence {1} because it could not be loaded.",
+							ShowItem.Name);
 						return;
 					}
 
 					//Give up to 30 seconds for the sequence to load.
 					int retryCount = 0;
-					while (sequenceEntry.SequenceLoading && retryCount<30)
+					while (sequenceEntry.SequenceLoading && retryCount < 30)
 					{
 						retryCount++;
 						Logging.Info("Waiting for sequence to load. {1}", ShowItem.Name);
@@ -103,27 +107,37 @@ namespace VixenModules.App.Shows
 
 					if (sequenceEntry.Sequence == null)
 					{
-						Logging.Error("Failed to preprocess sequence {1} because it could not be loaded.", ShowItem.Name);
+						Logging.Error("Failed to preprocess sequence {1} because it could not be loaded.",
+							ShowItem.Name);
 						return;
 					}
+
 					_sequence = sequenceEntry.Sequence;
-					
+
 					//Initialize the media if we have it so any audio effects can be rendered 
 					LoadMedia();
 					
-					ISequenceContext context = VixenSystem.Contexts.CreateSequenceContext(new ContextFeatures(ContextCaching.NoCaching), _sequence);
-
 					Parallel.ForEach(_sequence.SequenceData.EffectData.Cast<IEffectNode>(), RenderEffect);
 
-					context.SequenceEnded += sequence_Ended;
-
-					_sequenceContext = context;
+					if (_canExecute)
+					{
+						ISequenceContext context =
+							VixenSystem.Contexts.CreateSequenceContext(new ContextFeatures(ContextCaching.NoCaching),
+								_sequence);
+						context.SequenceEnded += sequence_Ended;
+						_sequenceContext = context;
+					}
 				}
-				PreProcessingCompleted = true;
+
 			}
 			catch (Exception ex)
 			{
-				Logging.Error(ex, "Could not pre-render sequence " + ShowItem.SequencePath + "; ");
+				_canExecute = false;
+				Logging.Error(ex, "Could not pre-render sequence. Sequence will not play until the issue is corrected." + ShowItem.SequencePath + "; ");
+			}
+			finally
+			{
+				PreProcessingCompleted = true;
 			}
 		}
 
@@ -141,22 +155,12 @@ namespace VixenModules.App.Shows
 		{
 			if (node.Effect.IsDirty)
 			{
-				node.Effect.PreRender();
+				var success = node.Effect.PreRender();
+				if (!success)
+				{
+					_canExecute = false;
+				}
 			}
-		}
-
-		DateTime _lastSequenceDateTime = DateTime.Now;
-		private bool SequenceChanged()
-		{
-			bool datesEqual = false;
-
-			if (System.IO.File.Exists(ShowItem.SequencePath))
-			{
-				DateTime lastWriteTime = System.IO.File.GetLastWriteTime(ShowItem.SequencePath);
-				datesEqual = (_lastSequenceDateTime == lastWriteTime);
-				_lastSequenceDateTime = lastWriteTime;
-			}
-			return !datesEqual;
 		}
 
 		private void sequence_Ended(object sender, EventArgs e)
@@ -180,7 +184,7 @@ namespace VixenModules.App.Shows
 				DisposeCurrentContext();
 				
 			}
-			SequenceManager.ConsumerFinished(ShowItem.SequencePath);
+			SequenceManager.ConsumerFinished(ShowItem.SequencePath, Id);
 			_sequenceContext = null;
 			base.Dispose(disposing);
 		}

--- a/Modules/App/Shows/SequenceManager.cs
+++ b/Modules/App/Shows/SequenceManager.cs
@@ -13,16 +13,16 @@ namespace VixenModules.App.Shows
 	{
 		private static readonly NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();
 		private static readonly ConcurrentDictionary<string, SequenceEntry> ActiveSequences = new ConcurrentDictionary<string, SequenceEntry>();
+		private static readonly ConcurrentDictionary<string, SequenceEntry> RetiredSequences = new ConcurrentDictionary<string, SequenceEntry>();
 
-		public static void ConsumerFinished(string sequenceFile)
+		public static void ConsumerFinished(string sequenceFile, Guid id)
 		{
-			
 			SequenceEntry entry = null;
 			if (ActiveSequences.TryGetValue(sequenceFile, out entry))
 			{
 				lock (entry)
 				{
-					entry.RemoveConsumer();
+					entry.RemoveConsumer(id);
 					if (!entry.HasConsumers())
 					{
 						SequenceEntry junk = null;
@@ -30,28 +30,78 @@ namespace VixenModules.App.Shows
 						DisposeSequence(entry.Sequence);
 					}
 				}
-			}
-		}
-
-		public static async Task<SequenceEntry> GetSequenceAsync(string sequenceFile)
-		{
-			//Returning the entry with a placeholder to the sequence facilitates parallel loading
-			SequenceEntry entry = null;
-			if (ActiveSequences.TryGetValue(sequenceFile, out entry))
+			}else if (RetiredSequences.TryGetValue(sequenceFile, out entry))
 			{
 				lock (entry)
 				{
-					entry.AddConsumer();
+					entry.RemoveConsumer(id);
+					if (!entry.HasConsumers())
+					{
+						SequenceEntry junk = null;
+						RetiredSequences.TryRemove(sequenceFile, out junk);
+						DisposeSequence(entry.Sequence);
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets a copy of the sequence and registers the consumer as a user
+		/// </summary>
+		/// <param name="sequenceFile"></param>
+		/// <param name="id">Unique Id of a consumer</param>
+		/// <returns></returns>
+		public static async Task<SequenceEntry> GetSequenceAsync(string sequenceFile, Guid id)
+		{
+			//Returning the entry with a placeholder to the sequence facilitates parallel loading
+			if (ActiveSequences.TryGetValue(sequenceFile, out var entry))
+			{
+				if (IsSequenceStale(sequenceFile))
+				{
+					ActiveSequences.TryRemove(sequenceFile, out entry);
+					entry.RemoveConsumer(id);
+					if (entry.HasConsumers())
+					{
+						RetiredSequences.TryAdd(sequenceFile, entry);
+					}
+					entry = await LoadSequenceAsync(sequenceFile);
+				}
+
+				lock (entry)
+				{
+					entry.AddConsumer(id);
 					return entry;
 				}
 			}
 
 			entry = await LoadSequenceAsync(sequenceFile);
-			if (entry != null)
-			{
-				entry.AddConsumer();
-			}
+			entry?.AddConsumer(id);
 			return entry;
+		}
+
+		private static DateTime SequenceLastModified(string sequenceFile)
+		{
+			if (ActiveSequences.TryGetValue(sequenceFile, out var entry))
+			{
+				return entry.SequenceLastModified;
+			}
+
+			return DateTime.MaxValue;
+		}
+
+		public static bool IsSequenceStale(string sequenceFile)
+		{
+			return SequenceLastModified(sequenceFile) < LastModifiedTime(sequenceFile);
+		}
+
+		private static DateTime LastModifiedTime(string file)
+		{
+			if (System.IO.File.Exists(file))
+			{
+				return System.IO.File.GetLastWriteTime(file);
+			}
+
+			return DateTime.MaxValue;
 		}
 
 		public static async Task PreLoadSequenceAsync(string sequenceFile)
@@ -77,6 +127,7 @@ namespace VixenModules.App.Shows
 				try
 				{
 					var sequence = await Task.Run(() => SequenceService.Instance.Load(sequenceFile));
+					entry.SequenceLastModified = LastModifiedTime(sequenceFile);
 					entry.Sequence = sequence;
 					entry.SequenceLoading = false;
 					return entry;
@@ -102,34 +153,32 @@ namespace VixenModules.App.Shows
 
 		public class SequenceEntry
 		{
-			private long _consumerCount;
+			private readonly HashSet<Guid> _consumerIds = new HashSet<Guid>();
 
 			public ISequence Sequence { get; set; }
 
-			public long ConsumerCount
-			{
-				get { return Interlocked.Read(ref _consumerCount); } 
-			}
+			public DateTime SequenceLastModified { get; set; }
+
+			public long ConsumerCount => _consumerIds.Count;
 
 			public bool SequenceLoading { get; internal set; }
 
-			internal void AddConsumer()
+			internal void AddConsumer(Guid id)
 			{
-				Interlocked.Increment(ref _consumerCount);
+				if (!_consumerIds.Contains(id))
+				{
+					_consumerIds.Add(id);
+				}
 			}
 
-			internal void RemoveConsumer()
+			internal bool RemoveConsumer(Guid id)
 			{
-				if (ConsumerCount > 0)
-				{
-					Interlocked.Decrement(ref _consumerCount);
-				}
-
+				return _consumerIds.Remove(id);
 			}
 
 			public bool HasConsumers()
 			{
-				return ConsumerCount > 0;
+				return _consumerIds.Count>0;
 			}
 		}
 

--- a/Modules/App/Shows/ShowEditorForm.cs
+++ b/Modules/App/Shows/ShowEditorForm.cs
@@ -364,8 +364,12 @@ namespace VixenModules.App.Shows
 					e.Item.ForeColor = listViewShowItems.ForeColor;
 					e.Item.BackColor = listViewShowItems.BackColor;
 				}
-				e.DrawBackground();
-				e.DrawText();
+
+				if (!e.Item.Bounds.IsEmpty)
+				{
+					e.DrawBackground();
+					e.DrawText();
+				}
 			}
 		}
 

--- a/Vixen.System/Module/Effect/EffectModuleInstanceBase.cs
+++ b/Vixen.System/Module/Effect/EffectModuleInstanceBase.cs
@@ -111,8 +111,9 @@ namespace Vixen.Module.Effect
 			}
 		}
 
-		public void PreRender(CancellationTokenSource cancellationToken = null)
+		public bool PreRender(CancellationTokenSource cancellationToken = null)
 		{
+			bool success = true;
 			if (IsDirty && !IsRendering)
 			{
 				try
@@ -126,6 +127,7 @@ namespace Vixen.Module.Effect
 					//Trap any errors to prevent the effect from staying in a state of rendering.
 					Logging.Error(e, $"Error rendering {EffectName} on element {TargetNodes?.FirstOrDefault()?.Name}");
 					Logging.Error($"Error rendering Effect Property settings: {PropertyInfo()}");
+					success = false;
 				}
 				finally
 				{
@@ -142,6 +144,7 @@ namespace Vixen.Module.Effect
 				}
 			}
 
+			return success;
 		}
 
 		public EffectIntents Render()

--- a/Vixen.System/Module/Effect/IEffect.cs
+++ b/Vixen.System/Module/Effect/IEffect.cs
@@ -37,7 +37,7 @@ namespace Vixen.Module.Effect
 		/// </summary>
 		object[] ParameterValues { get; set; }
 
-		void PreRender(CancellationTokenSource cancellationToken = null);
+		bool PreRender(CancellationTokenSource cancellationToken = null);
 		// Having two methods instead of a single one with default values so that the
 		// effect doesn't have to check to see if there is a time frame restriction
 		// with every call.


### PR DESCRIPTION
Rework the logic around the SequenceManager and the SequenceAction to be able to detect if a sequence changes while the show is running. If so reload the new version and retire the old one. This may have render impact on the running show, but I assume the user takes that knowledge when they want to change it.

Add logic to detect render errors in the SequenceAction and mark the item as can't execute so it will bypass it instead of throwing logs full of errors. IF the user fixes and saves as above, then it can run when it comes around if it renders properly.