### PR TITLE
VIX-2819 Improve the performance of the Preview Setup screen.

### DIFF
--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -366,7 +366,7 @@ namespace Common.Controls
 				// Check to see if a node was clicked on 
 				TreeNode node = GetNodeAt(e.Location);
 				if (node != null) {
-					if (ModifierKeys == Keys.None && m_SelectedNodes.Contains(node) && e.Button != MouseButtons.Right &&
+					if (ModifierKeys == Keys.None && !m_SelectedNodes.Contains(node) && e.Button != MouseButtons.Right &&
 					    _clickedNodeWasInBounds)
 						SelectNode(node);
 					if (ModifierKeys == Keys.Control && !_selectedNodeWithControlKey)

--- a/Modules/Preview/VixenPreview/Shapes/DisplayItemBaseControl.cs
+++ b/Modules/Preview/VixenPreview/Shapes/DisplayItemBaseControl.cs
@@ -36,5 +36,12 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			get { return _shape; }
 			set { _shape = value; }
 		}
+
+		protected void OnPropertyEdited()
+		{
+			PropertyEdited?.Invoke(this, EventArgs.Empty);
+		}
+
+		public event EventHandler<EventArgs> PropertyEdited;
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewShapeBaseSetupControl.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewShapeBaseSetupControl.cs
@@ -17,12 +17,17 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			ThemeUpdateControls.UpdateControls(this);
 			ThemePropertyGridRenderer.PropertyGridRender(propertyGrid);
 			propertyGrid.SelectedObject = Shape;
+			propertyGrid.PropertyValueChanged += PropertyGrid_PropertyValueChanged;
 			Shape.OnPropertiesChanged += OnPropertiesChanged;
 			if (ScalingTools.GetScaleFactor() >= 2)
 			{
 				propertyGrid.LargeButtons = true;
 			}
+		}
 
+		private void PropertyGrid_PropertyValueChanged(object s, System.Windows.Forms.PropertyValueChangedEventArgs e)
+		{
+			OnPropertyEdited();
 		}
 
 		~PreviewShapeBaseSetupControl()
@@ -40,4 +45,5 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			Common.VixenHelp.VixenHelp.ShowHelp(Common.VixenHelp.VixenHelp.HelpStrings.Preview_BasicShapes);
 		}
 	}
+
 }

--- a/Modules/Preview/VixenPreview/VixenPreviewControl.Designer.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.Designer.cs
@@ -54,7 +54,7 @@
 			// contextMenuStrip1
 			// 
 			this.contextMenuStrip1.Name = "contextMenuStrip1";
-			this.contextMenuStrip1.Size = new System.Drawing.Size(153, 26);
+			this.contextMenuStrip1.Size = new System.Drawing.Size(61, 4);
 			this.contextMenuStrip1.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.contextMenuStrip1_ItemClicked);
 			// 
 			// VixenPreviewControl
@@ -64,6 +64,7 @@
 			this.Name = "VixenPreviewControl";
 			this.Size = new System.Drawing.Size(290, 240);
 			this.Load += new System.EventHandler(this.VixenPreviewControl_Load);
+			this.Paint += new System.Windows.Forms.PaintEventHandler(this.VixenPreviewControl_Paint);
 			this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.VixenPreviewControl_MouseDown);
 			this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.VixenPreviewControl_MouseMove);
 			this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.VixenPreviewControl_MouseUp);

--- a/Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -56,6 +56,8 @@ namespace VixenModules.Preview.VixenPreview
 		internal int ItemIndex = 0;
 		internal int ItemBulbSize = 0;
 
+		private bool _holdRender;
+
 
 		public DisplayMoveType Type { get; private set; }
 
@@ -206,7 +208,7 @@ namespace VixenModules.Preview.VixenPreview
 				vScroll.Value = newYValue;
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public HashSet<Guid> HighlightedElements
@@ -246,6 +248,7 @@ namespace VixenModules.Preview.VixenPreview
 				{
 					Data.BackgroundAlpha = value;
 					SetupBackgroundAlphaImage();
+					EndUpdate();
 				}
 			}
 		}
@@ -349,12 +352,12 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void HScroll_Scroll(object sender, ScrollEventArgs e)
 		{
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void VScroll_Scroll(object sender, ScrollEventArgs e)
 		{
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void LayoutProps()
@@ -367,7 +370,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public Bitmap Background
@@ -431,7 +434,7 @@ namespace VixenModules.Preview.VixenPreview
 			}
 
 			SetupBackgroundAlphaImage();
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void LoadBackground()
@@ -548,7 +551,7 @@ namespace VixenModules.Preview.VixenPreview
 					OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 				}
 
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -572,13 +575,12 @@ namespace VixenModules.Preview.VixenPreview
 							{
 								SelectedDisplayItems.Remove(item);
 								OnSelectionChanged?.Invoke(this, EventArgs.Empty);
-								RenderInForeground();
 							}
 							else
 							{
 								SelectItemUnderPoint(translatedPoint, controlPressed);
 							}
-							
+							EndUpdate();
 							return;
 						}
 
@@ -915,7 +917,7 @@ namespace VixenModules.Preview.VixenPreview
 					zoomTo = MousePointToZoomPoint(e.Location);
 
 				}
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -932,7 +934,7 @@ namespace VixenModules.Preview.VixenPreview
 					{
 						_selectedDisplayItem.Shape.Select(true);
 					}
-					RenderInForeground();
+					EndUpdate();
 					break;
 				case "Group":
 					_selectedDisplayItem = CreateGroup();
@@ -940,7 +942,7 @@ namespace VixenModules.Preview.VixenPreview
 					{
 						_selectedDisplayItem.Shape.Select(true);
 					}
-					RenderInForeground();
+					EndUpdate();
 					break;
 				case "Ungroup":
 					if (_selectedDisplayItem != null)
@@ -998,7 +1000,7 @@ namespace VixenModules.Preview.VixenPreview
 				SelectedDisplayItems.Clear();
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void SetDisplayItemZ(DisplayItem displayItem, int pos)
@@ -1026,13 +1028,14 @@ namespace VixenModules.Preview.VixenPreview
 			}
 			Capture = true;
 			_mouseCaptured = true;
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void VixenPreviewControl_MouseMove(object sender, MouseEventArgs e)
 		{
 			if (_editMode)
 			{
+				BeginUpdate();
 				PreviewPoint translatedPoint = new PreviewPoint(e.X + hScroll.Value, e.Y + vScroll.Value);
 				Point zoomPoint = PointToZoomPoint(translatedPoint.ToPoint());
 				if (e.Button == System.Windows.Forms.MouseButtons.Middle)
@@ -1052,7 +1055,7 @@ namespace VixenModules.Preview.VixenPreview
 					if (_mouseCaptured && _selectedDisplayItem != null)
 					{
 						_selectedDisplayItem.Shape.MouseMove(dragCurrent.X, dragCurrent.Y, changeX, changeY);
-						RenderInForeground();
+						EndUpdate();
 					}
 						// If we get here, we're drwing a rubber band
 					else if (_banding)
@@ -1083,8 +1086,7 @@ namespace VixenModules.Preview.VixenPreview
 								OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 							}
 						}
-
-						RenderInForeground();
+						EndUpdate();
 					}
 						// Are we moving a group of display items?
 					else if (_mouseCaptured && _selectedDisplayItem == null && SelectedDisplayItems.Count() > 0)
@@ -1093,7 +1095,7 @@ namespace VixenModules.Preview.VixenPreview
 						{
 							item.Shape.MouseMove(zoomPoint.X, zoomPoint.Y, changeX, changeY);
 						}
-						RenderInForeground();
+						EndUpdate();
 					}
 
 					if (_selectedDisplayItem != null)
@@ -1174,7 +1176,7 @@ namespace VixenModules.Preview.VixenPreview
 							item.Shape.Nudge(0, -1);
 					}
 
-					RenderInForeground();
+					EndUpdate();
 				}
 				e.Handled = true;
 			}
@@ -1190,7 +1192,7 @@ namespace VixenModules.Preview.VixenPreview
 							item.Shape.Nudge(0, 1);
 					}
 
-					RenderInForeground();
+					EndUpdate();
 				}
 				e.Handled = true;
 			}
@@ -1206,7 +1208,7 @@ namespace VixenModules.Preview.VixenPreview
 							item.Shape.Nudge(1, 0);
 					}
 
-					RenderInForeground();
+					EndUpdate();
 				}
 				e.Handled = true;
 			}
@@ -1222,7 +1224,7 @@ namespace VixenModules.Preview.VixenPreview
 							item.Shape.Nudge(-1, 0);
 					}
 
-					RenderInForeground();
+					EndUpdate();
 				}
 				e.Handled = true;
 			}
@@ -1247,7 +1249,7 @@ namespace VixenModules.Preview.VixenPreview
 						OnSelectDisplayItem(this, _selectedDisplayItem);
 						DeSelectSelectedDisplayItem();
 						ResetMouse();
-						RenderInForeground();
+						EndUpdate();
 					}
 					else if (_selectedDisplayItem.Shape is PreviewMultiString && _selectedDisplayItem.Shape.Creating)
 					{
@@ -1256,7 +1258,7 @@ namespace VixenModules.Preview.VixenPreview
 						OnSelectDisplayItem(this, _selectedDisplayItem);
 						DeSelectSelectedDisplayItem();
 						ResetMouse();
-						RenderInForeground();
+						EndUpdate();
 					}
 					else
 					{
@@ -1358,7 +1360,7 @@ namespace VixenModules.Preview.VixenPreview
 			}
 			ResetMouse();
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private bool ShowElementCreateTemplateForCurrentTool()
@@ -1448,7 +1450,7 @@ namespace VixenModules.Preview.VixenPreview
 				Background = null;
 			}
 			SetupScrollBars();
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void SetupScrollBars()
@@ -1503,8 +1505,19 @@ namespace VixenModules.Preview.VixenPreview
 				_selectedDisplayItem.Shape.Deselect();
 				_selectedDisplayItem = null;
 				OnSelectionChanged?.Invoke(this, EventArgs.Empty);
-				RenderInForeground();
+				EndUpdate();
 			}
+		}
+
+		internal void BeginUpdate()
+		{
+			_holdRender = true;
+		}
+
+		internal void EndUpdate()
+		{
+			_holdRender = false;
+			RenderInForeground();
 		}
 
 		public void AddNodeToPixelMapping(DisplayItem item)
@@ -1552,7 +1565,7 @@ namespace VixenModules.Preview.VixenPreview
 		{
 			if (NodeToPixel == null) NodeToPixel = new ConcurrentDictionary<ElementNode, List<PreviewPixel>>();
 			NodeToPixel.Clear();
-
+			
 			if (DisplayItems == null)
 				throw new System.ArgumentException("DisplayItems == null");
 
@@ -1584,7 +1597,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 			}
 			LoadBackground();
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public bool Paused
@@ -1649,7 +1662,7 @@ namespace VixenModules.Preview.VixenPreview
 					item.Shape.Top -= deltaY;
 				}
 				StartMove(mousePoint.X, mousePoint.Y);
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -1663,7 +1676,7 @@ namespace VixenModules.Preview.VixenPreview
 
 				RemoveDisplayItem(_selectedDisplayItem);
 				DeSelectSelectedDisplayItem();
-				RenderInForeground();
+				EndUpdate();
 			}
 			else if (SelectedDisplayItems != null && SelectedDisplayItems.Count > 0)
 			{
@@ -1677,7 +1690,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 				SelectedDisplayItems.Clear();
 				OnSelectionChanged?.Invoke(this, EventArgs.Empty);
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -1729,7 +1742,7 @@ namespace VixenModules.Preview.VixenPreview
 				if (_selectedDisplayItem != null)
 				propertiesForm.ShowSetupControl(_selectedDisplayItem.Shape.GetSetupControl());
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void Resize_MoveSwapPlaces(DisplayItem lhs, PreviewItemPositionInfo rhs)
@@ -1744,7 +1757,7 @@ namespace VixenModules.Preview.VixenPreview
 				rhs.OriginalPreviewItem.Add(PreviewTools.SerializeToString(newObjectList));
 				lhs.Shape = temp1.Shape;
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		#endregion
@@ -1759,7 +1772,7 @@ namespace VixenModules.Preview.VixenPreview
 				e.Shape.ResizePixelsBy(reverseChange);
 				info.ChangeAmount = reverseChange;
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		#endregion
@@ -1820,7 +1833,7 @@ namespace VixenModules.Preview.VixenPreview
 			OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 			var action = new PreviewItemsGroupAddedUndoAction(this, newDisplayItem);//Start Undo Action.
 			UndoManager.AddUndoAction(action);
-			RenderInForeground();
+			EndUpdate();
 			return newDisplayItem;
 		}
 
@@ -1842,7 +1855,7 @@ namespace VixenModules.Preview.VixenPreview
 			{
 				DisplayItems.Remove(item);
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public DisplayItem CreateTemplate()
@@ -1916,7 +1929,7 @@ namespace VixenModules.Preview.VixenPreview
 
 					PreviewItemAddAction(); //starts Undo_Redo Action
 
-					RenderInForeground();
+					EndUpdate();
 				}
 			}
 		}
@@ -1937,7 +1950,7 @@ namespace VixenModules.Preview.VixenPreview
 				string path = openFileService.FileName;
 				await ImportCustomPropFromFile(path);
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private async Task ImportCustomPropFromFile(string path)
@@ -1980,7 +1993,7 @@ namespace VixenModules.Preview.VixenPreview
 					await ImportCustomPropFromFile(file, translatedPoint);
 				}
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void VixenPreviewSetup3_DragEnter(object sender, DragEventArgs e)
@@ -2016,7 +2029,7 @@ namespace VixenModules.Preview.VixenPreview
 			DisplayItems.Add(newDisplayItem);
 			SelectedDisplayItems.Clear();
 			OnSelectionChanged?.Invoke(this, EventArgs.Empty);
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		internal string GetSubstitutionString(string token)
@@ -2061,7 +2074,7 @@ namespace VixenModules.Preview.VixenPreview
 				SelectedDisplayItems.Clear();
 				OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		#endregion
@@ -2083,7 +2096,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 				PixelResize(1, SelectedDisplayItems);
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void DecreaseBulbSize()
@@ -2102,7 +2115,7 @@ namespace VixenModules.Preview.VixenPreview
 				PixelResize(-1, SelectedDisplayItems);
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void MatchBulbSize()
@@ -2114,7 +2127,7 @@ namespace VixenModules.Preview.VixenPreview
 					shape.MatchPixelSize(SelectedShapes()[0]);
 				}
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		#endregion
@@ -2134,7 +2147,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 			}
 
-			RenderInForeground();
+			EndUpdate();
 
 		}
 
@@ -2146,7 +2159,7 @@ namespace VixenModules.Preview.VixenPreview
 					shape.Left = SelectedShapes()[0].Right - (shape.Right - shape.Left);
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void AlignTop()
@@ -2157,7 +2170,7 @@ namespace VixenModules.Preview.VixenPreview
 					shape.Top = SelectedShapes()[0].Top;
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void AlignBottom()
@@ -2168,7 +2181,7 @@ namespace VixenModules.Preview.VixenPreview
 					shape.Top = SelectedShapes()[0].Bottom - (shape.Bottom - shape.Top);
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void AlignHorizontal()
@@ -2182,7 +2195,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void AlignVertical()
@@ -2196,7 +2209,7 @@ namespace VixenModules.Preview.VixenPreview
 				}
 			}
 
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void DistributeHorizontal()
@@ -2223,7 +2236,7 @@ namespace VixenModules.Preview.VixenPreview
 					}
 				}
 
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -2251,7 +2264,7 @@ namespace VixenModules.Preview.VixenPreview
 					}
 				}
 
-				RenderInForeground();
+				EndUpdate();
 			}
 		}
 
@@ -2275,13 +2288,11 @@ namespace VixenModules.Preview.VixenPreview
                     }
                 }
 
-                RenderInForeground();
+                EndUpdate();
             }
         }
 
 		#endregion
-
-		private delegate void RenderBufferedGraphicsDelgate(FastPixel.FastPixel fp /*, Bitmap floodBG*/);
 
 		#region "Foreground updates"
 
@@ -2291,8 +2302,8 @@ namespace VixenModules.Preview.VixenPreview
 		/// </summary>
 		public void RenderInForeground()
 		{
-			if (DisplayItems == null) return;
-			Console.Out.WriteLine("Render");
+			if (_holdRender || DisplayItems == null) return;
+			
 			AllocateGraphicsBuffer(false);
 			if (Background != null)
 			{
@@ -2350,7 +2361,7 @@ namespace VixenModules.Preview.VixenPreview
 		public void EraseScreen()
 		{
 			bufferedGraphics.Graphics.Clear(Color.Black);
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		#endregion
@@ -2443,12 +2454,12 @@ namespace VixenModules.Preview.VixenPreview
 				SelectedDisplayItems.Clear();
 				OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 			}
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		private void VixenPreviewControl_Paint(object sender, PaintEventArgs e)
 		{
-			RenderInForeground();
+			EndUpdate();
 		}
 
 		public void PixelResize(int changeAmount, List<DisplayItem> displayItems)

--- a/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -140,7 +140,7 @@ namespace VixenModules.Preview.VixenPreview
 			PreviewItemsAlignNew += vixenpreviewControl_PreviewItemsAlignNew;
 
 			elementsForm = new VixenPreviewSetupElementsDocument(previewForm.Preview);
-			propertiesForm = new VixenPreviewSetupPropertiesDocument();
+			propertiesForm = new VixenPreviewSetupPropertiesDocument(previewForm.Preview);
 
 			previewForm.Show(dockPanel, WeifenLuo.WinFormsUI.Docking.DockState.Document);
 			elementsForm.Show(dockPanel, WeifenLuo.WinFormsUI.Docking.DockState.DockLeft);
@@ -216,7 +216,7 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void OnSelectDisplayItem(object sender, Shapes.DisplayItem displayItem) {
 			Shapes.DisplayItemBaseControl setupControl = displayItem.Shape.GetSetupControl();
-
+			elementsForm.ClearSelectedNodes();
 			if (setupControl != null) {
 				propertiesForm.ShowSetupControl(setupControl);
 			}

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.Designer.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.Designer.cs
@@ -28,26 +28,21 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.components = new System.ComponentModel.Container();
-			this.timerRender = new System.Windows.Forms.Timer(this.components);
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(VixenPreviewSetupDocument));
 			this.previewControl = new VixenModules.Preview.VixenPreview.VixenPreviewControl();
 			this.SuspendLayout();
 			// 
-			// timerRender
-			// 
-			this.timerRender.Enabled = true;
-			this.timerRender.Interval = 10;
-			this.timerRender.Tick += new System.EventHandler(this.timerRender_Tick);
-			// 
 			// previewControl
 			// 
+			this.previewControl.AllowDrop = true;
+			this.previewControl.Background = ((System.Drawing.Bitmap)(resources.GetObject("previewControl.Background")));
 			this.previewControl.BackgroundAlpha = 255;
 			this.previewControl.CurrentTool = VixenModules.Preview.VixenPreview.VixenPreviewControl.Tools.Select;
 			this.previewControl.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.previewControl.EditMode = false;
 			this.previewControl.Location = new System.Drawing.Point(0, 0);
 			this.previewControl.Name = "previewControl";
 			this.previewControl.Paused = false;
+			this.previewControl.SelectedDisplayItems = ((System.Collections.Generic.List<VixenModules.Preview.VixenPreview.Shapes.DisplayItem>)(resources.GetObject("previewControl.SelectedDisplayItems")));
 			this.previewControl.ShowInfo = false;
 			this.previewControl.Size = new System.Drawing.Size(758, 394);
 			this.previewControl.TabIndex = 0;
@@ -66,6 +61,7 @@
 			this.Text = "Preview";
 			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.VixenPreviewSetupDocument_FormClosing);
 			this.Load += new System.EventHandler(this.VixenPreviewSetupDocument_Load);
+			this.Paint += new System.Windows.Forms.PaintEventHandler(this.VixenPreviewSetupDocument_Paint);
 			this.ResumeLayout(false);
 
         }
@@ -73,7 +69,6 @@
         #endregion
 
         private VixenPreviewControl previewControl;
-		private System.Windows.Forms.Timer timerRender;
 
     }
 }

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.cs
@@ -16,19 +16,8 @@ namespace VixenModules.Preview.VixenPreview
 			get { return previewControl; }
 		}
 
-		private void timerRender_Tick(object sender, EventArgs e)
-		{
-			//timerRender.Stop();
-			//Preview.RenderInForeground();
-			//timerRender.Start();
-		}
-
 		private void VixenPreviewSetupDocument_Load(object sender, EventArgs e)
 		{
-			//vScroll.Left = ClientSize.Width - vScroll.Width;
-			//hScroll.Top = ClientSize.Height - hScroll.Height;
-			//previewControl.Width = vScroll.Left - 1;
-			//previewControl.Height = hScroll.Top - 1;
 			previewControl.EditMode = true;
 		}
 

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using WeifenLuo.WinFormsUI.Docking;
 
@@ -24,9 +18,9 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void timerRender_Tick(object sender, EventArgs e)
 		{
-			timerRender.Stop();
-			Preview.RenderInForeground();
-			timerRender.Start();
+			//timerRender.Stop();
+			//Preview.RenderInForeground();
+			//timerRender.Start();
 		}
 
 		private void VixenPreviewSetupDocument_Load(object sender, EventArgs e)
@@ -40,7 +34,12 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void VixenPreviewSetupDocument_FormClosing(object sender, FormClosingEventArgs e)
 		{
-			timerRender.Stop();
+			//timerRender.Stop();
+		}
+
+		private void VixenPreviewSetupDocument_Paint(object sender, PaintEventArgs e)
+		{
+			Preview.RenderInForeground();
 		}
 	}
 }

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.resx
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupDocument.resx
@@ -117,7 +117,5 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="timerRender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
+  
 </root>

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
@@ -56,7 +56,6 @@ namespace VixenModules.Preview.VixenPreview
 		{
 			treeElements.treeviewAfterSelect += treeElements_AfterSelect;
 			treeElements.treeviewDeselected += TreeElementsOnTreeviewDeselected;
-			
 		}
 
 		private void HighlightNode(ElementNode node)
@@ -78,43 +77,36 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void treeElements_AfterSelect(object sender, TreeViewEventArgs e)
 		{
+			_preview.BeginUpdate();
 			_preview.HighlightedElements.Clear();
 
 			foreach (var node in treeElements.SelectedElementNodes) {
 				HighlightNode(node);
 			}
 
-			if (treeElements.SelectedElementNodes.Count() == 1)
+			if (!_preview.SelectedDisplayItems.Any())
 			{
-				if (_preview.NodeToPixel.TryGetValue(treeElements.SelectedNode.GetLeafEnumerator().First(), out var previewPixel))
-				{
-					if (previewPixel.Any())
-					{
-						var shape = _preview.DisplayItemAtPoint(previewPixel.First().Point);
-						if (shape != null)
-						{
-							_preview.propertiesForm.ShowSetupControl(shape.Shape.GetSetupControl());
-						}
-					}
-
-				}
-				else
-				{
-					if (!_preview.SelectedDisplayItems.Any())
-					{
-						_preview.propertiesForm.ClearSetupControl();
-					}
-				}
+				_preview.propertiesForm.ClearSetupControl();
 			}
+
+			_preview.EndUpdate();
 		}
 
 		private void TreeElementsOnTreeviewDeselected(object sender, EventArgs e)
 		{
+			TreeViewNodesDeselected();
+		}
+
+		private void TreeViewNodesDeselected()
+		{
+			_preview.BeginUpdate();
 			_preview.HighlightedElements.Clear();
 			if (!_preview.SelectedDisplayItems.Any())
 			{
 				_preview.propertiesForm.ClearSetupControl();
 			}
+
+			_preview.EndUpdate();
 		}
 
 		public ElementNode SelectedNode => treeElements.SelectedNode;
@@ -133,6 +125,7 @@ namespace VixenModules.Preview.VixenPreview
 		internal void ClearSelectedNodes()
 		{
 			treeElements.ClearSelectedNodes();
+			TreeViewNodesDeselected();
 		}
 
 		internal bool SetupTemplate(IElementTemplate template)

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupPropertiesDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupPropertiesDocument.cs
@@ -1,28 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using Common.Controls.Theme;
+using VixenModules.Preview.VixenPreview.Shapes;
 using WeifenLuo.WinFormsUI.Docking;
 
 namespace VixenModules.Preview.VixenPreview
 {
 	public partial class VixenPreviewSetupPropertiesDocument : DockContent
 	{
-		public VixenPreviewSetupPropertiesDocument()
+		private readonly VixenPreviewControl _previewControl;
+		private DisplayItemBaseControl _setupControl;
+
+		public VixenPreviewSetupPropertiesDocument(VixenPreviewControl previewControl)
 		{
 			InitializeComponent();
 			ThemeUpdateControls.UpdateControls(this);
+			_previewControl = previewControl;
 		}
 
-		public void ShowSetupControl(VixenModules.Preview.VixenPreview.Shapes.DisplayItemBaseControl setupControl)
+		public void ShowSetupControl(DisplayItemBaseControl setupControl)
 		{
+			if (_setupControl != null)
+			{
+				_setupControl.PropertyEdited -= SetupControlPropertyEdited;
+			}
+
+			_setupControl = setupControl;
 			Controls.Clear();
-			if (setupControl != null) {
+			if (setupControl != null)
+			{
+				setupControl.PropertyEdited += SetupControlPropertyEdited;
 				Controls.Add(setupControl);
 				setupControl.Dock = DockStyle.Fill;
 				Text = setupControl.Title;
@@ -30,6 +37,11 @@ namespace VixenModules.Preview.VixenPreview
 			else {
 				Text = @"Properties";
 			}
+		}
+
+		private void SetupControlPropertyEdited(object sender, EventArgs e)
+		{
+			_previewControl.EndUpdate();
 		}
 
 		public void ClearSetupControl()


### PR DESCRIPTION
Remove the render timer that rendered all the time on a schedule. Add logic to all the places that change things that affect the display to call the render routine and update the screen. This reduces render cycles to those that are actually needed to respond to changes. This significantly reduces the amount of CPU used in this form. As we allowing more setup in this screen, users will be spending more time in it and the improvement will be much needed.