### PR TITLE
VIX-2808 Fix an index out of bounds exception in the video effect.

### DIFF
--- a/Modules/Effect/Video/Video.cs
+++ b/Modules/Effect/Video/Video.cs
@@ -743,8 +743,15 @@ namespace VixenModules.Effect.Video
 
 			int pictureCount = _moviePicturesFileList.Count;
 
-			int currentImage = Convert.ToInt32(_currentMovieImageNum);
-			if (currentImage >= pictureCount || currentImage < 0) _currentMovieImageNum = 0;
+			int currentImage = (int)_currentMovieImageNum;
+			if (currentImage >= pictureCount)
+			{
+				_currentMovieImageNum = currentImage = pictureCount-1;
+			}
+			else if(currentImage < 0)
+			{
+				_currentMovieImageNum = currentImage = 0;
+			}
 			var image = Image.FromFile(_moviePicturesFileList[currentImage]);
 			// Convert to Grey scale if selected.
 			_fp = EffectColorType == EffectColorType.RenderGreyScale ? new FastPixel.FastPixel(new Bitmap(ConvertToGrayScale(image))) : new FastPixel.FastPixel(new Bitmap(image, (int)(_renderWidth * _ratioWidth), (int)(_renderHeight * _ratioHeight)));


### PR DESCRIPTION
The index checking was not being handled correctly and could let invalid values pass through. This should prevent that, but not sure why the values where out of bounds to start with as I cannot recreate the users original problem.