### PR TITLE
VIX-2820 Optimize the linking in the preview setup.

### DIFF
--- a/Common/Controls/MultiSelectTreeview.cs
+++ b/Common/Controls/MultiSelectTreeview.cs
@@ -1248,6 +1248,12 @@ namespace Common.Controls
 			if (x == y)
 				return 0;
 
+			if (x.Parent == y.Parent)
+			{
+				if (x.Index > y.Index) return 1;
+				return -1;
+			}
+
 			TreeNode first = FindFirstInCollection(_treeView.Nodes, x, y);
 
 			if (first == x)


### PR DESCRIPTION
Restructure the logic that sorts the columns in the preview elements linking to only adjust the columns once the operation has been completed.

Refactor the drag logic to be more efficient in how it selects the hovered target. Fix the drag enter and drag over methods to work correctly and set the proper effect when the element can be dropped and when it can't. This should eliminate the bizarre popup when it is dropped in the wrong place.

Make an optimization in the Element tree sorting mechanism to allow it to sort faster when elements have the same parent. This can speed up element selection a fair amount. Further optimization could be done later with more extensive refactoring.