### PR TITLE
VIX-2821 Optimize the row loading in the editor.

### DIFF
--- a/Common/Controls/TimeLineControl/Row.cs
+++ b/Common/Controls/TimeLineControl/Row.cs
@@ -47,11 +47,11 @@ namespace Common.Controls.Timeline
 			{
 				// cap the height to a minimum of 10 pixels
 				m_height = Math.Max(value, 10);
-				if(m_visible)
-				{ RowLabel.Height = m_height;}
-
-				//_RowChanged();
-				_RowHeightChanged();
+				if (m_visible)
+				{
+					RowLabel.Height = m_height;
+					_RowHeightChanged();
+				}
 			}
 		}
 


### PR DESCRIPTION
The editor was drawing the row layout after every row was added to the time line even when they are not visible. Refactor to only fire the event for visible rows so it does not do unnecessary changes.