### PR TITLE
VIX-2822 Optimize the color space conversions.

### DIFF
--- a/Modules/App/LipSync/LipSyncMapData.cs
+++ b/Modules/App/LipSync/LipSyncMapData.cs
@@ -204,7 +204,7 @@ namespace VixenModules.App.LipSyncApp
 				{
 					HSV hsvVal = HSV.FromRGB(item.ElementColor);
 					hsvVal.V = 1;
-					colorRetVal = hsvVal.ToRGB().ToArgb();
+					colorRetVal = hsvVal.ToRGB();
 					intensityRetVal = HSV.VFromRgb(item.ElementColor);
 				}
 			}
@@ -249,7 +249,7 @@ namespace VixenModules.App.LipSyncApp
 				{
 					HSV hsvVal = HSV.FromRGB(item.ElementColor);
 					hsvVal.V = 1;
-					retVal = hsvVal.ToRGB().ToArgb();
+					retVal = hsvVal.ToRGB();
 				}
 			}
 			

--- a/Modules/Effect/Effect/PixelFrameBuffer.cs
+++ b/Modules/Effect/Effect/PixelFrameBuffer.cs
@@ -69,7 +69,7 @@ namespace VixenModules.Effect.Effect
 		// 0,0 is lower left
 		public void SetPixel(int x, int y, HSV hsv)
 		{
-			Color color = hsv.ToRGB().ToArgb();
+			Color color = hsv.ToRGB();
 			SetPixel(x, y, color);
 		}
 

--- a/Vixen.System/Data/Value/DiscreteValue.cs
+++ b/Vixen.System/Data/Value/DiscreteValue.cs
@@ -41,7 +41,7 @@ namespace Vixen.Data.Value
 			{
 				HSV hsv = HSV.FromRGB(_color);
 				hsv.V = hsv.V*_intensity;
-				return hsv.ToRGB().ToArgb();
+				return hsv.ToRGB();
 			}
 		}
 


### PR DESCRIPTION
The focus was on the HSV to Color and the Color to HSV. Move around some of the math operations so they they only execute if they have to. Simplify the math by setting some constant factors that were being calculated all the time.

Make the return types what we need instead of running it through another conversion.