### PR TITLE
VIX-2826 Various fixes and polish.

### DIFF
--- a/Modules/App/TimedSequenceMapper/SequencePackageImport/SequencePackageImportSummaryStage.cs
+++ b/Modules/App/TimedSequenceMapper/SequencePackageImport/SequencePackageImportSummaryStage.cs
@@ -334,7 +334,12 @@ namespace VixenModules.App.TimedSequenceMapper.SequencePackageImport
 					//if a same named file exists, skip overwriting it.
 					if (!File.Exists(destinationPath))
 					{
-						file.ExtractToFile(destinationPath, true);
+						var dir = Path.GetDirectoryName(destinationPath);
+						if(!string.IsNullOrEmpty(dir))
+						{
+							Directory.CreateDirectory(dir);
+							file.ExtractToFile(destinationPath, true);
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Add logic to handle the Nutcracker files on export. Even though they are deprecated there are likely still some in the wild.

Add additional error handling to manage issues with the export. Add logic to provide messaging to the user when errors occur.

Clean up some leftover commented code.