### PR TITLE
VIX-2835 Fix the bug that when creating multi-string objects they are…

### DIFF
--- a/Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -659,14 +659,10 @@ namespace VixenModules.Preview.VixenPreview
 					}
 
 					// If we're not Selecting items, we're drawing them
-					//else if (_currentTool == Tools.PolyLine && _mouseCaptured)
-					//{
-					//	return;
-					//}
-					//else if (_currentTool == Tools.MultiString && _mouseCaptured)
-					//{
-					//	return;
-					//}
+					else if (_mouseCaptured && (_currentTool == Tools.PolyLine || _currentTool == Tools.MultiString))
+					{
+						return;
+					}
 					else
 					{
 						DeSelectSelectedDisplayItem();


### PR DESCRIPTION
… not connected properly.

Some code was inadvertently commented out in a previous change. This restores that code and the functionality.