### PR TITLE
VIX-2834 Find binding warning in the Mark Collection editor.

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
+++ b/Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
@@ -325,7 +325,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// Decorator property data.
 		/// </summary>
-		public static readonly PropertyData DecoratorProperty = RegisterProperty("Decorator", typeof(MarkDecorator), null);
+		public static readonly PropertyData DecoratorProperty = RegisterProperty("Decorator", typeof(IMarkDecorator), null);
 
 		#endregion
 


### PR DESCRIPTION
The model binding was using the concrete type vs the interface which was throwing a binding warning.