### PR TITLE
VIX-2841 Fix a few bugs in the select within logic.

### DIFF
--- a/Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -597,7 +597,7 @@ namespace Common.Controls.Timeline
 			                              Math.Max(m_selectionRectangleStart.Y, gridLocation.Y));
 
 			SelectionArea = Util.RectangleFromPoints(topLeft, bottomRight);
-			selectElementsWithin(SelectionArea);
+			selectElementsWithin(SelectionArea, true);
 			Invalidate();
 			Update();
 		}


### PR DESCRIPTION
The fix in a previous ticket did not solve for multiple effects overlapping on the same element row. This takes into account the stacking logic to resolve that and still maintain the function when the same row is exposed multiple times.

Add logic to ignore the CAD style selection logic so the Shift select can use it without changing behaviors depending on the direction of the rectangle.