### PR TITLE
VIX-2840 Virtualize the link elements tree loading in the Preview.

### DIFF
--- a/Common/Controls/ElementTree.cs
+++ b/Common/Controls/ElementTree.cs
@@ -54,7 +54,7 @@ namespace Common.Controls
 			{
 				if (elementNode.Children.Any() && e.Node.Nodes.Count == 1 && e.Node.Nodes[0].Name.Equals(VirtualNodeName))
 				{
-					AddChildrenToTree(e.Node, e.Node.Tag as ElementNode);
+					AddChildrenToTree(e.Node, elementNode);
 				}
 
 				_expandedNodes.Add(GenerateTreeNodeFullPath(e.Node, treeview.PathSeparator));

--- a/Modules/Preview/VixenPreview/Shapes/PreviewSetElements.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewSetElements.cs
@@ -18,6 +18,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
         private List<PreviewSetElementString> _strings = new List<PreviewSetElementString>();
         private List<PreviewBaseShape> _shapes;
         private bool connectStandardStrings;
+        private const string VirtualNodeName = @"VIRT";
 
         public PreviewSetElements(List<PreviewBaseShape> shapes)
         {
@@ -76,9 +77,59 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
         private void PreviewSetElements_Load(object sender, EventArgs e)
         {
-            PreviewTools.PopulateElementTree(treeElements);
+            PopulateElementTree(treeElements);
+			treeElements.BeforeExpand += TreeElements_BeforeExpand;
             PopulateStringList();
             UpdateListLinkedElements();
+        }
+
+		private void TreeElements_BeforeExpand(object sender, TreeViewCancelEventArgs e)
+		{
+			if (e.Node.Tag is ElementNode elementNode)
+			{
+				if (elementNode.Children.Any() && e.Node.Nodes.Count == 1 && e.Node.Nodes[0].Name.Equals(VirtualNodeName))
+				{
+					AddChildrenToTree(e.Node, elementNode);
+				}
+			}
+		}
+
+		// 
+		// Add the root nodes to the Display Element tree
+		//
+		private static void PopulateElementTree(TreeView tree)
+        {
+	        foreach (ElementNode channel in VixenSystem.Nodes.GetRootNodes()) {
+		        AddNodeToElementTree(tree.Nodes, channel);
+	        }
+        }
+
+        // 
+        // Add each child Display Element or Display Element Group to the tree
+        // 
+        private static void AddNodeToElementTree(TreeNodeCollection collection, ElementNode elementNode)
+        {
+	        TreeNode addedNode = new TreeNode();
+	        addedNode.Name = elementNode.Id.ToString();
+	        addedNode.Text = elementNode.Name;
+	        addedNode.Tag = elementNode;
+	        collection.Add(addedNode);
+
+	        if(elementNode.Children.Any())
+	        {
+		        TreeNode virtNode = new TreeNode();
+		        virtNode.Name = VirtualNodeName;
+		        addedNode.Nodes.Add(virtNode);
+	        }
+        }
+
+        private void AddChildrenToTree(TreeNode node, ElementNode elementNode)
+        {
+	        node.Nodes.Clear();
+	        foreach (ElementNode childNode in elementNode.Children)
+	        {
+		        AddNodeToElementTree(node.Nodes, childNode);
+	        }
         }
 
         private void PopulateStringList()

--- a/Modules/Preview/VixenPreview/Shapes/PreviewTools.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewTools.cs
@@ -110,32 +110,6 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			return p;
 		}
 
-		// 
-		// Add the root nodes to the Display Element tree
-		//
-		public static void PopulateElementTree(TreeView tree)
-		{
-			foreach (ElementNode channel in VixenSystem.Nodes.GetRootNodes()) {
-				AddNodeToElementTree(tree.Nodes, channel);
-			}
-		}
-
-		// 
-		// Add each child Display Element or Display Element Group to the tree
-		// 
-		private static void AddNodeToElementTree(TreeNodeCollection collection, ElementNode channelNode)
-		{
-			TreeNode addedNode = new TreeNode();
-			addedNode.Name = channelNode.Id.ToString();
-			addedNode.Text = channelNode.Name;
-			addedNode.Tag = channelNode;
-			collection.Add(addedNode);
-
-			foreach (ElementNode childNode in channelNode.Children) {
-				AddNodeToElementTree(addedNode.Nodes, childNode);
-			}
-		}
-
 		public static List<Point> GetArcPoints(double Width, double Height, double NumPoints)
 		{
 			List<Point> points = new List<Point>();


### PR DESCRIPTION
The ticket was focused on the speed of selection. There is not any logic around the treeview selection, so the speed is purely the cost of the control itself managing the selection. Virtualizing the tree makes it smaller, so it will load faster and maybe the selection logic will work better with a smaller foot print.

Fix a double cast in the expand logic in the setup element tree that was found when reusing the logic for this fix. Marginal improvement, but proper structure.