### PR TITLE
VIX-2856 Fix a bug in the effect rasterizer that was not properly dra…

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/EffectRasterizer.cs
+++ b/Modules/Editor/TimedSequenceEditor/EffectRasterizer.cs
@@ -42,13 +42,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 				int skipCount = count>tmpsiz ? count / tmpsiz: 1;
 
-				double heightPerElement = height/ ( count / skipCount);
-
 				double y = 0;
 				int ctr = 0;
 
 				var elements = effect.TargetNodes.GetElements();
 
+				double heightPerElement = height/ ( elements.Length / skipCount);
+				
 				foreach (var element in elements)
 				{
 					if(ctr++ % skipCount != 0) continue;


### PR DESCRIPTION
…wing when the intent count was less than the element count. This can occur in some situations where the element children do not fully support all the colors and do not render an intent for them,