### PR TITLE
VIX-2871 Correct a math error in the dimming curve where it was using…

### DIFF
--- a/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
+++ b/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
@@ -199,7 +199,7 @@ namespace VixenModules.OutputFilter.DimmingCurve
 		{
 			if (command is _8BitCommand cmd)
 			{
-				double newIntensity = _curve.GetValue(cmd.CommandValue / Byte.MaxValue) * Byte.MaxValue;
+				double newIntensity = _curve.GetValue(cmd.CommandValue / 255d) * Byte.MaxValue;
 				return CommandLookup8BitEvaluator.CommandLookup[(byte) newIntensity];
 			}
 


### PR DESCRIPTION
… integer division instead of floating point.