### PR TITLE
VIX-2875 Swap the controller start logic to use the mediator instead …

### DIFF
--- a/Modules/App/WebServer/Service/SystemHelper.cs
+++ b/Modules/App/WebServer/Service/SystemHelper.cs
@@ -25,7 +25,7 @@ namespace VixenModules.App.WebServer.Service
 				{
 					if (!c.IsRunning || c.IsPaused)
 					{
-						c.Start();
+						VixenSystem.OutputControllers.Start(c);
 						success = true;
 					}
 				}
@@ -33,7 +33,7 @@ namespace VixenModules.App.WebServer.Service
 				{
 					if (c.IsRunning)
 					{
-						c.Stop();
+						VixenSystem.OutputControllers.Stop(c);
 						success = true;
 					}
 				}


### PR DESCRIPTION
…of trying to start the controller directly.

If all controllers are off, adjusting the controller directly will not work correctly.