### PR TITLE
VIX-2876 Allow pixel specific effects to set their frame rate to matc…

### DIFF
--- a/Modules/App/ExportWizard/BulkExportSummaryStage.cs
+++ b/Modules/App/ExportWizard/BulkExportSummaryStage.cs
@@ -144,6 +144,8 @@ namespace VixenModules.App.ExportWizard
 
 		private async Task<bool> DoExport(IProgress<ExportProgressStatus> progress)
 		{
+			var updateIntervalHold = VixenSystem.DefaultUpdateInterval;
+			VixenSystem.DefaultUpdateInterval = _data.ActiveProfile.Interval;
 			var exportProgressStatus = new ExportProgressStatus();
 			var overallProgressSteps = _data.ActiveProfile.SequenceFiles.Count * 2d; //There are basically 2 steps for each. Render and export.
 			var overallProgressStep = 0;
@@ -201,6 +203,8 @@ namespace VixenModules.App.ExportWizard
 				progress.Report(exportProgressStatus);
 
 			});
+
+			VixenSystem.DefaultUpdateInterval = updateIntervalHold;
 			return true;
 		}
 

--- a/Modules/Effect/Effect/BaseEffect.cs
+++ b/Modules/Effect/Effect/BaseEffect.cs
@@ -20,9 +20,15 @@ namespace VixenModules.Effect.Effect
 	public abstract class BaseEffect : EffectModuleInstanceBase
 	{
 		private bool _hasDiscreteColors;
-		protected const short FrameTime = 50;
-		protected static TimeSpan FrameTimespan = new TimeSpan(0, 0, 0, 0, FrameTime);
+		protected int FrameTime;
+		protected static TimeSpan FrameTimespan;
 
+		protected BaseEffect()
+		{
+			FrameTime = VixenSystem.DefaultUpdateInterval;
+			FrameTimespan = new TimeSpan(0, 0, 0, 0, FrameTime);
+		}
+		
 		protected abstract EffectTypeModuleData EffectModuleData { get; }
 
 


### PR DESCRIPTION
…h the default interval.

Added logic to the base class to obtain the frame rate from the default interval.

Added logic to the export wizard to set the default rate to match the export rate so the sequences will be rendered at the correct frame rate where pixel effects are involved.

Does not address exporting from the sequence editor where the loaded sequence is already rendered at the default rate.