### PR TITLE
VIX-2872 Paste of non supported data crashes Vixen.

### DIFF
--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -4874,6 +4874,11 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				data = dataObject.GetData(ClipboardFormatName.Name) as TimelineElementsClipboardData;
 			}
 
+			if(data == null)
+			{
+				return result;
+			}
+
 			List<int> index = new List<int>();
 			List<TimeSpan> markStartTimes = new List<TimeSpan>();
 			List<KeyValuePair<EffectModelCandidate, int>> effects;


### PR DESCRIPTION
Fix the validation logic in the paste method to return if the proper data is not retrieved from the the clipboard.