### PR TITLE
VIX-2792 Part two of this fix to address additional issues.

### DIFF
--- a/Modules/Effect/SetLevel/SetLevel.cs
+++ b/Modules/Effect/SetLevel/SetLevel.cs
@@ -139,8 +139,7 @@ namespace VixenModules.Effect.SetLevel
 		{
 			EffectIntents effectIntents = new EffectIntents();
 			var leafs = node.GetLeafEnumerator();
-			IIntent intent = CreateIntent(leafs.First(), Color, IntensityLevel, TimeSpan);
-			foreach (IElementNode elementNode in node.GetLeafEnumerator())
+			foreach (IElementNode elementNode in leafs)
 			{
 				if (HasDiscreteColors && IsElementDiscrete(elementNode))
 				{
@@ -150,7 +149,7 @@ namespace VixenModules.Effect.SetLevel
 						continue;
 					}
 				}
-				
+				var intent = CreateIntent(leafs.First(), Color, IntensityLevel, TimeSpan);
 				effectIntents.AddIntentForElement(elementNode.Element.Id, intent, TimeSpan.Zero);
 			}
 


### PR DESCRIPTION
When a Set Level is used on a group of discrete elements and a dimming curve is in place, those multiple elements will have a multiplier of the dimming curve for each child under the main group. The fix is to ensure each child element gets it's own intent vs trying to share a common one across them.