### PR TITLE
VIX-2893

### DIFF
--- a/Common/Box2D/Particle/b2ParticleSystem.cpp
+++ b/Common/Box2D/Particle/b2ParticleSystem.cpp
@@ -2733,9 +2733,14 @@ void b2ParticleSystem::RemoveSpuriousBodyContacts()
 				b2ParticleSystem::BodyContactCompare);
 
 	int32 discarded = 0;
-	std::remove_if(m_bodyContactBuffer.Begin(),
+	b2ParticleBodyContact* dontCare = std::remove_if(m_bodyContactBuffer.Begin(),
 					m_bodyContactBuffer.End(),
 					b2ParticleBodyContactRemovePredicate(this, &discarded));
+	
+	// This line of code was added to work around compiler warning C2220.
+	// It is possible that in the future remove_if will be excluded from this warning and
+	// this line of code can be removed.
+	dontCare = NULL;
 
 	m_bodyContactBuffer.SetCount(m_bodyContactBuffer.GetCount() - discarded);
 }


### PR DESCRIPTION
Updating Box2D to avoid C2220 warning that is converted into an error.  Added some trivial code using the remove_if return value to work around the warning.