### PR TITLE
VIX-2851 Fix refresh issue on undo redo items in the preview.

### DIFF
--- a/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -635,22 +635,30 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void undoButton_ButtonClick(object sender, EventArgs e)
 		{
+			previewForm.Preview.BeginUpdate();
 			_undoMgr.Undo();
+			previewForm.Preview.EndUpdate();
 		}
 
 		private void undoButton_ItemChosen(object sender, UndoMultipleItemsEventArgs e)
 		{
+			previewForm.Preview.BeginUpdate();
 			_undoMgr.Undo(e.NumItems);
+			previewForm.Preview.EndUpdate();
 		}
 
 		private void redoButton_ButtonClick(object sender, EventArgs e)
 		{
+			previewForm.Preview.BeginUpdate();
 			_undoMgr.Redo();
+			previewForm.Preview.EndUpdate();
 		}
 
 		private void redoButton_ItemChosen(object sender, UndoMultipleItemsEventArgs e)
 		{
+			previewForm.Preview.BeginUpdate();
 			_undoMgr.Redo(e.NumItems);
+			previewForm.Preview.EndUpdate();
 		}
 
 		private void _undoMgr_UndoItemsChanged(object sender, EventArgs e)


### PR DESCRIPTION
The previous refactor that changed the preview rendering to on demand needs to have specific refresh calls to render when things change. Added the calls when the undo redo is executed.