### PR TITLE
VIX-2903 Fix the missing NCalc library.

### DIFF
--- a/Common/Libraries/Libraries.csproj
+++ b/Common/Libraries/Libraries.csproj
@@ -122,6 +122,7 @@
     <PackageReference Include="Microsoft.Owin.Security" Version="4.1.0" />
     <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.1.0" />
     <PackageReference Include="Mono.Security" Version="5.4.0.201" />
+    <PackageReference Include="NCalc2" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="Nowin" Version="0.26.0" />

--- a/Modules/App/Curves/CurveEditor.cs
+++ b/Modules/App/Curves/CurveEditor.cs
@@ -8,7 +8,7 @@ using Vixen.Module.App;
 using Vixen.Services;
 using ZedGraph;
 using Common.Controls.Theme;
-using NCalc;
+using NCalc2;
 using Point = System.Drawing.Point;
 
 namespace VixenModules.App.Curves

--- a/Modules/App/Curves/Curves.csproj
+++ b/Modules/App/Curves/Curves.csproj
@@ -28,6 +28,11 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NCalc2" Version="2.1.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\Vixen.System\Vixen.csproj">
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>
@@ -99,10 +104,5 @@
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="ncalc" Version="1.3.8">
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Include the library in the library project.
Update to NCalc2 that is supported under .NET Standard.