### PR TITLE
VIX-2899 Correct several issues with the speed control in the Bars ef…

### DIFF
--- a/Modules/Effect/Bars/Bars.cs
+++ b/Modules/Effect/Bars/Bars.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using Common.Controls.ColorManagement.ColorModels;
@@ -297,33 +298,35 @@ namespace VixenModules.Effect.Bars
 			{
 				var s = CalculateSpeed(intervalPosFactor);
 				if (frame == 0) _position = s;
-				_position += s / 100 * FrameTime / 50d; //Adjust the speed setting for different frame rates with FrameTime / 50d
-				if (_position < 0)
-				{
-					_negPosition = true;
-					_position = -_position;
-				}
+				var adj = s / 100 * FrameTime / 50d;
+				_position += adj; //Adjust the speed setting for different frame rates with FrameTime / 50d
+				//Debug.WriteLine($"S:{s}, PosFactor:{intervalPosFactor}, Frame:{frame}, FrameTime:{FrameTime}, Position:{_position}, Adj:{adj}");
+				_negPosition = _position < 0;
 			}
+
+			var workingPosition = Math.Abs(_position);
 
 			if (barCount < 1) barCount = 1;
 			double level = LevelCurve.GetValue(intervalPosFactor) / 100;
+			var bufferHt = BufferHt;
+			var bufferWi = BufferWi;
 
 			if (Direction < BarDirection.Left || Direction == BarDirection.AlternateUp || Direction == BarDirection.AlternateDown)
 			{
-				int barHt = BufferHt / barCount+1;
+				int barHt = bufferHt / barCount+1;
 				if (barHt < 1) barHt = 1;
-				int halfHt = BufferHt / 2;
+				int halfHt = bufferHt / 2;
 				int blockHt = colorcnt * barHt;
 				if (blockHt < 1) blockHt = 1;
-				int fOffset = (int) (_position*blockHt*Repeat);// : Speed * frame / 4 % blockHt);
+				int fOffset = (int) (workingPosition*blockHt*Repeat);// : Speed * frame / 4 % blockHt);
 				if(Direction == BarDirection.AlternateUp || Direction == BarDirection.AlternateDown)
 				{
-					fOffset = (int)(Math.Floor(_position*barCount)*barHt);
+					fOffset = (int)(Math.Floor(workingPosition*barCount)*barHt);
 				}
 
 				var indexAdjust = 1;
 				
-				for (y = 0; y < BufferHt; y++)
+				for (y = 0; y < bufferHt; y++)
 				{
 					n = y + fOffset;
 					colorIdx = ((n + indexAdjust) % blockHt) / barHt;
@@ -356,14 +359,14 @@ namespace VixenModules.Effect.Bars
 							// dow
 							if (_negPosition)
 							{
-								for (x = 0; x < BufferWi; x++)
+								for (x = 0; x < bufferWi; x++)
 								{
-									frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+									frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 								}
 							}
 							else
 							{
-								for (x = 0; x < BufferWi; x++)
+								for (x = 0; x < bufferWi; x++)
 								{
 									frameBuffer.SetPixel(x, y, c);
 								}
@@ -376,10 +379,10 @@ namespace VixenModules.Effect.Bars
 							{
 								if (y <= halfHt)
 								{
-									for (x = 0; x < BufferWi; x++)
+									for (x = 0; x < bufferWi; x++)
 									{
 										frameBuffer.SetPixel(x, y, c);
-										frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+										frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 									}
 								}
 							}
@@ -387,10 +390,10 @@ namespace VixenModules.Effect.Bars
 							{
 								if (y >= halfHt)
 								{
-									for (x = 0; x < BufferWi; x++)
+									for (x = 0; x < bufferWi; x++)
 									{
 										frameBuffer.SetPixel(x, y, c);
-										frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+										frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 									}
 								}
 							}
@@ -401,10 +404,10 @@ namespace VixenModules.Effect.Bars
 							{
 								if (y <= halfHt)
 								{
-									for (x = 0; x < BufferWi; x++)
+									for (x = 0; x < bufferWi; x++)
 									{
 										frameBuffer.SetPixel(x, y, c);
-										frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+										frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 									}
 								}
 							}
@@ -412,10 +415,10 @@ namespace VixenModules.Effect.Bars
 							{
 								if (y >= halfHt)
 								{
-									for (x = 0; x < BufferWi; x++)
+									for (x = 0; x < bufferWi; x++)
 									{
 										frameBuffer.SetPixel(x, y, c);
-										frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+										frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 									}
 								}
 							}
@@ -424,14 +427,14 @@ namespace VixenModules.Effect.Bars
 							// up & AlternateUp
 							if (!_negPosition)
 							{
-								for (x = 0; x < BufferWi; x++)
+								for (x = 0; x < bufferWi; x++)
 								{
-									frameBuffer.SetPixel(x, BufferHt - y - 1, c);
+									frameBuffer.SetPixel(x, bufferHt - y - 1, c);
 								}
 							}
 							else
 							{
-								for (x = 0; x < BufferWi; x++)
+								for (x = 0; x < bufferWi; x++)
 								{
 									frameBuffer.SetPixel(x, y, c);
 								}
@@ -442,18 +445,18 @@ namespace VixenModules.Effect.Bars
 			}
 			else
 			{
-				int barWi = BufferWi / barCount+1;
+				int barWi = bufferWi / barCount+1;
 				if (barWi < 1) barWi = 1;
-				int halfWi = BufferWi / 2;
+				int halfWi = bufferWi / 2;
 				int blockWi = colorcnt * barWi;
 				if (blockWi < 1) blockWi = 1;
-				int fOffset = (int)(_position * blockWi * Repeat);
+				int fOffset = (int)(workingPosition * blockWi * Repeat);
 				if (Direction > BarDirection.AlternateDown)
 				{
-					fOffset = (int)(Math.Floor(_position * barCount) * barWi);
+					fOffset = (int)(Math.Floor(workingPosition * barCount) * barWi);
 				} 
 				
-				for (x = 0; x < BufferWi; x++)
+				for (x = 0; x < bufferWi; x++)
 				{
 					n = x + fOffset;
 					//we need the integer division here to make things work
@@ -484,38 +487,38 @@ namespace VixenModules.Effect.Bars
 						case BarDirection.Right:
 						case BarDirection.AlternateRight:
 							// right
-							for (y = 0; y < BufferHt; y++)
+							for (y = 0; y < bufferHt; y++)
 							{
-								frameBuffer.SetPixel(BufferWi - x - 1, y, c);
+								frameBuffer.SetPixel(_negPosition?x:bufferWi - x - 1, y, c);
 							}
 							break;
 						case BarDirection.HExpand:
 							// H-expand
-							if (x <= halfWi)
+							if (!_negPosition && x <= halfWi || _negPosition && x >= halfWi)
 							{
-								for (y = 0; y < BufferHt; y++)
+								for (y = 0; y < bufferHt; y++)
 								{
 									frameBuffer.SetPixel(x, y, c);
-									frameBuffer.SetPixel(BufferWi - x - 1, y, c);
+									frameBuffer.SetPixel(bufferWi - x - 1, y, c);
 								}
 							}
 							break;
 						case BarDirection.HCompress:
 							// H-compress
-							if (x >= halfWi)
+							if (!_negPosition && x >= halfWi || _negPosition && x <= halfWi)
 							{
-								for (y = 0; y < BufferHt; y++)
+								for (y = 0; y < bufferHt; y++)
 								{
 									frameBuffer.SetPixel(x, y, c);
-									frameBuffer.SetPixel(BufferWi - x - 1, y, c);
+									frameBuffer.SetPixel(bufferWi - x - 1, y, c);
 								}
 							}
 							break;
 						default:
 							// left & AlternateLeft
-							for (y = 0; y < BufferHt; y++)
+							for (y = 0; y < bufferHt; y++)
 							{
-								frameBuffer.SetPixel(x, y, c);
+								frameBuffer.SetPixel(_negPosition?bufferWi - x - 1:x, y, c);
 							}
 							break;
 					}
@@ -579,6 +582,7 @@ namespace VixenModules.Effect.Bars
 			var nodeCount = nodes.Count();
 			var halfNodeCount = (nodeCount - 1) / 2;
 			var evenHalfCount = nodeCount%2!=0;
+			_negPosition = false;
 			for (int frame = 0; frame < numFrames; frame++)
 			{
 				frameBuffer.CurrentFrame = frame;
@@ -594,23 +598,28 @@ namespace VixenModules.Effect.Bars
 					var s = CalculateSpeed(intervalPosFactor);
 					if (frame == 0) _position = s;
 					_position += s / 100 * FrameTime / 50d; //Adjust the speed setting for different frame rates with FrameTime / 50d
+					_negPosition = _position < 0;
 				}
+
+				
+				var workingPosition = Math.Abs(_position);
 
 				int n;
 				int colorIdx;
 				if (Direction < BarDirection.Left || Direction == BarDirection.AlternateUp || Direction == BarDirection.AlternateDown)
 				{
 					
-					int fOffset = (int)(_position * blockHt * Repeat);// : Speed * frame / 4 % blockHt);
+					int fOffset = (int)(workingPosition * blockHt * Repeat);// : Speed * frame / 4 % blockHt);
 					if (Direction == BarDirection.AlternateUp || Direction == BarDirection.AlternateDown)
 					{
-						fOffset = (int)(Math.Floor(_position * barCount) * barHt);
+						fOffset = (int)(Math.Floor(workingPosition * barCount) * barHt);
 					}
 					
 					int indexAdjust = 1;
 
 					int i = 0;
 					bool exitLoop = false;
+
 					foreach (IGrouping<int, ElementLocation> elementLocations in nodes)
 					{
 						int y = elementLocations.Key;
@@ -620,10 +629,10 @@ namespace VixenModules.Effect.Bars
 							case BarDirection.Down:
 							case BarDirection.AlternateDown:
 							case BarDirection.Expand:
-								n = (bufferHt+bufferHtOffset) - y + fOffset;
+								n = (bufferHt+bufferHtOffset) - (_negPosition?bufferHt-y-1:y) + fOffset;
 								break;
 							default:
-								n =  y - bufferHtOffset + fOffset;
+								n =  (_negPosition?bufferHt-y-1:y) - bufferHtOffset + fOffset;
 								break;
 						}
 						
@@ -691,10 +700,10 @@ namespace VixenModules.Effect.Bars
 				else
 				{
 					
-					int fOffset = (int)(_position * blockWi * Repeat);
+					int fOffset = (int)(workingPosition * blockWi * Repeat);
 					if (Direction > BarDirection.AlternateDown)
 					{
-						fOffset = (int)(Math.Floor(_position * barCount) * barWi);
+						fOffset = (int)(Math.Floor(workingPosition * barCount) * barWi);
 					}
 					
 					int i = 0;
@@ -708,10 +717,10 @@ namespace VixenModules.Effect.Bars
 							case BarDirection.Right:
 							case BarDirection.AlternateRight:
 								case BarDirection.HCompress:
-								n = (bufferWi+bufferWiOffset) - x + fOffset;
+								n = (bufferWi+bufferWiOffset) - (_negPosition?bufferWi-x-1:x) + fOffset;
 								break;
 							default:
-								n = x - bufferWiOffset + fOffset;
+								n = (_negPosition?bufferWi-x-1:x) - bufferWiOffset + fOffset;
 								break;
 						}
 						


### PR DESCRIPTION
…fect.

The position indicator was going negative and the logic was negating that. However the next frame would bring it right back and it never cycled. Added logic to let the position cycle, and then use the abs value in the calculations.

Add missing negation logic to the horizontal directions to match the vertical ones in the by strings methods.

Add all the missing speed reversing logic to the location types. These were not even there and would not reverse with the speed control. This makes everything behave the same.