### PR TITLE
VIX-2920 Fix up Prop Editor fields.

### DIFF
--- a/Modules/App/CustomPropEditor/Model/Prop.cs
+++ b/Modules/App/CustomPropEditor/Model/Prop.cs
@@ -34,6 +34,7 @@ namespace VixenModules.App.CustomPropEditor.Model
             Name = "New Prop";
 			CreationDate = DateTime.Now;
 	        ModifiedDate = CreationDate;
+	        CreatedBy = Environment.UserName;
 			VendorMetadata = new VendorMetadata();
 			PhysicalMetadata = new PhysicalMetadata();
 			InformationMetadata = new InformationMetadata();

--- a/Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
@@ -329,6 +329,12 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		[Browsable(false)]
 		public new IViewModel ParentViewModel => base.ParentViewModel;
+		
+		[Browsable(false)]
+		public new bool IsCanceled => base.IsCanceled;
+
+		[Browsable(false)]
+		public new bool IsSaved => base.IsSaved;
 
 		#endregion
 

--- a/Modules/App/CustomPropEditor/ViewModels/PhysicalMetadataViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/PhysicalMetadataViewModel.cs
@@ -41,6 +41,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// Gets or sets the Height value.
 		/// </summary>
 		[PropertyOrder(1)]
+		[Description("The overall height of the prop.")]
 		[ViewModelToModel("PhysicalMetadata")]
 		public string Height
 		{
@@ -61,6 +62,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// Gets or sets the Width value.
 		/// </summary>
 		[PropertyOrder(1)]
+		[Description("The overall width of the prop.")]
 		[ViewModelToModel("PhysicalMetadata")]
 		public string Width
 		{
@@ -81,6 +83,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// Gets or sets the Material value.
 		/// </summary>
 		[PropertyOrder(0)]
+		[Description("The predominate material the props is made of.")]
 		[ViewModelToModel("PhysicalMetadata")]
 		public string Material
 		{
@@ -101,6 +104,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// Gets or sets the Depth value.
 		/// </summary>
 		[PropertyOrder(3)]
+		[Description("The overall depth of the prop.")]
 		[ViewModelToModel("PhysicalMetadata")]
 		public string Depth
 		{
@@ -144,6 +148,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		[PropertyOrder(5)]
 		[DisplayName("Bulb Type")]
 		[ViewModelToModel("PhysicalMetadata")]
+		[Description("The light type used.")]
 		[TypeConverter(typeof(BulbTypeConverter))]
 		public string BulbType
 		{
@@ -165,7 +170,9 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		[PropertyOrder(6)]
 		[DisplayName("Color Mode")]
-		[Description("Declares color handling for the entire prop. \nIf the prop contains multiple color modes, choose other.")]
+		[Description(@"Declares color handling for the entire prop.
+If the prop contains multiple color modes, choose other.
+This maps to color handling in the Display Setup.")]
 		[ViewModelToModel("PhysicalMetadata")]
 		public ColorMode ColorMode
 		{
@@ -182,7 +189,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#region Overrides
 
-		//We are not using these properties in the view so hiding them so the property giris does not expose them.
+		//We are not using these properties in the view so hiding them so the property grid does not expose them.
 
 		[Browsable(false)]
 		public new DateTime ViewModelConstructionTime => base.ViewModelConstructionTime;
@@ -198,6 +205,12 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		[Browsable(false)]
 		public new IViewModel ParentViewModel => base.ParentViewModel;
+
+		[Browsable(false)]
+		public new bool IsCanceled => base.IsCanceled;
+
+		[Browsable(false)]
+		public new bool IsSaved => base.IsSaved;
 
 		#endregion
 	}

--- a/Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -92,6 +92,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		[PropertyOrder(18)]
 		[Category("Details")]
+		[Description("A useful category like Christmas, Halloween, General")]
 		[ViewModelToModel("Prop")]
 		public string Type
 		{
@@ -251,6 +252,12 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		[Browsable(false)]
 		public new IViewModel ParentViewModel => base.ParentViewModel;
+
+		[Browsable(false)]
+		public new bool IsCanceled => base.IsCanceled;
+
+		[Browsable(false)]
+		public new bool IsSaved => base.IsSaved;
 
 		#endregion
 

--- a/Modules/App/CustomPropEditor/ViewModels/VendorMetadataViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/VendorMetadataViewModel.cs
@@ -159,7 +159,13 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 	    [Browsable(false)]
 	    public new IViewModel ParentViewModel => base.ParentViewModel;
+		
+	    [Browsable(false)]
+	    public new bool IsCanceled => base.IsCanceled;
 
+	    [Browsable(false)]
+	    public new bool IsSaved => base.IsSaved;
+		
 	    #endregion
 
 	}


### PR DESCRIPTION
The upgrade to newer versions of Catel exposed a few new properties in view models that the Property Grid was dynamically picking up. Added logic to override and add the browsable attribute to them to suppress them.

Added some tool tip descriptions to a few other fields to help the user with their meaning.

Populate the created by field with the system user name so it has some default.