### PR TITLE
VIX-2933 Add ability to duplicate a preview.

### DIFF
--- a/Application/VixenApplication/ConfigPreviews.Designer.cs
+++ b/Application/VixenApplication/ConfigPreviews.Designer.cs
@@ -39,6 +39,7 @@
 			this.buttonCancel = new System.Windows.Forms.Button();
 			this.label3 = new System.Windows.Forms.Label();
 			this.label4 = new System.Windows.Forms.Label();
+			this.buttonDuplicateSelected = new System.Windows.Forms.Button();
 			this.groupBoxSelectedController.SuspendLayout();
 			this.SuspendLayout();
 			// 
@@ -53,9 +54,9 @@
 			this.groupBoxSelectedController.Controls.Add(this.textBoxName);
 			this.groupBoxSelectedController.Controls.Add(this.buttonConfigureController);
 			this.groupBoxSelectedController.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.groupBoxSelectedController.Location = new System.Drawing.Point(12, 275);
+			this.groupBoxSelectedController.Location = new System.Drawing.Point(14, 317);
 			this.groupBoxSelectedController.Name = "groupBoxSelectedController";
-			this.groupBoxSelectedController.Size = new System.Drawing.Size(390, 158);
+			this.groupBoxSelectedController.Size = new System.Drawing.Size(455, 182);
 			this.groupBoxSelectedController.TabIndex = 1;
 			this.groupBoxSelectedController.TabStop = false;
 			this.groupBoxSelectedController.Text = "Selected Preview";
@@ -66,9 +67,9 @@
 			this.label1.AutoSize = true;
 			this.label1.BackColor = System.Drawing.SystemColors.Control;
 			this.label1.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.label1.Location = new System.Drawing.Point(129, 66);
+			this.label1.Location = new System.Drawing.Point(150, 76);
 			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(197, 13);
+			this.label1.Size = new System.Drawing.Size(221, 15);
 			this.label1.TabIndex = 33;
 			this.label1.Text = "Configure details specific to the preview.";
 			// 
@@ -80,9 +81,9 @@
 			this.buttonUpdate.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonUpdate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonUpdate.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonUpdate.Location = new System.Drawing.Point(308, 21);
+			this.buttonUpdate.Location = new System.Drawing.Point(359, 24);
 			this.buttonUpdate.Name = "buttonUpdate";
-			this.buttonUpdate.Size = new System.Drawing.Size(73, 25);
+			this.buttonUpdate.Size = new System.Drawing.Size(85, 29);
 			this.buttonUpdate.TabIndex = 2;
 			this.buttonUpdate.Text = "Update";
 			this.buttonUpdate.UseVisualStyleBackColor = false;
@@ -95,9 +96,9 @@
 			this.label2.AutoSize = true;
 			this.label2.BackColor = System.Drawing.SystemColors.Control;
 			this.label2.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.label2.Location = new System.Drawing.Point(14, 27);
+			this.label2.Location = new System.Drawing.Point(16, 31);
 			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(38, 13);
+			this.label2.Size = new System.Drawing.Size(42, 15);
 			this.label2.TabIndex = 26;
 			this.label2.Text = "Name:";
 			// 
@@ -106,9 +107,9 @@
 			this.textBoxName.BackColor = System.Drawing.SystemColors.Control;
 			this.textBoxName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
 			this.textBoxName.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.textBoxName.Location = new System.Drawing.Point(58, 24);
+			this.textBoxName.Location = new System.Drawing.Point(68, 28);
 			this.textBoxName.Name = "textBoxName";
-			this.textBoxName.Size = new System.Drawing.Size(136, 20);
+			this.textBoxName.Size = new System.Drawing.Size(158, 23);
 			this.textBoxName.TabIndex = 1;
 			// 
 			// buttonConfigureController
@@ -119,9 +120,9 @@
 			this.buttonConfigureController.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonConfigureController.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonConfigureController.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonConfigureController.Location = new System.Drawing.Point(13, 60);
+			this.buttonConfigureController.Location = new System.Drawing.Point(15, 69);
 			this.buttonConfigureController.Name = "buttonConfigureController";
-			this.buttonConfigureController.Size = new System.Drawing.Size(110, 25);
+			this.buttonConfigureController.Size = new System.Drawing.Size(128, 29);
 			this.buttonConfigureController.TabIndex = 0;
 			this.buttonConfigureController.Text = "Configure Preview";
 			this.buttonConfigureController.UseVisualStyleBackColor = false;
@@ -148,10 +149,10 @@
             listViewGroup2});
 			this.listViewControllers.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
 			this.listViewControllers.HideSelection = false;
-			this.listViewControllers.Location = new System.Drawing.Point(12, 30);
+			this.listViewControllers.Location = new System.Drawing.Point(14, 35);
 			this.listViewControllers.Name = "listViewControllers";
 			this.listViewControllers.ShowGroups = false;
-			this.listViewControllers.Size = new System.Drawing.Size(391, 190);
+			this.listViewControllers.Size = new System.Drawing.Size(456, 219);
 			this.listViewControllers.TabIndex = 0;
 			this.listViewControllers.UseCompatibleStateImageBehavior = false;
 			this.listViewControllers.View = System.Windows.Forms.View.Details;
@@ -178,9 +179,9 @@
 			this.buttonOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonOk.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonOk.Location = new System.Drawing.Point(216, 447);
+			this.buttonOk.Location = new System.Drawing.Point(252, 516);
 			this.buttonOk.Name = "buttonOk";
-			this.buttonOk.Size = new System.Drawing.Size(90, 25);
+			this.buttonOk.Size = new System.Drawing.Size(105, 29);
 			this.buttonOk.TabIndex = 4;
 			this.buttonOk.Text = "OK";
 			this.buttonOk.UseVisualStyleBackColor = false;
@@ -196,9 +197,9 @@
 			this.buttonDeleteController.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonDeleteController.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonDeleteController.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonDeleteController.Location = new System.Drawing.Point(237, 236);
+			this.buttonDeleteController.Location = new System.Drawing.Point(318, 272);
 			this.buttonDeleteController.Name = "buttonDeleteController";
-			this.buttonDeleteController.Size = new System.Drawing.Size(120, 25);
+			this.buttonDeleteController.Size = new System.Drawing.Size(140, 29);
 			this.buttonDeleteController.TabIndex = 3;
 			this.buttonDeleteController.Text = "Delete Selected";
 			this.buttonDeleteController.UseVisualStyleBackColor = false;
@@ -216,9 +217,9 @@
 			this.buttonAddController.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonAddController.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonAddController.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonAddController.Location = new System.Drawing.Point(62, 236);
+			this.buttonAddController.Location = new System.Drawing.Point(17, 272);
 			this.buttonAddController.Name = "buttonAddController";
-			this.buttonAddController.Size = new System.Drawing.Size(120, 25);
+			this.buttonAddController.Size = new System.Drawing.Size(140, 29);
 			this.buttonAddController.TabIndex = 2;
 			this.buttonAddController.Text = "Add New Preview";
 			this.buttonAddController.UseVisualStyleBackColor = false;
@@ -236,9 +237,9 @@
 			this.buttonCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
 			this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.buttonCancel.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.buttonCancel.Location = new System.Drawing.Point(312, 447);
+			this.buttonCancel.Location = new System.Drawing.Point(364, 516);
 			this.buttonCancel.Name = "buttonCancel";
-			this.buttonCancel.Size = new System.Drawing.Size(90, 25);
+			this.buttonCancel.Size = new System.Drawing.Size(105, 29);
 			this.buttonCancel.TabIndex = 5;
 			this.buttonCancel.Text = "Cancel";
 			this.buttonCancel.UseVisualStyleBackColor = false;
@@ -249,9 +250,9 @@
 			// 
 			this.label3.AutoSize = true;
 			this.label3.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.label3.Location = new System.Drawing.Point(12, 12);
+			this.label3.Location = new System.Drawing.Point(14, 14);
 			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(35, 13);
+			this.label3.Size = new System.Drawing.Size(39, 15);
 			this.label3.TabIndex = 6;
 			this.label3.Text = "Name";
 			// 
@@ -259,20 +260,39 @@
 			// 
 			this.label4.AutoSize = true;
 			this.label4.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.label4.Location = new System.Drawing.Point(197, 12);
+			this.label4.Location = new System.Drawing.Point(230, 14);
 			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(31, 13);
+			this.label4.Size = new System.Drawing.Size(31, 15);
 			this.label4.TabIndex = 7;
 			this.label4.Text = "Type";
+			// 
+			// buttonDuplicateSelected
+			// 
+			this.buttonDuplicateSelected.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+			this.buttonDuplicateSelected.BackColor = System.Drawing.Color.Transparent;
+			this.buttonDuplicateSelected.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(40)))), ((int)(((byte)(40)))), ((int)(((byte)(40)))));
+			this.buttonDuplicateSelected.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
+			this.buttonDuplicateSelected.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
+			this.buttonDuplicateSelected.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
+			this.buttonDuplicateSelected.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+			this.buttonDuplicateSelected.ForeColor = System.Drawing.SystemColors.ControlText;
+			this.buttonDuplicateSelected.Location = new System.Drawing.Point(167, 272);
+			this.buttonDuplicateSelected.Name = "buttonDuplicateSelected";
+			this.buttonDuplicateSelected.Size = new System.Drawing.Size(140, 29);
+			this.buttonDuplicateSelected.TabIndex = 8;
+			this.buttonDuplicateSelected.Text = "Duplicate Selected";
+			this.buttonDuplicateSelected.UseVisualStyleBackColor = false;
+			this.buttonDuplicateSelected.Click += new System.EventHandler(this.buttonDuplicateSelected_Click);
 			// 
 			// ConfigPreviews
 			// 
 			this.AcceptButton = this.buttonOk;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.SystemColors.Control;
 			this.CancelButton = this.buttonCancel;
-			this.ClientSize = new System.Drawing.Size(413, 493);
+			this.ClientSize = new System.Drawing.Size(482, 569);
+			this.Controls.Add(this.buttonDuplicateSelected);
 			this.Controls.Add(this.label4);
 			this.Controls.Add(this.label3);
 			this.Controls.Add(this.groupBoxSelectedController);
@@ -284,9 +304,9 @@
 			this.DoubleBuffered = true;
 			this.ForeColor = System.Drawing.SystemColors.ControlText;
 			this.MaximizeBox = false;
-			this.MaximumSize = new System.Drawing.Size(429, 1982);
+			this.MaximumSize = new System.Drawing.Size(498, 2281);
 			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(429, 502);
+			this.MinimumSize = new System.Drawing.Size(498, 573);
 			this.Name = "ConfigPreviews";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
 			this.Text = "Setup Previews";
@@ -316,5 +336,6 @@
 		private System.Windows.Forms.Button buttonCancel;
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.Button buttonDuplicateSelected;
 	}
 }

--- a/Application/VixenApplication/ConfigPreviews.cs
+++ b/Application/VixenApplication/ConfigPreviews.cs
@@ -32,11 +32,10 @@ namespace VixenApplication
 		{
 			InitializeComponent();
 			Icon = Resources.Icon_Vixen3;
-			ForeColor = ThemeColorTable.ForeColor;
-			BackColor = ThemeColorTable.BackgroundColor;
 			ThemeUpdateControls.UpdateControls(this);
 			this.ShowInTaskbar = false;
 			_displayedController = null;
+			buttonDeleteController.Enabled = buttonDuplicateSelected.Enabled = false;
 		}
 
 		private void ConfigPreviews_Load(object sender, EventArgs e)
@@ -53,6 +52,8 @@ namespace VixenApplication
 			else {
 				_PopulateFormWithController(listViewControllers.SelectedItems[0].Tag as OutputPreview);
 			}
+
+			buttonDuplicateSelected.Enabled = buttonDeleteController.Enabled = listViewControllers.SelectedItems.Count > 0;
 		}
 
 		private void buttonAddController_Click(object sender, EventArgs e)
@@ -117,6 +118,42 @@ namespace VixenApplication
 			}
 		}
 
+		private void buttonDuplicateSelected_Click(object sender, EventArgs e)
+		{
+			if (listViewControllers.SelectedItems.Count > 0)
+			{
+				foreach (ListViewItem item in listViewControllers.SelectedItems)
+				{
+					OutputPreview op = item.Tag as OutputPreview;
+
+					PreviewFactory previewFactory = new PreviewFactory();
+					OutputPreview preview = (OutputPreview) previewFactory.CreateDevice(op.ModuleId, op.Name + "-copy");
+					if (preview.PreviewModule is IPreviewModuleInstance newInstance)
+					{
+						if (op.PreviewModule is IPreviewModuleInstance origInstance)
+						{
+							var md = origInstance.ModuleData.Clone();
+							//The new module will have it's own instance data. If we want to replace it we need to replace it in the
+							//ModuleStore as well so it will be saved. So remove it and then assign it and then update it in the store
+							md.ModuleDataSet.RemoveModuleInstanceData(newInstance);
+							newInstance.ModuleData = md;
+							md.ModuleDataSet.AssignModuleInstanceData(newInstance);
+						}
+						
+					}
+					VixenSystem.Previews.Add(preview);
+					_PopulateFormWithController(preview);
+
+				}
+
+				_PopulateControllerList();
+
+				_changesMade = true;
+				Refresh();
+			}
+
+		}
+
 		private void buttonUpdate_Click(object sender, EventArgs e)
 		{
 			if (_displayedController == null)
@@ -176,27 +213,15 @@ namespace VixenApplication
 
 			if (oc == null) {
 				textBoxName.Text = string.Empty;
-				buttonDeleteController.Enabled = false;
 				textBoxName.Enabled = false;
 				buttonUpdate.Enabled = false;
-				buttonUpdate.ForeColor = ThemeColorTable.ForeColorDisabled;
-				buttonConfigureController.Enabled = false;
-				buttonDeleteController.ForeColor = ThemeColorTable.ForeColorDisabled;
-				buttonConfigureController.ForeColor = ThemeColorTable.ForeColorDisabled;
-				label1.ForeColor = ThemeColorTable.ForeColorDisabled;
-				label2.ForeColor = ThemeColorTable.ForeColorDisabled;
+				buttonConfigureController.Enabled = label1.Enabled = label2.Enabled = false;
 			}
 			else {
 				textBoxName.Text = oc.Name;
-				buttonDeleteController.Enabled = true;
 				textBoxName.Enabled = true;
 				buttonUpdate.Enabled = true;
-				buttonUpdate.ForeColor = ThemeColorTable.ForeColor;
-				buttonConfigureController.Enabled = true;
-				buttonDeleteController.ForeColor = ThemeColorTable.ForeColor;
-				buttonConfigureController.ForeColor = ThemeColorTable.ForeColor;
-				label1.ForeColor = ThemeColorTable.ForeColor;
-				label2.ForeColor = ThemeColorTable.ForeColor;
+				buttonConfigureController.Enabled = label1.Enabled = label2.Enabled = true;
 			}
 		}
 
@@ -296,5 +321,6 @@ namespace VixenApplication
 		{
 			ThemeGroupBoxRenderer.GroupBoxesDrawBorder(sender, e, Font);
 		}
+
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/DisplayItem.cs
+++ b/Modules/Preview/VixenPreview/Shapes/DisplayItem.cs
@@ -123,7 +123,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		public object Clone()
 		{
-			DisplayItem item = new DisplayItem();
+			DisplayItem item = (DisplayItem) MemberwiseClone();
 			item.Shape = Shape.Clone() as PreviewBaseShape;
 			return item;
 		}

--- a/Modules/Preview/VixenPreview/Shapes/PreviewArch.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewArch.cs
@@ -367,7 +367,16 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		public override object Clone()
 		{
-			return this.MemberwiseClone();
+			var newArch =(PreviewArch)MemberwiseClone();
+			newArch._topLeft = _topLeft.Copy();
+			newArch._bottomRight = _bottomRight.Copy();
+			newArch.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newArch.Pixels.Add(previewPixel.Clone());
+			}
+
+			return newArch;
 		}
 
 		public override void MoveTo(int x, int y)

--- a/Modules/Preview/VixenPreview/Shapes/PreviewBaseShape.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewBaseShape.cs
@@ -552,7 +552,13 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		public virtual object Clone()
 		{
-			return this.MemberwiseClone();
+			var shape = (PreviewBaseShape)this.MemberwiseClone();
+			foreach (var previewPixel in Pixels)
+			{
+				shape.Pixels.Add(previewPixel.Clone());
+			}
+
+			return shape;
 		}
 
 		public abstract void MoveTo(int x, int y);

--- a/Modules/Preview/VixenPreview/Shapes/PreviewCane.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewCane.cs
@@ -415,5 +415,27 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_archLeftPoint.Y = archStart.Y;
 			Resize(aspect);
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newCane = (PreviewCane) MemberwiseClone();
+
+			newCane._topLeftPoint = _topLeftPoint.Copy();
+			newCane._bottomRightPoint = _bottomRightPoint.Copy();
+			newCane._archLeftPoint = _archLeftPoint.Copy();
+			newCane._pixels = new List<PreviewPixel>();
+
+			foreach (PreviewPixel pixel in _pixels) {
+				newCane._pixels.Add(pixel.Clone());
+			}
+
+			
+			return newCane;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewCustom.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewCustom.cs
@@ -283,5 +283,27 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		{
 			throw new NotImplementedException();
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newCustom = (PreviewCustom) MemberwiseClone();
+
+			newCustom.Strings = new List<PreviewBaseShape>(Strings.Count);
+
+			newCustom._topLeft = _topLeft.Copy();
+
+			foreach (var previewBaseShape in Strings)
+			{
+				newCustom.Strings.Add((PreviewBaseShape)previewBaseShape.Clone());
+			}
+
+
+			return newCustom;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
@@ -647,7 +647,26 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			Layout();
 		}
 
+		#region Overrides of PreviewBaseShape
 
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newProp = (PreviewCustomProp) MemberwiseClone();
+			newProp.PropPixels = new List<PreviewPixel>();
+
+			foreach (PreviewPixel pixel in PropPixels)
+			{
+				var p = pixel.Clone();
+				newProp.PropPixels.Add(p);
+			}
+
+			newProp.Pixels = PropPixels;
+
+			return newProp;
+		}
+
+		#endregion
 	}
 
 	public static class Extensions

--- a/Modules/Preview/VixenPreview/Shapes/PreviewEllipse.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewEllipse.cs
@@ -385,5 +385,21 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_bottomRight.Y = p2Start.Y;
 			Resize(aspect);
 		}
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newEllipse = (PreviewEllipse) MemberwiseClone();
+			newEllipse._topLeft = _topLeft.Copy();
+			newEllipse._bottomRight = _bottomRight.Copy();
+
+			newEllipse.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newEllipse.Pixels.Add(previewPixel.Clone());
+			}
+			
+			return newEllipse;
+		}
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewIcicle.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewIcicle.cs
@@ -403,14 +403,21 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		public override object Clone()
 		{
-            PreviewIcicle newLine = (PreviewIcicle)this.MemberwiseClone();
+            PreviewIcicle newIcicle = (PreviewIcicle)this.MemberwiseClone();
 
-			//newLine._pixels = new List<Preview Pixel>();
+			newIcicle._points = new List<PreviewPoint>();
+
+			foreach (var previewPoint in _points)
+			{
+				newIcicle._points.Add(previewPoint.Copy());
+			}
+
+			newIcicle._pixels = new List<PreviewPixel>();
 
 			foreach (PreviewPixel pixel in _pixels) {
-				newLine.AddPixel(pixel.X, pixel.Y);
+				newIcicle.Pixels.Add(pixel.Clone());
 			}
-			return newLine;
+			return newIcicle;
 		}
 
 		public override void MoveTo(int x, int y)

--- a/Modules/Preview/VixenPreview/Shapes/PreviewLine.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewLine.cs
@@ -339,7 +339,13 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			newLine._pixels = new List<PreviewPixel>();
 
 			foreach (PreviewPixel pixel in _pixels) {
-				newLine.AddPixel(pixel.X, pixel.Y);
+				newLine._pixels.Add(pixel.Clone());
+			}
+
+			newLine._points = new List<PreviewPoint>();
+			foreach (var previewPoint in _points)
+			{
+				newLine._points.Add(previewPoint.Copy());
 			}
 			return newLine;
 		}

--- a/Modules/Preview/VixenPreview/Shapes/PreviewMegaTree.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewMegaTree.cs
@@ -588,8 +588,8 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 				PreviewBaseShape newLine = (PreviewLine) line.Clone();
 				newTree._strings.Add(newLine);
 			}
-			newTree._topLeft = new PreviewPoint(_topLeft);
-			newTree._bottomRight = new PreviewPoint(_bottomRight);
+			newTree._topLeft = _topLeft.Copy();
+			newTree._bottomRight = _bottomRight.Copy();
 
 			return newTree;
 		}

--- a/Modules/Preview/VixenPreview/Shapes/PreviewMultiString.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewMultiString.cs
@@ -449,12 +449,19 @@ namespace VixenModules.Preview.VixenPreview.Shapes
         {
             PreviewMultiString newMultiString = (PreviewMultiString)this.MemberwiseClone();
 
-            //foreach (PreviewPixel pixel in _pixels)
-            //{
-            //    newLine.AddPixel(pixel.X, pixel.Y);
-            //}
-            //Console.WriteLine("Clone");
-            return newMultiString;
+			foreach (PreviewPixel pixel in _pixels)
+			{
+				newMultiString.AddPixel(pixel.X, pixel.Y);
+			}
+
+			newMultiString._points = new List<PreviewPoint>();
+			foreach (var previewPoint in _points)
+			{
+				newMultiString._points.Add(previewPoint.Copy());
+			}
+
+			//Console.WriteLine("Clone");
+			return newMultiString;
         }
 
         public override void MoveTo(int x, int y)

--- a/Modules/Preview/VixenPreview/Shapes/PreviewNet.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewNet.cs
@@ -493,5 +493,23 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_bottomLeft.Y = bottomLeftStart.Y;
 			Resize(aspect);
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newNet = (PreviewNet) MemberwiseClone();
+			newNet._topLeft = _topLeft.Copy();
+			newNet._topRight = _topRight.Copy();
+			newNet._bottomRight = _bottomRight.Copy();
+			newNet._bottomLeft = _bottomLeft.Copy();
+
+			newNet.Reconfigure(initiallyAssignedNode);
+
+			return newNet;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewPixelGrid.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewPixelGrid.cs
@@ -543,8 +543,10 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 				PreviewBaseShape newLine = (PreviewLine) line.Clone();
 				newGrid._strings.Add(newLine);
 			}
-			newGrid._topLeft = new PreviewPoint(_topLeft);
-			newGrid._bottomRight = new PreviewPoint(_bottomRight);
+			newGrid._topLeft = _topLeft.Copy();
+			newGrid._topRight = _topRight.Copy();
+			newGrid._bottomRight = _bottomRight.Copy();
+			newGrid._bottomLeft = _bottomLeft.Copy();
 
 			return newGrid;
 		}

--- a/Modules/Preview/VixenPreview/Shapes/PreviewPoint.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewPoint.cs
@@ -48,6 +48,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		{
 			_x = pointToClone.X;
 			_y = pointToClone.Y;
+			_pointType = pointToClone.PointType;
 		}
 
 		public PreviewPoint(Point point)
@@ -78,6 +79,11 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		public override string ToString()
 		{
 			return string.Format("{{{0},{1}}}", X,Y);
+		}
+
+		public PreviewPoint Copy()
+		{
+			return new PreviewPoint(this);
 		}
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewPolyLine.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewPolyLine.cs
@@ -526,11 +526,17 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		{
             PreviewPolyLine newLine = (PreviewPolyLine)this.MemberwiseClone();
 
-			//newLine._pixels = new List<Preview Pixel>();
+			newLine._pixels = new List<PreviewPixel>();
 
 			foreach (PreviewPixel pixel in _pixels) {
-				newLine.AddPixel(pixel.X, pixel.Y);
+				newLine._pixels.Add(pixel.Clone());
 			}
+
+            newLine._points = new List<PreviewPoint>();
+            foreach (var previewPoint in _points)
+            {
+	            newLine._points.Add(previewPoint.Copy());
+            }
 			return newLine;
 		}
 

--- a/Modules/Preview/VixenPreview/Shapes/PreviewRectangle.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewRectangle.cs
@@ -599,5 +599,27 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 			Resize(aspect);
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newRectangle = (PreviewRectangle) MemberwiseClone();
+			newRectangle._topRight = _topRight.Copy();
+			newRectangle._topLeft = _topLeft.Copy();
+			newRectangle._bottomRight = _bottomRight.Copy();
+			newRectangle._bottomLeft = _bottomLeft.Copy();
+
+			newRectangle.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newRectangle.Pixels.Add(previewPixel.Clone());
+			}
+
+			return newRectangle;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewSingle.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewSingle.cs
@@ -221,5 +221,17 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			p1.Y = p1Start.Y;
 			Resize(aspect);
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newSingle = (PreviewSingle) MemberwiseClone();
+			newSingle.p1 = p1.Copy();
+			return newSingle;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewStar.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewStar.cs
@@ -603,5 +603,24 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_bottomRightPoint.Y = bottomRightStart.Y;
 			Resize(aspect);
 		}
+
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newStar = (PreviewStar) MemberwiseClone();
+			newStar._topLeftPoint = _topLeftPoint.Copy();
+			newStar._bottomRightPoint = _bottomRightPoint.Copy();
+			newStar.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newStar.Pixels.Add(previewPixel.Clone());
+			}
+
+			return newStar;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewStarBurst.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewStarBurst.cs
@@ -548,5 +548,23 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			Resize(aspect);
 		}
 
+		#region Overrides of PreviewBaseShape
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newStar = (PreviewStarBurst) MemberwiseClone();
+			newStar._topRight = _topRight.Copy();
+			newStar._bottomRight = _bottomRight.Copy();
+			newStar.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newStar.Pixels.Add(previewPixel.Clone());
+			}
+
+			return newStar;
+		}
+
+		#endregion
 	}
 }

--- a/Modules/Preview/VixenPreview/Shapes/PreviewTriangle.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewTriangle.cs
@@ -478,5 +478,21 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_point3.Y = p3Start.Y;
 			Resize(aspect);
 		}
+
+		/// <inheritdoc />
+		public override object Clone()
+		{
+			var newEllipse = (PreviewTriangle) MemberwiseClone();
+			newEllipse._point1 = _point1.Copy();
+			newEllipse._point2 = _point2.Copy();
+			newEllipse._point3 = _point3.Copy();
+			newEllipse.Pixels = new List<PreviewPixel>();
+			foreach (var previewPixel in Pixels)
+			{
+				newEllipse.Pixels.Add(previewPixel.Clone());
+			}
+			
+			return newEllipse;
+		}
 	}
 }

--- a/Modules/Preview/VixenPreview/VixenPreviewData.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewData.cs
@@ -10,26 +10,23 @@ namespace VixenModules.Preview.VixenPreview
 	public class VixenPreviewData : ModuleDataModelBase
 	{
 		private List<DisplayItem> _displayItems = new List<DisplayItem>();
-		private int _backgroundAlpha = 255;
-		private bool _saveLocations = true;
 
 		public override IModuleDataModel Clone()
 		{
 			//Console.WriteLine("Clone");
-			VixenPreviewData result = new VixenPreviewData
-			                          	{
-			                          		Width = 1024,
-			                          		Height = 800
-			                          	};
+			VixenPreviewData result = (VixenPreviewData)MemberwiseClone();
+			List<DisplayItem> displayItemCopy = new List<DisplayItem>(DisplayItems.Count);
+			foreach (var displayItem in DisplayItems)
+			{
+				displayItemCopy.Add((DisplayItem)displayItem.Clone());
+			}
+
+			result.DisplayItems = displayItemCopy;
 			return result;
 		}
 
 		[DataMember]
-		public int BackgroundAlpha
-		{
-			get { return _backgroundAlpha; }
-			set { _backgroundAlpha = value; }
-		}
+		public int BackgroundAlpha { get; set; } = 255;
 
 		[DataMember]
 		public string BackgroundFileName { get; set; }
@@ -59,11 +56,7 @@ namespace VixenModules.Preview.VixenPreview
 		public int Height { get; set; }
 
 		[DataMember]
-		public bool SaveLocations
-		{
-			get { return _saveLocations; }
-			set { _saveLocations = value; }
-		}
+		public bool SaveLocations { get; set; } = true;
 
 		[DataMember]
 		public Vector3D LocationOffset { get; set; }


### PR DESCRIPTION
Add UI elements and logic in the ConfigPreviews to duplicate selected previews.

Core changes to the make sure the clone methods on all the shapes work correctly and make a unlinked duplicate of the shapes. This looks more invasive than it actually was. All the shapes were touched as many of them did not have a proper clone override. Some of them did, but it was not making a proper deep clone of all items.