### PR TITLE
VIX-2934 Fix an issue where the first frame text would be black.

### DIFF
--- a/Modules/Effect/Text/Text.cs
+++ b/Modules/Effect/Text/Text.cs
@@ -741,11 +741,11 @@ namespace VixenModules.Effect.Text
 		{
 			var bufferHt = BufferHt;
 			var bufferWi = BufferWi;
+			_level = LevelCurve.GetValue(GetEffectTimeIntervalPosition(frame) * 100) / 100;
 			using (var bitmap = new Bitmap(bufferWi, bufferHt))
 			{
 				InitialRender(frame, bitmap, bufferHt, bufferWi);
 				if (_text.Count == 0 && !UseBaseColor) return;
-				_level = LevelCurve.GetValue(GetEffectTimeIntervalPosition(frame) * 100) / 100;
 				FastPixel.FastPixel fp = new FastPixel.FastPixel(bitmap);
 				fp.Lock();
 				// copy to frameBuffer


### PR DESCRIPTION
The level value was not being initialized before the initial render operation happened on the first frame. This was causing the first frame to have transparent text on the the initial render. It is a class level variable, so the next time it rendered it would have the last value which if positive would produce a non transparent frame. I moved the initialization of that variable to ensure it happens correctly.