### PR TITLE
VIX-2942 Fix a bug in the Star that would not set the string type cor…

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/PreviewStar.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewStar.cs
@@ -104,17 +104,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		private bool IsPixelStar(ElementNode selectedNode)
 		{
-			int childCount = 0;
-			// Iterate through each child
-			foreach (ElementNode child in selectedNode.Children)
-			{
-				// If we have children and this is a group
-				if (child.Children.ToList().Count() > 0 && !child.IsLeaf)
-				{
-					childCount++;
-				}
-			}
-			return (childCount >= 2);
+			return !selectedNode.IsLeaf && selectedNode.GetLeafEnumerator().Count() >= 2;
 		}
 
 		private void AddAllChildren(ElementNode selectedNode)


### PR DESCRIPTION
…rectly.

The logic to determine if the Star is on a pixel or standard string type was not working correctly. Simplified and rewrote the logic to satisfy the test.