### PR TITLE
VIX-2941

### DIFF
--- a/Modules/Effect/Effect/ExpandoObjectObservableCollection.cs
+++ b/Modules/Effect/Effect/ExpandoObjectObservableCollection.cs
@@ -9,7 +9,7 @@ namespace VixenModules.Effect.Effect
 	/// for sharing mark collections with these objects.
 	/// </summary>
 	/// <typeparam name="T">Collection Item Type</typeparam>
-	public class ExpandoObjectObservableCollection<T> : NotifyPropertyObservableCollection<T>
+	public abstract class ExpandoObjectObservableCollection<T> : NotifyPropertyObservableCollection<T>
 		where T : IMarkCollectionExpandoObject
 	{
 		#region Constructor

--- a/Modules/Effect/Wave/Wave/Wave.cs
+++ b/Modules/Effect/Wave/Wave/Wave.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Vixen.Attributes;
 using Vixen.Marks;
 using Vixen.Module;
-using Vixen.Sys.Attribute;
 using VixenModules.App.ColorGradients;
 using VixenModules.App.Curves;
 using VixenModules.Effect.Effect;
@@ -109,7 +108,7 @@ namespace VixenModules.Effect.Wave
 			_data = new WaveData();
 
 			// Create the collection of waves
-			_waves = new ExpandoObjectObservableCollection<IWaveform>("Waves");
+			_waves = new WaveFormCollection();
 
 			// Give the wave a reference to the effect.
 			// This is needed so that the waveforms can use the parent to register (listen) for mark collection events

--- a/Modules/Effect/Wave/Wave/WaveFormCollection.cs
+++ b/Modules/Effect/Wave/Wave/WaveFormCollection.cs
@@ -1,0 +1,22 @@
+﻿using VixenModules.Effect.Effect;
+
+namespace VixenModules.Effect.Wave
+{
+	/// <summary>
+	/// Maintains a collection of IWaveform objects.
+	/// </summary>
+	public class WaveFormCollection : ExpandoObjectObservableCollection<IWaveform>
+	{
+		#region Constructor
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public WaveFormCollection() : 
+			base("Waves")
+		{
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Made ExpandoObjectObservablecollection abastract so that we are forced to create derived collections with parameterless contructors.  The effect editor requires a parameterless constructor such that new collections can be created with the Activator.