### PR TITLE
VIX-2943 Enhance the Shockwave radius curve to use a scaled range bas…

### DIFF
--- a/Modules/Effect/Shockwave/Shockwave.cs
+++ b/Modules/Effect/Shockwave/Shockwave.cs
@@ -92,6 +92,22 @@ namespace VixenModules.Effect.Shockwave
 				OnPropertyChanged();
 			}
 		}
+
+		[Value]
+		[ProviderCategory(@"Config", 1)]
+		[ProviderDisplayName(@"ScaledRadius")]
+		[ProviderDescription(@"ScaledRadius")]
+		[PropertyOrder(6)]
+		public bool ScaledRadius
+		{
+			get { return _data.ScaledRadius; }
+			set
+			{
+				_data.ScaledRadius = value;
+				IsDirty = true;
+				OnPropertyChanged();
+			}
+		}
 		
 		[Value]
 		[ProviderCategory(@"Config", 1)]
@@ -234,7 +250,7 @@ namespace VixenModules.Effect.Shockwave
 			}
 
 			Point centerPoint = new Point((int)posX, (int)posY);
-			double centerRadius = CalculateRadius(effectPositionAdjust);
+			double centerRadius = CalculateRadius(effectPositionAdjust, ScaledRadius?Math.Max(BufferHt, BufferWi):750);
 			double halfWidth = CalculateWidth(effectPositionAdjust) / 2.0;
 			var radius1 = Math.Max(0.0, centerRadius - halfWidth);
 			var radius2 = centerRadius + halfWidth;
@@ -287,7 +303,7 @@ namespace VixenModules.Effect.Shockwave
 				frameBuffer.CurrentFrame = effectFrame;
 				double effectPositionAdjust = CalculateAcceleration(intervalPos, CalculateAcceleration(intervalPosFactor))*100.0;
 				Color c = Color.GetColorAt(intervalPos);
-				double centerRadius = CalculateRadius(effectPositionAdjust);
+				double centerRadius = CalculateRadius(effectPositionAdjust, ScaledRadius?Math.Max(BufferHt, BufferWi):750);
 				double halfWidth = CalculateWidth(effectPositionAdjust) / 2.0;
 
 				var radius1 = Math.Max(0.0, centerRadius - halfWidth);
@@ -354,9 +370,9 @@ namespace VixenModules.Effect.Shockwave
 			return ScaleCurveToValue(AccelerationCurve.GetValue(intervalPos), 10, -10);
 		}
 
-		private double CalculateRadius(double intervalPos)
+		private double CalculateRadius(double intervalPos, int scale)
 		{
-			return ScaleCurveToValue(RadiusCurve.GetValue(intervalPos), 750, 0);
+			return ScaleCurveToValue(RadiusCurve.GetValue(intervalPos), scale, 0);
 		}
 
 		private double DistanceFromCenter(Point center, Point point)

--- a/Modules/Effect/Shockwave/ShockwaveData.cs
+++ b/Modules/Effect/Shockwave/ShockwaveData.cs
@@ -19,14 +19,13 @@ namespace VixenModules.Effect.Shockwave
 			Gradient.Colors.Add(new ColorPoint(Color.Lime, .5));
 			Gradient.Colors.Add(new ColorPoint(Color.Blue, 1.0));
 			WidthCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 2.0, 4.0 }));
-			//EndWidthCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 4.0, 4.0 }));
-			RadiusCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 0.2, 1.2 }));
-			//EndRadiusCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 1.2, 1.2 }));
+			RadiusCurve = new Curve(CurveType.RampUp);
 			CenterXCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 50.0, 50.0 }));
 			CenterYCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 50.0, 50.0 }));
-			AccelerationCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 50.0, 50.0 }));
+			AccelerationCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 55.0, 55.0 }));
 			BlendEdges = true;
 			Orientation=StringOrientation.Vertical;
+			ScaledRadius = true;
 		}
 
 		[DataMember]
@@ -70,6 +69,9 @@ namespace VixenModules.Effect.Shockwave
 
 		[DataMember]
 		public bool BlendEdges { get; set; }
+
+		[DataMember]
+		public bool ScaledRadius { get; set; }
 
 		[DataMember]
 		public StringOrientation Orientation { get; set; }

--- a/Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -1065,4 +1065,7 @@
   <data name="VFlakeCount" xml:space="preserve">
     <value>Adjust the number of Vertical Snowflakes.</value>
   </data>
+  <data name="ScaledRadius" xml:space="preserve">
+    <value>Scale the radius setting to the size of the element.</value>
+  </data>
 </root>

--- a/Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
+++ b/Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
@@ -1029,4 +1029,7 @@
   <data name="VFlakeCount" xml:space="preserve">
     <value>Vertical Flake Count</value>
   </data>
+  <data name="ScaledRadius" xml:space="preserve">
+    <value>Scaled Radius</value>
+  </data>
 </root>


### PR DESCRIPTION
…ed on the prop size.

Add logic to select the new scaled method and make it the default for new effects. Old effects will remain unscaled to allow clean backward compatibility.

Change the default curve for the radius to provide a better default with the scaling option.

Fix the acceleration rate curve default to act like the original did before the curve introduction.