### PR TITLE
VIX-2953 Polygon editor locked up while resizing a polygon

### DIFF
--- a/Modules/Editor/PolygonEditor/Adorners/ResizeAdorner.cs
+++ b/Modules/Editor/PolygonEditor/Adorners/ResizeAdorner.cs
@@ -346,29 +346,17 @@ namespace VixenModules.Editor.PolygonEditor.Adorners
 
 		private void HandleMiddleTop(object sender, DragDeltaEventArgs args)
 		{
-			bool scaled = false;
-
 			double scaleY = -args.VerticalChange / GetYScaleDenominator();
 			scaleY += 1;
-						
-			do
-			{								
-				Rect boundsCopy = Bounds;
-
-				var centerPoint = new Point((Bounds.Right - Bounds.Left) / 2, Bounds.Bottom);
-				ScaleTransform t = new ScaleTransform(1, scaleY, centerPoint.X, centerPoint.Y);
+			
+			var centerPoint = new Point((Bounds.Right - Bounds.Left) / 2, Bounds.Bottom);
+			ScaleTransform t = new ScaleTransform(1, scaleY, centerPoint.X, centerPoint.Y);
 				
-				// If the transform is valid then...
-				if (IsTransformValid(t))
-				{
-					TransformItems(t);
-					scaled = true;
-				}
-				scaleY = scaleY - 1.0;
-				scaleY /= 2.0;
-				scaleY += 1.0;				
+			// If the transform is valid then...
+			if (IsTransformValid(t))
+			{
+				TransformItems(t);
 			}
-			while (!scaled);
 		}
 
 		private void HandleRotate(object sender, DragDeltaEventArgs e)

--- a/Modules/Editor/PolygonEditor/Views/PolygonEditorView.xaml.cs
+++ b/Modules/Editor/PolygonEditor/Views/PolygonEditorView.xaml.cs
@@ -93,8 +93,8 @@ namespace VixenModules.Editor.PolygonEditor.Views
 				}
 				
 				// Give the view model the drawing canvas width and height
-				vm.CanvasWidth = (int)Math.Round(_polygonContainer.Width * factor, MidpointRounding.AwayFromZero);
-				vm.CanvasHeight = (int) Math.Round(_polygonContainer.Height * factor, MidpointRounding.AwayFromZero);
+				vm.CanvasWidth = (int)Math.Ceiling(_polygonContainer.Width * factor);
+				vm.CanvasHeight = (int) Math.Ceiling(_polygonContainer.Height * factor);
 
 				// Give the polygon point converter the scale factor
 				PolygonPointXConverter.XScaleFactor = xScaleFactor;


### PR DESCRIPTION
Removed some logic that was trying to assist when resizing to the edges.  It was only on the the middle top adorner so it was unbalanced anyway.

The other issue was with a Math.Round that was not doing what I thought it was doing.  Replaced it with Math.Ceiling.