### PR TITLE
VIX-2961 Fix Scheduler hang with sequences that need to be migrated.

### DIFF
--- a/Application/VixenApplication/VixenApplication.cs
+++ b/Application/VixenApplication/VixenApplication.cs
@@ -29,6 +29,8 @@ using Common.Controls.Theme;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog.Targets;
+using Vixen.Module.App;
+using VixenModules.App.SuperScheduler;
 using Application = System.Windows.Forms.Application;
 using Point = System.Drawing.Point;
 using SystemFonts = System.Drawing.SystemFonts;
@@ -64,6 +66,7 @@ namespace VixenApplication
 		{
 			InitializeComponent();
 
+			VixenSystem.UIThread = Thread.CurrentThread;
 			_startupProgress = new Progress<Tuple<int, string>>(UpdateProgress);
 
             //Begin WPF init
@@ -410,6 +413,11 @@ namespace VixenApplication
 			progressBar.Visible = false;
 			PopulateRecentSequencesList();
 			EnableButtons();
+
+		    // This is a hack to workaround threading issues in the Scheduler start up. TODO revisit and solve this in a better way.
+			var scheduler = ApplicationServices.Get<IAppModuleInstance>(SuperSchedulerDescriptor._typeId) as SuperSchedulerModule;
+			scheduler?.Start();
+
 			Cursor = Cursors.Default;
 		}
 

--- a/Application/VixenApplication/VixenApplication.csproj
+++ b/Application/VixenApplication/VixenApplication.csproj
@@ -59,6 +59,10 @@
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>
     </ProjectReference>
+    <ProjectReference Include="..\..\Modules\App\SuperScheduler\SuperScheduler.csproj">
+      <Private>false</Private>
+      <IncludeAssets>None</IncludeAssets>
+    </ProjectReference>
     <ProjectReference Include="..\..\Modules\PostFilter\DimmingCurve\DimmingCurve.csproj">
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>

--- a/Modules/App/SuperScheduler/SuperSchedulerDescriptor.cs
+++ b/Modules/App/SuperScheduler/SuperSchedulerDescriptor.cs
@@ -5,7 +5,7 @@ namespace VixenModules.App.SuperScheduler
 {
 	public class SuperSchedulerDescriptor : AppModuleDescriptorBase
 	{
-		private Guid _typeId = new Guid("{985315E8-2B83-4D1A-89D1-58BFEA7835A0}");
+		public static Guid _typeId = new Guid("{985315E8-2B83-4D1A-89D1-58BFEA7835A0}");
 
 		public override string TypeName
 		{

--- a/Modules/App/SuperScheduler/SuperSchedulerModule.cs
+++ b/Modules/App/SuperScheduler/SuperSchedulerModule.cs
@@ -28,7 +28,7 @@ namespace VixenModules.App.SuperScheduler
 			CreateMenu();
 			//SetSchedulerEnableState(_data.IsEnabled);
 			_executor = new ScheduleExecutor(_data);
-			_executor.CheckSchedule();
+			//_executor.CheckSchedule();
 		}
 
 		public override void Unloading()
@@ -47,6 +47,11 @@ namespace VixenModules.App.SuperScheduler
 		{
 			get { return _data; }
 			set { _data = (SuperSchedulerData) value; }
+		}
+
+		public void Start()
+		{
+			_executor.CheckSchedule();
 		}
 
 		//private System.Timers.Timer Timer

--- a/Modules/Sequence/Timed/Timed.csproj
+++ b/Modules/Sequence/Timed/Timed.csproj
@@ -30,6 +30,11 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.6.8">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\Vixen.System\Vixen.csproj">
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>

--- a/Vixen.System/Sys/VixenSystem.cs
+++ b/Vixen.System/Sys/VixenSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Vixen.Module;
@@ -29,7 +30,9 @@ namespace Vixen.Sys
 		private static bool _systemConfigSaving;
 		private static bool _moduleConfigSaving;
 
-		internal static bool MigrationOccured { get; set; }	
+		internal static bool MigrationOccured { get; set; }
+
+		public static Thread UIThread { get; set; }
 
 		public static bool IsSaving()
 		{


### PR DESCRIPTION
Suppress the migration message when not on the UI thread.

Fix a threading issue with starting the scheduler from the module startup that occurs in a non UI thread. This is workaround until a better solution can be found.