### PR TITLE
VIX-2961 Resolve the synchronization issues in the Scheduler.

### DIFF
--- a/Application/VixenApplication/VixenApplication.cs
+++ b/Application/VixenApplication/VixenApplication.cs
@@ -30,7 +30,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog.Targets;
 using Vixen.Module.App;
-using VixenModules.App.SuperScheduler;
 using Application = System.Windows.Forms.Application;
 using Point = System.Drawing.Point;
 using SystemFonts = System.Drawing.SystemFonts;
@@ -67,6 +66,7 @@ namespace VixenApplication
 			InitializeComponent();
 
 			VixenSystem.UIThread = Thread.CurrentThread;
+			VixenSystem.UIContext = SynchronizationContext.Current;
 			_startupProgress = new Progress<Tuple<int, string>>(UpdateProgress);
 
             //Begin WPF init
@@ -413,10 +413,6 @@ namespace VixenApplication
 			progressBar.Visible = false;
 			PopulateRecentSequencesList();
 			EnableButtons();
-
-		    // This is a hack to workaround threading issues in the Scheduler start up. TODO revisit and solve this in a better way.
-			var scheduler = ApplicationServices.Get<IAppModuleInstance>(SuperSchedulerDescriptor._typeId) as SuperSchedulerModule;
-			scheduler?.Start();
 
 			Cursor = Cursors.Default;
 		}

--- a/Application/VixenApplication/VixenApplication.csproj
+++ b/Application/VixenApplication/VixenApplication.csproj
@@ -59,10 +59,6 @@
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>
     </ProjectReference>
-    <ProjectReference Include="..\..\Modules\App\SuperScheduler\SuperScheduler.csproj">
-      <Private>false</Private>
-      <IncludeAssets>None</IncludeAssets>
-    </ProjectReference>
     <ProjectReference Include="..\..\Modules\PostFilter\DimmingCurve\DimmingCurve.csproj">
       <Private>false</Private>
       <IncludeAssets>None</IncludeAssets>

--- a/Modules/App/Scheduler/SchedulerModule.cs
+++ b/Modules/App/Scheduler/SchedulerModule.cs
@@ -37,7 +37,7 @@ namespace VixenModules.App.Scheduler
 			
 			_AddApplicationMenu();
 			_SetEnableState(_data.IsEnabled);
-			_synchronizationContext = SynchronizationContext.Current;
+			_synchronizationContext = VixenSystem.UIContext;
 			Logging.Info("Scheduler module loaded.");
 		}
 

--- a/Modules/App/SuperScheduler/ScheduleExecutor.cs
+++ b/Modules/App/SuperScheduler/ScheduleExecutor.cs
@@ -22,7 +22,7 @@ namespace VixenModules.App.SuperScheduler
 		public ScheduleExecutor(SuperSchedulerData data)
 		{
 			Data = data;
-			_synchronizationContext = SynchronizationContext.Current;
+			_synchronizationContext = VixenSystem.UIContext;
 			if (Enabled)
 			{
 				Timer.Enabled = true;
@@ -57,7 +57,8 @@ namespace VixenModules.App.SuperScheduler
 			set
 			{
 				_enabled = value;
-				ShowStatusForm(_enabled);
+				_synchronizationContext.Send(o => ShowStatusForm(_enabled), null);
+				
 				if (Enabled)
 				{
 					Timer.Enabled = true;

--- a/Modules/App/SuperScheduler/SuperSchedulerModule.cs
+++ b/Modules/App/SuperScheduler/SuperSchedulerModule.cs
@@ -28,7 +28,7 @@ namespace VixenModules.App.SuperScheduler
 			CreateMenu();
 			//SetSchedulerEnableState(_data.IsEnabled);
 			_executor = new ScheduleExecutor(_data);
-			//_executor.CheckSchedule();
+			_executor.CheckSchedule();
 		}
 
 		public override void Unloading()

--- a/Vixen.System/Sys/VixenSystem.cs
+++ b/Vixen.System/Sys/VixenSystem.cs
@@ -33,6 +33,7 @@ namespace Vixen.Sys
 		internal static bool MigrationOccured { get; set; }
 
 		public static Thread UIThread { get; set; }
+		public static SynchronizationContext UIContext { get; set; }
 
 		public static bool IsSaving()
 		{


### PR DESCRIPTION
Store off the UI context for later use. Use that to run the forms in the modules when they start forms so they are in the proper UI context.

Revert the temporary workaround.