### PR TITLE
VIX-2953 - Fix scaling math

### DIFF
--- a/Modules/Editor/PolygonEditor/ViewModels/PolygonEditorViewModel.cs
+++ b/Modules/Editor/PolygonEditor/ViewModels/PolygonEditorViewModel.cs
@@ -4789,27 +4789,32 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 			{
 				// Transform the point
 				Point transformedPoint = scaleTransform.Transform(point.GetPoint());
-				
+
+				// Round the point to ten fractional digits to account for floating point errors
+				// when scaling the points
+				double x = Math.Round(transformedPoint.X, 10);
+				double y = Math.Round(transformedPoint.Y, 10);
+
 				// If the point is off the canvas to the left
-				if (transformedPoint.X < 0)
+				if (x < 0)
 				{
 					isTransformValid = false;
 				}
 
 				// If the point is off the canvas to the top
-				if (transformedPoint.Y < 0)
+				if (y < 0)
 				{
 					isTransformValid = false;
 				}
 
 				// If the point is off the canvas to the right
-				if (transformedPoint.X > ActualWidth - 1)
+				if (x > ActualWidth - 1)
 				{
 					isTransformValid = false;
 				}
 
 				// If the point is off the canvas to the bottom
-				if (transformedPoint.Y > ActualHeight - 1)
+				if (y > ActualHeight - 1)
 				{
 					isTransformValid = false;
 				}

--- a/Modules/Editor/PolygonEditor/Views/PolygonEditorView.xaml.cs
+++ b/Modules/Editor/PolygonEditor/Views/PolygonEditorView.xaml.cs
@@ -67,35 +67,36 @@ namespace VixenModules.Editor.PolygonEditor.Views
 				// Take the minimum scale factor between the width and height
 				double factor = Math.Min(wfactor, hfactor);
 
+				// Calculate the width and height of the canvas using the scale factor and rounding to the next largest pixel
+				vm.CanvasWidth = (int)Math.Ceiling(_polygonContainer.Width * factor);
+				vm.CanvasHeight = (int)Math.Ceiling(_polygonContainer.Height * factor);
+
 				// Determine the X and Y scale factors
 				double xScaleFactor = 1.0; 
 
 				// Need to guard against dividing by zero when working with 1 pixel width
-				if ((_polygonContainer.Width - 1.0) == 0.0)
+				if (_polygonContainer.Width - 1.0 == 0.0)
 				{
-					xScaleFactor = 1.0;
+					xScaleFactor = (vm.CanvasWidth - 1.0);
 				}
 				else
 				{
-					xScaleFactor = (_polygonContainer.Width * factor - 1.0) / (_polygonContainer.Width - 1.0);
+					xScaleFactor = (vm.CanvasWidth - 1.0) / (_polygonContainer.Width - 1.0);
 				}
 
 				double yScaleFactor = 1.0;
 
 				// Need to guard against dividing by zero when working with 1 pixel height
-				if ((_polygonContainer.Height - 1.0) == 0.0)
+				if (_polygonContainer.Height - 1.0 == 0.0)
 				{
-					yScaleFactor = (_polygonContainer.Height * factor - 1.0); 
+					yScaleFactor = (vm.CanvasHeight - 1.0);
 				}
 				else
 				{
-					yScaleFactor = (_polygonContainer.Height * factor - 1.0) / (_polygonContainer.Height - 1.0);
+					yScaleFactor = (vm.CanvasHeight - 1.0) / (_polygonContainer.Height - 1.0);
 				}
 				
-				// Give the view model the drawing canvas width and height
-				vm.CanvasWidth = (int)Math.Ceiling(_polygonContainer.Width * factor);
-				vm.CanvasHeight = (int) Math.Ceiling(_polygonContainer.Height * factor);
-
+				
 				// Give the polygon point converter the scale factor
 				PolygonPointXConverter.XScaleFactor = xScaleFactor;
 				PolygonPointYConverter.YScaleFactor = yScaleFactor;


### PR DESCRIPTION
Original fix to (VIX-2953) was to take the ceiling of the scaled width and height. This had the potential to add some fractional slop to the drawing canvas. To fix this, I moved the logic to calculate the canvas size up so that the final scale factor can be based on the canvas size and the original display element size.

Once the scale factor was improved I noticed on my mega-tree that the scaling produced some floating point error which prevented the user from resizing the polygon. To account for the floating point error I added some rounding in the IsTransformValid method.

Finally I noticed there was an inconsistency on how single width display elements like arches were being scaled. This was updated to be consistent between the X and Y.