### PR TITLE
VIX-2969 Fix WaveType on Wave Effect

### DIFF
--- a/Modules/Effect/Wave/Wave/Wave.cs
+++ b/Modules/Effect/Wave/Wave/Wave.cs
@@ -162,13 +162,13 @@ namespace VixenModules.Effect.Wave
 			}
 		}
 
-		private ExpandoObjectObservableCollection<IWaveform> _waves;
+		private WaveFormCollection _waves;
 		
 		[ProviderCategory(@"Config", 1)]
 		[ProviderDisplayName(@"Waves")]
 		[ProviderDescription(@"Waves")]
 		[PropertyOrder(2)]
-		public ExpandoObjectObservableCollection<IWaveform> Waves
+		public WaveFormCollection Waves
 		{
 			get
 			{


### PR DESCRIPTION
The fix for VIX-2941 was incomplete.  I think I got too much in hurry / over confident and did not test sufficiently.

The property on the effect needs be the most derived type for the reflection to work properly.