### PR TITLE
VIX-2978 Fix a bug in the Lipsync that does not properly detect Lipsy…

### DIFF
--- a/Modules/Effect/LipSync/LipSync.cs
+++ b/Modules/Effect/LipSync/LipSync.cs
@@ -379,7 +379,7 @@ namespace VixenModules.Effect.LipSync
 
 		private void SetupMarks()
 		{
-			if (MarkCollections == null || !MarkCollections.Any())
+			if (MarkCollections == null || MarkCollections.All(x => x.CollectionType == MarkCollectionType.Generic))
 			{
 				LipSyncMode = LipSyncMode.Phoneme;
 				return;


### PR DESCRIPTION
…nc Marks.

Add logic to the test to ensure the collection is a lipsync type mark collection to set the mode back to phoneme.