### PR TITLE
VIX-2981 Fix the logic in the spin to avoid invalid values from break…

### DIFF
--- a/Modules/Effect/Spin/Spin.cs
+++ b/Modules/Effect/Spin/Spin.cs
@@ -603,9 +603,14 @@ namespace VixenModules.Effect.Spin
 			double pulseInterpolationOffset = 1.0/(double) targetNodeCount;
 
 			// figure out either the revolution count or time, based on what data we have
-			if (SpeedFormat == SpinSpeedFormat.RevolutionCount) {
-				revTimeMs = (TimeSpan.TotalMilliseconds - pulseConstant)/
-				            (RevolutionCount + pulseFractional - pulseInterpolationOffset);
+			if (SpeedFormat == SpinSpeedFormat.RevolutionCount)
+			{
+				var t = (RevolutionCount + pulseFractional - pulseInterpolationOffset);
+				if (t <= 0)
+				{
+					t = RevolutionCount > 0?RevolutionCount:1;
+				}
+				revTimeMs = (TimeSpan.TotalMilliseconds - pulseConstant) / t;
 			}
 			else if (SpeedFormat == SpinSpeedFormat.RevolutionFrequency) {
 				revTimeMs = (1.0/RevolutionFrequency)*1000.0; // convert Hz to period ms


### PR DESCRIPTION
…ing the effect.

In some cases depending on the settings and the element that the effect is placed on it can cause the effect to have render errors. This will try to detect the invalid value condition that can occur and use use values that will not cause an error. In all likelihood the effect may not do anything meaning full and the user will correct it. USer provided example was setting the Fixed Pulse interval to a value that combined was longer than the effect duration.