### PR TITLE
VIX-2986 Fix the editor rendering of the Lipsync.

### DIFF
--- a/Modules/Effect/LipSync/LipSync.cs
+++ b/Modules/Effect/LipSync/LipSync.cs
@@ -916,6 +916,19 @@ namespace VixenModules.Effect.LipSync
 							}
 						}
 					}
+					else
+					{
+						//in mark mode with no marks, draw a rest.
+						if (_phonemeBitmaps.TryGetValue(PhonemeType.REST, out displayImage))
+						{
+							var endX = (int)((TimeSpan.Ticks + StartTime.Ticks) / (double)TimeSpan.Ticks * clipRectangle.Width);
+							var startX = (int)(StartTime.Ticks / (double)TimeSpan.Ticks * clipRectangle.Width);
+							scaledImage = new Bitmap(displayImage,
+								Math.Min(clipRectangle.Width, endX - startX),
+								clipRectangle.Height);
+							g.DrawImage(scaledImage, clipRectangle.X, clipRectangle.Y);
+						}
+					}
 				}
 				else
 				{


### PR DESCRIPTION
When there are no marks to work from and mark collection is selected as the type, the REST phoneme will be used. The rendering routine in the effect was not drawing anything. Added the logic to draw the default path.