### PR TITLE
VIX-2987 Fix conflicts when rapid saves occur.

### DIFF
--- a/Application/VixenApplication/VixenApplication.cs
+++ b/Application/VixenApplication/VixenApplication.cs
@@ -106,6 +106,8 @@ namespace VixenApplication
 			toolStripStatusLabelExecutionState.ForeColor = ThemeColorTable.ForeColor;
 			toolStripStatusLabel_memory.ForeColor = ThemeColorTable.ForeColor;
 			contextMenuStripRecent.Renderer = new ThemeToolStripRenderer();
+			progressBar.TextColor = ThemeColorTable.ForeColor;
+			progressBar.ProgressColor = Color.DarkGreen;
 
 			string[] args = Environment.GetCommandLineArgs();
 			foreach (string arg in args) {
@@ -419,7 +421,7 @@ namespace VixenApplication
 			progressBar.Visible = false;
 			PopulateRecentSequencesList();
 			EnableButtons();
-
+			MakeTopMost();
 			Cursor = Cursors.Default;
 		}
 
@@ -436,15 +438,23 @@ namespace VixenApplication
 			serviceLocator.AutoRegisterTypesViaAttributes = true;
 		}
 
-		private async void VixenApplication_Shown(object sender, EventArgs e)
+		private void VixenApplication_Shown(object sender, EventArgs e)
 		{
 			CheckForTestBuild();
-			//Try to make sure at load we are on top.
-			await Task.Delay(750);
 			MakeTopMost();
 		}
 
-		private void MakeTopMost()
+		private async void MakeTopMost()
+		{
+			await Task.Run(async delegate
+			{
+				await Task.Delay(1000);
+				Invoke(new MethodInvoker(SetTopMost));
+			});
+			
+		}
+
+		private void SetTopMost()
 		{
 			TopMost = true;
 			TopMost = false;
@@ -960,10 +970,25 @@ namespace VixenApplication
 			using (ConfigPreviews form = new ConfigPreviews()) {
 				DialogResult result = form.ShowDialog();
 				if (result == DialogResult.OK) {
+					Cursor = Cursors.WaitCursor;
+					EnableButtons(false);
+					progressBar.Visible = true;
+					UpdateProgress(Tuple.Create(0,"Saving Configuration"));
 					await VixenSystem.SaveSystemAndModuleConfigAsync();
+					progressBar.Visible = false;
+					EnableButtons();
+					Cursor = Cursors.Default;
 				}
 				else {
+					Cursor = Cursors.WaitCursor;
+					EnableButtons(false);
+					progressBar.Visible = true;
+					UpdateProgress(Tuple.Create(0,"Reloading Configuration"));
 					VixenSystem.ReloadSystemConfig();
+					progressBar.Visible = false;
+					EnableButtons();
+					Cursor = Cursors.Default;
+					MakeTopMost();
 				}
 			}
 		}
@@ -974,10 +999,25 @@ namespace VixenApplication
 				DialogResult dr = form.ShowDialog();
 
 				if (dr == DialogResult.OK) {
+					Cursor = Cursors.WaitCursor;
+					EnableButtons(false);
+					progressBar.Visible = true;
+					UpdateProgress(Tuple.Create(0,"Saving Configuration"));
 					await VixenSystem.SaveSystemAndModuleConfigAsync();
+					progressBar.Visible = false;
+					EnableButtons();
+					Cursor = Cursors.Default;
 				}
 				else {
+					Cursor = Cursors.WaitCursor;
+					EnableButtons(false);
+					progressBar.Visible = true;
+					UpdateProgress(Tuple.Create(0,"Reloading Configuration"));
 					VixenSystem.ReloadSystemConfig();
+					progressBar.Visible = false;
+					EnableButtons();
+					Cursor = Cursors.Default;
+					MakeTopMost();
 				}
 			}
 		}

--- a/Vixen.System/Sys/VixenSystem.cs
+++ b/Vixen.System/Sys/VixenSystem.cs
@@ -156,10 +156,10 @@ namespace Vixen.Sys
 
 		public static async Task<bool> SaveSystemAndModuleConfigAsync()
 		{
-			var systemConfig = SaveSystemConfigAsync();
-			var moduleConfig = SaveModuleConfigAsync();
-			await systemConfig;
-			await moduleConfig;
+			List<Task> taskList = new List<Task>();
+			taskList.Add(SaveSystemConfigAsync());
+			taskList.Add(SaveModuleConfigAsync());
+			await Task.WhenAll(taskList.ToArray());
 			return true;
 		}
 
@@ -233,6 +233,11 @@ namespace Vixen.Sys
 
 		public static void LoadSystemConfig(IProgress<Tuple<int, string>> progress= null)
 		{
+			while (_systemConfigSaving || _moduleConfigSaving)
+			{
+				Logging.Info("Reload Requested while save in progress. Waiting 5 ms.");
+				Thread.Sleep(5);
+			}
 			Execution.initInstrumentation();
 			DataFlow = new DataFlowManager();
 			Elements = new ElementManager();


### PR DESCRIPTION
The saves when a user opens the Display setup or the Preview setup occur on a background thread to free up the UI. But the user is not prevented from opening the other setup while that is occurring. If they do that and close it before the other save completes, then conflicts can occur. Add logic to disable the buttons while the save is occurring. Add indicator in the progress bar on the admin that saving is in progress so the user is aware of what is going on.

Add wait cursors while saves are occurring.

Add the same blocking logic and progress indicator for the cancel path when the system is being reloaded.

Change the backup logic from a File move to a File copy to improve the performance. For some reason the move randomly is much slower. Copy seems to perform much faster and more consistent. This reduces the time the user is sitting waiting for the save to occur.

Fix the logic to move the Admin form back to the top after a system reload and utilize it on the reload from a cancel operation.