### PR TITLE
Fix the formatting of the build release notes used in the build email…

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -27,7 +27,6 @@ jobs:
       notes_build_type: ${{ env.VIX_NOTES_BUILD_TYPE }}
       notes_fix_version: ${{ env.VIX_NOTES_FIX_VERSION }}
       pre_release: ${{ env.VIX_PRE_RELEASE }}
-      release_notes_markdown: ${{ env.VIX_RELEASE_NOTES_MARKDOWN }}
       release_tag: ${{ env.VIX_RELEASE_TAG }}
       version: ${{ env.VIX_VERSION }}
       
@@ -71,6 +70,12 @@ jobs:
         with:
           name: _releaseNotes
           path: "Release Notes.txt"
+          
+      - name: Upload Build Release Notes Markdown artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: _releaseNotesMd
+          path: "Release Notes.md"
 
 
   build_x86:
@@ -219,7 +224,12 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: _setup64
-      
+          
+      - name: Download Build Release Notes Markdown artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: _releaseNotesMd
+          
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -228,8 +238,7 @@ jobs:
         with:
           tag_name: ${{ needs.setup.outputs.release_tag }}
           release_name: ${{ needs.setup.outputs.release_tag }}
-          body: |
-            ${{ needs.setup.outputs.release_notes_markdown }}
+          body_path: _releaseNotesMd\Release Notes.md
           draft: false
           prerelease: ${{ needs.setup.outputs.pre_release }}
       

--- a/Build/CreateReleaseNotes.ps1
+++ b/Build/CreateReleaseNotes.ps1
@@ -16,6 +16,8 @@ param (
 	[string] $buildType
 )
 
+$nl = [Environment]::NewLine
+
 if($fixVersion.EndsWith('u0')){
 	$fixVersion = $fixVersion -replace ".{2}$"
 }
@@ -86,20 +88,20 @@ foreach ($issue in $issues)
 $output = [string]::Empty
 
 $output += "Release Notes - Vixen 3 - " + $buildType + " Build "
-$output += "`r`n`r`n"
+$output += "$nl$nl"
 
 
 foreach ($type in $issueMap.keys)
 {
-	$output += "** $type`r`n"
+	$output += "** $type$nl"
 
 	foreach ($issue in $issueMap[$type].keys)
 	{
 		$summary = $issueMap[$type][$issue]
-		$output += "    * [$issue] - $summary`r`n"
+		$output += "    * [$issue] - $summary$nl"
 	}
 
-	$output += "`r`n"
+	$output += "$nl"
 }
 
 # Store the release notes as Github Actions output to use in release body
@@ -108,12 +110,9 @@ $actionsOutput = $output.Trim()
 $actionsOutput = $actionsOutput -replace '\A', '## '
 $actionsOutput = $actionsOutput -replace '(?m)^\*\* ', '### '
 $actionsOutput = $actionsOutput -replace '(?m)^    \* ', '* '
-# set-env doesn't like multiline strings - escape CR/LF
-$actionsOutput = $actionsOutput -replace '%', '%25'
-$actionsOutput = $actionsOutput -replace "`r", '%0D'
-$actionsOutput = $actionsOutput -replace "`n", '%0A'
-echo "VIX_RELEASE_NOTES_MARKDOWN=$actionsOutput" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+$file = 'Release Notes.md'
+Out-File -FilePath $file -InputObject $actionsOutput -Encoding UTF8
 
 $file = './Release Notes.txt'
 $regex = '^Release Notes - Vixen 3$'


### PR DESCRIPTION
… and the Github release notes.

The changes to deprecate the set-env commands in Github required the mechanism for creating these notes to change from being passed as an environment variable to being passed as a file artifact.