### PR TITLE
VIX-3011 Correct the MoveTo logic to account for Zoom level.

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -617,8 +618,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// <inheritdoc />
 		public override void MoveTo(int x, int y)
 		{
-			int xOffset = x - (int)Bounds.X;
-			int yOffset = y - (int)Bounds.Y;
+			var xOffset = ZoomCoordToOriginal(x - Bounds.X);
+			var yOffset = ZoomCoordToOriginal(y - Bounds.Y);
+			
 			foreach (var previewPixel in PropPixels)
 			{
 				var p = new Point(previewPixel.Location.X + xOffset, previewPixel.Location.Y + yOffset);


### PR DESCRIPTION
The move to logic was not scaling the movement offset back to the original zoom level that the prop coordinates are in and thus was multiplying the movement. This created erratic behavior the further from the original location the mouse was moving toward. Apply the reverse zoom logic to the move offset to get it into the same coordinate plane.