### PR TITLE
VIX-2980 Improve the performance of a few routines that are used in d…

### DIFF
--- a/Common/Controls/TimeLineControl/Grid.cs
+++ b/Common/Controls/TimeLineControl/Grid.cs
@@ -101,6 +101,7 @@ namespace Common.Controls.Timeline
 			Row.RowSelectedChanged += RowSelectedChangedHandler;
 			Row.RowToggled += RowToggledHandler;
             Row.RowHeightChanged += RowHeightChangedHandler;
+			Row.RowVisibilityChanged += RowVisibilityChangedHandler;
 			TimeLineGlobalEventManager.Manager.AlignmentActivity += TimeLineAlignmentHandler;
 
 			// Drag & Drop
@@ -284,9 +285,18 @@ namespace Common.Controls.Timeline
 			}
 		}
 
+		private IEnumerable<Element> _selectedElements;
 		public IEnumerable<Element> SelectedElements
 		{
-			get { return Rows.SelectMany(x => x.SelectedElements).Distinct(); }
+			get
+			{
+				if (_selectedElements == null)
+				{
+					_selectedElements = Rows.SelectMany(x => x.SelectedElements).Distinct().ToList();
+				}
+
+				return _selectedElements;
+			}
 		}
 
 		public IEnumerable<Row> SelectedRows
@@ -405,6 +415,7 @@ namespace Common.Controls.Timeline
 
 		private void _SelectionChanged()
 		{
+			_selectedElements = null;
 			if (SupressSelectionEvents) return;
 			if (SelectionChanged != null)
 				SelectionChanged(this, EventArgs.Empty);
@@ -493,7 +504,10 @@ namespace Common.Controls.Timeline
 			// when dragging, the control will invalidate after it's done, in case multiple elements are changing.
 			if (m_dragState != DragState.Moving && !SequenceLoading)
 				if (!SuppressInvalidate) Invalidate();
+		}
 
+		protected void RowVisibilityChangedHandler(object sender, EventArgs e)
+		{
 			_visibleRowsDirty = true;
 		}
 

--- a/Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -826,8 +826,11 @@ namespace Common.Controls.Timeline
 			}
 
 			// if we've moved vertically, we may need to move elements between rows
-			if (dy != 0) {
+			if (dy != 0)
+			{
+				SuppressInvalidate = true;
 				MoveElementsVerticallyToLocation(SelectedElements, gridLocation);
+				SuppressInvalidate = false;
 			}
 
 			Invalidate();

--- a/Common/Controls/TimeLineControl/Row.cs
+++ b/Common/Controls/TimeLineControl/Row.cs
@@ -230,6 +230,7 @@ namespace Common.Controls.Timeline
 					RowLabel.Height = Height;
 				}
 				_RowChanged();
+				_RowVisibilityChanged();
 			}
 		}
 
@@ -280,6 +281,7 @@ namespace Common.Controls.Timeline
 		public static event EventHandler RowHeightResized;
 		public static event EventHandler RowLabelContextMenuSelect;
 		public static event EventHandler<ModifierKeysEventArgs> RowSelectedChanged;
+		public static event EventHandler RowVisibilityChanged;
 
 		private void _ElementAdded(Element te)
 		{
@@ -319,6 +321,11 @@ namespace Common.Controls.Timeline
 		private void _RowSelectedChanged(Keys k)
 		{
 			if (RowSelectedChanged != null) RowSelectedChanged(this, new ModifierKeysEventArgs(k));
+		}
+
+		private void _RowVisibilityChanged()
+		{
+			RowVisibilityChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		#endregion
@@ -528,7 +535,7 @@ namespace Common.Controls.Timeline
 
 		public bool AddUniqueElement(Element element)
 		{
-			if (m_elements.Contains(element))
+			if (ContainsElement(element))
 				return false;
 
 			AddElement(element);


### PR DESCRIPTION
…ragging effects in the editor.

Fix the distinct routine that was intended to cache the list of distinct rows that was not working correctly. Add a proper event that only gets fired when the visibility changes.