### PR TITLE
VIX-2878 Amend the fix from this original bug around rogue props in the preview.

### DIFF
--- a/Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -373,6 +373,8 @@ namespace VixenModules.Preview.VixenPreview
 			EndUpdate();
 		}
 
+		public Size VirtualSize => new Size(Width+hScroll.Maximum, Height+vScroll.Maximum);
+
 		public Bitmap Background
 		{
 			get { return _background; }

--- a/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -177,33 +177,34 @@ namespace VixenModules.Preview.VixenPreview
 			List<DisplayItem> itemsToRemove = new List<DisplayItem>();
 			foreach (var previewDisplayItem in previewForm.Preview.DisplayItems)
 			{
-				if (previewDisplayItem.Shape.Bottom < 1 || previewDisplayItem.Shape.Top > previewForm.Preview.Background.Height ||
-				    previewDisplayItem.Shape.Right < 1 || previewDisplayItem.Shape.Left > previewForm.Preview.Background.Width)
+				if (previewDisplayItem.Shape.Top == previewDisplayItem.Shape.Bottom &&
+				    previewDisplayItem.Shape.Left == previewDisplayItem.Shape.Right)
 				{
-					if (previewDisplayItem.Shape.Top == previewDisplayItem.Shape.Bottom &&
-					    previewDisplayItem.Shape.Left == previewDisplayItem.Shape.Right)
+					//if items don't have any size then they were probably added by mistake.
+					itemsToRemove.Add(previewDisplayItem);
+					Logging.Info($"Removing preview item that has no size. {previewDisplayItem.Shape.Name}");
+					continue;
+				}
+
+				if (previewDisplayItem.Shape is PreviewMultiString ms)
+				{
+					if (ms.Strings.Count == 0)
 					{
-						//if items don't have any size then they were probably added by mistake.
 						itemsToRemove.Add(previewDisplayItem);
-						Logging.Info($"Removing preview item that has no size. {previewDisplayItem.Shape.Name}");
+						Logging.Info($"Removing preview MultiString that has no Strings. {previewDisplayItem.Shape.Name}");
 						continue;
 					}
+				}
 
-					if (previewDisplayItem.Shape is PreviewMultiString ms)
-					{
-						if (ms.Strings.Count == 0)
-						{
-							itemsToRemove.Add(previewDisplayItem);
-							Logging.Info($"Removing preview MultiString that has no Strings. {previewDisplayItem.Shape.Name}");
-							continue;
-						}
-					}
-
+				if (previewDisplayItem.Shape.Bottom < 1 || previewDisplayItem.Shape.Right < 1 &&
+					previewDisplayItem.Shape.Top < previewDisplayItem.Shape.Bottom &&
+					previewDisplayItem.Shape.Left < previewDisplayItem.Shape.Right)
+				{
 					Logging.Info($"Moving preview item back in bounds. {newOriginX},10 : {previewDisplayItem.Shape.Name}");
 					var width = previewDisplayItem.Shape.Right - previewDisplayItem.Shape.Left;
 					previewDisplayItem.Shape.MoveTo(newOriginX, 10);
 					newOriginX = newOriginX + width + 5;
-					if (newOriginX > previewForm.Preview.Background.Width || newOriginX <=0)
+					if (newOriginX > previewForm.Preview.Background.Width || newOriginX <= 0)
 					{
 						newOriginX = 10;
 					}


### PR DESCRIPTION
There are some cases where the default blank background will not be the same size as the view port. Change the logic to calculate the view port size and use that to determine if props are outside the viewable range.