### PR TITLE
Moving scaling logic to the SetupRender; previously was doing it in t…

### DIFF
--- a/Modules/Effect/Morph/Morph/Morph.cs
+++ b/Modules/Effect/Morph/Morph/Morph.cs
@@ -214,16 +214,9 @@ namespace VixenModules.Effect.Morph
 				// Save off the data for the effect
 				_data = value as MorphData;
 
-				// Save off the width and height from the effect data
-				int	width = _data.DisplayElementWidth;
-				int	height = _data.DisplayElementHeight;
-				
 				// Update the morph polygon model data
 				UpdatePolygonModel(_data);
-
-				// Scale the shapes associated with the morph polygons
-				ScaleShapesToFitDisplayElement(width, height);
-
+				
 				// Update the visibility of controls
 				UpdateAttributes();
 
@@ -960,10 +953,6 @@ namespace VixenModules.Effect.Morph
 				}
 			}
 
-			// Save off the display element width and height
-			_data.DisplayElementWidth = BufferWi;
-			_data.DisplayElementHeight = BufferHt;
-
 			// If effect has been associated with a display element then...
 			if (previousBufferHeight != 0 && previousBufferWidth != 0)
 			{
@@ -1089,6 +1078,17 @@ namespace VixenModules.Effect.Morph
 		/// </summary>
 		protected override void SetupRender()
 		{
+			// Store off the display element width and height
+			_bufferWi = BufferWi;
+			_bufferHt = BufferHt;
+
+			// Check to see if the display element changed size and if the morph polygons needs to scaled
+			ScaleShapesToFitDisplayElement(_data.DisplayElementWidth, _data.DisplayElementHeight);
+
+			// Save off the display element width and height
+			_data.DisplayElementWidth = _bufferWi;
+			_data.DisplayElementHeight = _bufferHt;
+
 			if (PolygonType == PolygonType.Pattern)
 			{
 				// Transfer the top level settings to the morph polygon
@@ -1098,12 +1098,6 @@ namespace VixenModules.Effect.Morph
 				MorphPolygons[0].HeadColor = new ColorGradient(HeadColor);
 				MorphPolygons[0].TailColor = new ColorGradient(TailColor);
 			}
-
-			// Store off the display element width and height
-			_bufferWi = BufferWi;
-			_bufferHt = BufferHt;
-			_data.DisplayElementWidth = _bufferWi;
-			_data.DisplayElementHeight = _bufferHt;
 
 			// Give the morph polygon access to the display element dimensions
 			MorphPolygon.BufferWidth = _bufferWi;
@@ -1164,6 +1158,14 @@ namespace VixenModules.Effect.Morph
 						BufferWi,
 						BufferHt);
 				}
+
+				// Save off the display element width and height
+				_data.DisplayElementWidth = BufferWi;
+				_data.DisplayElementHeight = BufferHt;
+
+				// Mark the sequence dirty so that the scaled polygons and the new width and height of the display element
+				// are saved off
+				IsDirty = true;
 			}
 		}
 		


### PR DESCRIPTION
…he ModuleData set

When the effect was in location mode the BufferWi and BufferHt properties were not correct inside the ModuleData set property which caused incorrect scaling to occur.  Moving the logic to SetupRender should avoid this issue.