### PR TITLE
VIX-3017 Fix crash during alignment when effect is moving or resizing.

### DIFF
--- a/Common/Controls/TimeLineControl/Grid.cs
+++ b/Common/Controls/TimeLineControl/Grid.cs
@@ -390,6 +390,8 @@ namespace Common.Controls.Timeline
 			get { return ModifierKeys.HasFlag(Keys.Alt); }
 		}
 
+		public bool IsResizeDragInProgress => m_dragState != DragState.Normal;
+
 		private int CurrentRowIndexUnderMouse { get; set; }
 		private SortedDictionary<TimeSpan, List<SnapDetails>> StaticSnapPoints { get; set; }
 		private SortedDictionary<TimeSpan, List<SnapDetails>> CurrentDragSnapPoints { get; set; }

--- a/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Hotkeys.cs
+++ b/Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Hotkeys.cs
@@ -96,6 +96,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 					break;
 				
 				case Keys.S:
+					if (TimelineControl.grid.IsResizeDragInProgress)
+					{
+						break;
+					}
 					if (e.Shift & e.Control)
 					{
 						AlignEffectsToNearestMarks("Start");
@@ -108,7 +112,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 					}
 					break;
 				case Keys.E:
-
+					if (TimelineControl.grid.IsResizeDragInProgress)
+					{
+						break;
+					}
 					if (e.Shift & e.Control)
 					{
 						AlignEffectsToNearestMarks("End");
@@ -122,6 +129,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 					break;
 					
 				case Keys.B:
+					if (TimelineControl.grid.IsResizeDragInProgress)
+					{
+						break;
+					}
 					if (e.Shift & e.Control)
 					{
 						AlignEffectsToNearestMarks("Both");


### PR DESCRIPTION
Add logic to the key stroke handler to prevent an alignment event if effects are being resized or moving. Added the logic to expose if the move/resize is occurring.