### PR TITLE
VIX-3016 Add size fields to the Custom Prop similar to other shapes.

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewCustomProp.cs
@@ -80,6 +80,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			{
 				UpdateDragPoints();
 			}
+			FireOnPropertiesChanged(this,this);
 		}
 
 		#region Overrides of PreviewBaseShape
@@ -113,7 +114,26 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			{
 				MoveTo((int)Bounds.X, value);
 			}
+		}
 
+		[Browsable(true)]
+		[Category("Position")]
+		[PropertyOrder(3)]
+		[DisplayName("Top Left")]
+		public System.Drawing.Point TopLeft
+		{
+			get => new System.Drawing.Point((int)Bounds.Left, (int)Bounds.Top);
+			set => MoveTo(value.X, value.Y);
+		}
+
+		[Browsable(true)]
+		[Category("Position")]
+		[PropertyOrder(4)]
+		[DisplayName("Bottom Right")]
+		public System.Drawing.Point BottomRight
+		{
+			get => new System.Drawing.Point((int)Bounds.Right, (int)Bounds.Bottom);
+			set => MoveTo(value.X, value.Y);
 		}
 
 		/// <inheritdoc />
@@ -121,7 +141,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		[DataMember]
 		[DisplayName("Rotation Angle")]
-		[PropertyOrder(3)]
+		[PropertyOrder(5)]
 		[Category("Position")]
 		public int RotationAngle
 		{
@@ -618,6 +638,12 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// <inheritdoc />
 		public override void MoveTo(int x, int y)
 		{
+			if(x < 0 || y < 0)
+			{
+				x = 10;
+				y = 10;
+
+			}
 			var xOffset = ZoomCoordToOriginal(x - Bounds.X);
 			var yOffset = ZoomCoordToOriginal(y - Bounds.Y);
 			

--- a/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -275,10 +275,14 @@ namespace VixenModules.Preview.VixenPreview
 		}
 
 		private void OnSelectDisplayItem(object sender, Shapes.DisplayItem displayItem) {
-			Shapes.DisplayItemBaseControl setupControl = displayItem.Shape.GetSetupControl();
-			elementsForm.ClearSelectedNodes();
-			if (setupControl != null) {
-				propertiesForm.ShowSetupControl(setupControl);
+
+			if (propertiesForm.SetupPreviewShape() != displayItem.Shape)
+			{
+				DisplayItemBaseControl setupControl = displayItem.Shape.GetSetupControl();
+				elementsForm.ClearSelectedNodes();
+				if (setupControl != null) {
+					propertiesForm.ShowSetupControl(setupControl);
+				}
 			}
 		}
 

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupPropertiesDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupPropertiesDocument.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using System.Windows.Shapes;
 using Common.Controls.Theme;
 using VixenModules.Preview.VixenPreview.Shapes;
 using WeifenLuo.WinFormsUI.Docking;
@@ -37,6 +38,11 @@ namespace VixenModules.Preview.VixenPreview
 			else {
 				Text = @"Properties";
 			}
+		}
+
+		public PreviewBaseShape SetupPreviewShape()
+		{
+			return _setupControl?.Shape;
 		}
 
 		private void SetupControlPropertyEdited(object sender, EventArgs e)


### PR DESCRIPTION
Add the Top Left and Bottom Right fields.

Add logic to update them on any movement so you have live updates when moving a single prop.

Fix a bug that would reload the property viewer on mouse up even if the shape was already being edited. This was introducing an annoying flicker.