### PR TITLE
VIX-3018 Correct row zoom bug.

### DIFF
--- a/Common/Controls/TimeLineControl/TimelineControl.cs
+++ b/Common/Controls/TimeLineControl/TimelineControl.cs
@@ -398,6 +398,9 @@ namespace Common.Controls.Timeline
 			EnableDisableHandlers();
 			grid.AllowGridResize = true;
 			LayoutRows();
+			//This seemingly do nothing line of code actually forces the row to fire the row height changed to 
+			//compensate for the events being disabled in the code above that actually makes the changes
+			Rows.ElementAt(0).Height = Rows.ElementAt(0).Height;
 		}
 
 		public void ResizeGrid()


### PR DESCRIPTION
A seemingly do nothing line of code was removed in a previous change, however it was compensating for events being disabled after rows were resized. There is likely a better way to solve this in the future, but for now restored the line of code with some comments indicating its purpose.