### PR TITLE
VIX-3019 Fix the logic looking for zero size shapes.

### DIFF
--- a/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -178,7 +178,8 @@ namespace VixenModules.Preview.VixenPreview
 			foreach (var previewDisplayItem in previewForm.Preview.DisplayItems)
 			{
 				if (previewDisplayItem.Shape.Top == previewDisplayItem.Shape.Bottom &&
-				    previewDisplayItem.Shape.Left == previewDisplayItem.Shape.Right)
+				    previewDisplayItem.Shape.Left == previewDisplayItem.Shape.Right &&
+				    previewDisplayItem.Shape.Top == previewDisplayItem.Shape.Left)
 				{
 					//if items don't have any size then they were probably added by mistake.
 					itemsToRemove.Add(previewDisplayItem);


### PR DESCRIPTION
The logic does not account for single Preview Pixels that their coordinates are exposed in a non standard way. Amend to ensure the coordinates are in the same place.