### PR TITLE
VIX-3026 Fix issue with timing changing when the frame rate changes.

### DIFF
--- a/Modules/Effect/Tree/Tree.cs
+++ b/Modules/Effect/Tree/Tree.cs
@@ -315,7 +315,7 @@ namespace VixenModules.Effect.Tree
 			HSV backgroundhsv = HSV.FromRGB(BackgroundColor.GetColorAt(pos));
 			int x, y, mod, b;
 			float V;
-			int cycleLen = frame * Speed;
+			int cycleLen = (int)(frame * Speed * (FrameTimespan.Milliseconds / 50d));
 			int pixelsPerBranch = (int)(0.5 + (double)BufferHt / Branches);
 			if (pixelsPerBranch == 0)
 			{


### PR DESCRIPTION
Added compensation logic to the Speed logic to offset it from the expected 50ms when the real rate is different. This uses the real frame rate divided by the standard 50ms to create the offset multiplier.