### PR TITLE
VIX-2988 Fix a couple issues in the legacy FPP export.

### DIFF
--- a/Modules/App/ExportWizard/BulkExportOutputFormatStage.cs
+++ b/Modules/App/ExportWizard/BulkExportOutputFormatStage.cs
@@ -202,7 +202,7 @@ namespace VixenModules.App.ExportWizard
 				if (_data.ActiveProfile.IsFalconFormat)
 				{
 					if (CanTestPath() && 
-					    Directory.Exists(_data.ActiveProfile.IsFalconFormat ? _data.ActiveProfile.FalconOutputFolder: _data.ActiveProfile.OutputFolder))
+					    Directory.Exists(_data.ActiveProfile.IsFalcon2xFormat ? _data.ActiveProfile.FalconOutputFolder: _data.ActiveProfile.OutputFolder))
 					{
 						return true;
 					}
@@ -339,7 +339,7 @@ namespace VixenModules.App.ExportWizard
 
 		private void chkIncludeAudio_CheckedChanged(object sender, EventArgs e)
 		{
-			if (_data.ActiveProfile.IsFalconFormat)
+			if (_data.ActiveProfile.IsFalcon2xFormat)
 			{
 				_data.ActiveProfile.RenameAudio = chkFppIncludeAudio.Checked;
 				_data.ActiveProfile.IncludeAudio = chkFppIncludeAudio.Checked;

--- a/Modules/App/ExportWizard/BulkExportSummaryStage.cs
+++ b/Modules/App/ExportWizard/BulkExportSummaryStage.cs
@@ -210,7 +210,7 @@ namespace VixenModules.App.ExportWizard
 
 		private async Task CreateUniverseFile()
 		{
-			if (_data.ActiveProfile.IsFalconFormat)
+			if (_data.ActiveProfile.IsFalcon2xFormat)
 			{
 				var path = Path.Combine(_data.ActiveProfile.FalconOutputFolder, "config");
 				if (!Directory.Exists(path))
@@ -229,6 +229,7 @@ namespace VixenModules.App.ExportWizard
 
 				await _data.Export.Write2xUniverseFile(fileName);
 			}
+			
 		}
 
 		private bool RenderSequence(ISequence sequence, IProgress<ExportProgressStatus> progress)


### PR DESCRIPTION
The 1.x FPP export flow was not properly updating the move next button. Changed the criteria to validate the correct folder.

The logic was also trying to export the new universe file to the 2.x folder which may not be specified. Fixed that logic.