### PR TITLE
VIX-2937 Initial attempt to use the sequence package import can fail …

### DIFF
--- a/Modules/App/TimedSequenceMapper/SequencePackageExport/SequencePackageExportOutputStage.cs
+++ b/Modules/App/TimedSequenceMapper/SequencePackageExport/SequencePackageExportOutputStage.cs
@@ -59,12 +59,17 @@ namespace VixenModules.App.TimedSequenceMapper.SequencePackageExport
 			saveFileDialog.CheckPathExists = true;
 			//saveFileDialog.CreatePrompt = true;
 			saveFileDialog.OverwritePrompt = true;
-			var dir = Path.GetDirectoryName(_data.ExportOutputFile);
-			if (!Directory.Exists(dir))
+
+			if (!string.IsNullOrEmpty(_data.ExportOutputFile))
 			{
-				dir = Path.Combine(Paths.DataRootPath, "Export");
+				var dir = Path.GetDirectoryName(_data.ExportOutputFile);
+				if (!Directory.Exists(dir))
+				{
+					dir = Path.Combine(Paths.DataRootPath, "Export");
+					saveFileDialog.InitialDirectory = dir;
+				}
 			}
-			saveFileDialog.InitialDirectory = dir;
+
 			saveFileDialog.FileName = $"{VixenSystem.ProfileName}.{PackageExtension}";
 
 			var filter = $"Vixen 3 Sequence Package (*.{PackageExtension})|*.{PackageExtension}";

--- a/Modules/App/TimedSequenceMapper/SequencePackageImport/SequencePackageImportInputStage.cs
+++ b/Modules/App/TimedSequenceMapper/SequencePackageImport/SequencePackageImportInputStage.cs
@@ -53,10 +53,13 @@ namespace VixenModules.App.TimedSequenceMapper.SequencePackageImport
 		{
 			var openFileDialog = new OpenFileDialog();
 			openFileDialog.CheckPathExists = true;
-			var dir = Path.GetDirectoryName(_data.InputFile);
-			if (!Directory.Exists(dir))
+			if (!string.IsNullOrEmpty(_data.InputFile))
 			{
-				openFileDialog.InitialDirectory = dir;
+				var dir = Path.GetDirectoryName(_data.InputFile);
+				if (!Directory.Exists(dir))
+				{
+					openFileDialog.InitialDirectory = dir;
+				}
 			}
 			
 			var filter = $"Vixen 3 Sequence Package (*.{Constants.PackageExtension})|*.{Constants.PackageExtension}";


### PR DESCRIPTION
…when using the file selector.

The initial value of the import folder is uninitialized and the Path.GetDirectory method throws an path not of legal form exception even though it claims to accept null input. Added logic to test for empty or null and bypass the directory logic. Added the same to the output side to be safe even though it should be populated by default.