### PR TITLE
VIX-3045 Changes to allow additional vendor to be added to the prop v…

### DIFF
--- a/Modules/App/CustomPropEditor/Import/XLights/XModelInventoryMapper.cs
+++ b/Modules/App/CustomPropEditor/Import/XLights/XModelInventoryMapper.cs
@@ -72,7 +72,7 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 					PixelSpacing = model.PixelSpacing,
 					ProductType = model.Type
 			};
-				if (model.ImageFile != null && model.ImageFile.Any())
+				if (model.ImageFile != null && model.ImageFile.Any() && !string.IsNullOrEmpty(model.ImageFile.First()))
 				{
 					p.ImageUrl = new Uri(model.ImageFile.First());
 				}
@@ -80,7 +80,7 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 				if (model.Wiring != null && model.Wiring.Any())
 				{
 					int index = 1;
-					p.ModelLinks = model.Wiring.Select(x => new ModelLink(ModelType.XModel, string.IsNullOrEmpty(x.Name)?$"Model {index++}":x.Name, x.Description, new Uri(x.XModelLink)))
+					p.ModelLinks = model.Wiring.Where(l=> l.IsValid).Select(x => new ModelLink(ModelType.XModel, string.IsNullOrEmpty(x.Name)?$"Model {index++}":x.Name, x.Description, x.XModelLink != null?new Uri(x.XModelLink):null))
 						.ToList();
 				}
 				else

--- a/Modules/App/CustomPropEditor/Model/ExternalVendorInventory/Wiring.cs
+++ b/Modules/App/CustomPropEditor/Model/ExternalVendorInventory/Wiring.cs
@@ -16,5 +16,7 @@ namespace VixenModules.App.CustomPropEditor.Model.ExternalVendorInventory
 
 		[XmlElement("imageFile")]
 		public List<string> Images { get; set; }
+
+		public bool IsValid => !string.IsNullOrEmpty(XModelLink);
 	}
 }

--- a/Modules/App/CustomPropEditor/ViewModels/VendorInventoryWindowViewModel.cs
+++ b/Modules/App/CustomPropEditor/ViewModels/VendorInventoryWindowViewModel.cs
@@ -98,6 +98,24 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
+		#region IsModelValid property
+
+		/// <summary>
+		/// Gets or sets the ShowModelTab value.
+		/// </summary>
+		public bool IsModelValid
+		{
+			get { return GetValue<bool>(IsModelValidProperty); }
+			set { SetValue(IsModelValidProperty, value); }
+		}
+
+		/// <summary>
+		/// ShowModelTab property data.
+		/// </summary>
+		public static readonly PropertyData IsModelValidProperty = RegisterProperty("IsModelValid", typeof(bool));
+
+		#endregion
+
 		#region IsProductVisible property
 
 		#region IsProductVisible property
@@ -117,6 +135,24 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		public static readonly PropertyData IsProductVisibleProperty = RegisterProperty("IsProductVisible", typeof(bool));
 
 		#endregion
+
+		#endregion
+
+		#region IsProductViewSelected property
+
+		/// <summary>
+		/// Gets or sets the ProductTabSelected value.
+		/// </summary>
+		public bool IsProductViewSelected
+		{
+			get { return GetValue<bool>(IsProductViewSelectedProperty); }
+			set { SetValue(IsProductViewSelectedProperty, value); }
+		}
+
+		/// <summary>
+		/// ProductTabSelected property data.
+		/// </summary>
+		public static readonly PropertyData IsProductViewSelectedProperty = RegisterProperty("IsProductViewSelected", typeof(bool));
 
 		#endregion
 
@@ -140,6 +176,9 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 			SelectedModelLink = null;
 			SelectedProduct = p;
 			IsProductVisible = p != null;
+			IsModelValid = p.ModelLinks != null && p.ModelLinks.Any(x => x.Link != null);
+			IsProductViewSelected = true;
+
 		}
 
 		#endregion
@@ -227,7 +266,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		private void ImportModel(ModelLink ml)
 		{
-			if (SelectedProduct != null && ml != null)
+			if (SelectedProduct != null && ml != null && ml.Link != null)
 			{
 				SelectedModelLink = ml;
 				DialogResult = true;

--- a/Modules/App/CustomPropEditor/Views/VendorInventoryWindow.xaml
+++ b/Modules/App/CustomPropEditor/Views/VendorInventoryWindow.xaml
@@ -14,6 +14,7 @@
 				<ResourceDictionary Source="..\Themes\Theme.xaml"/>
 				<ResourceDictionary Source="pack://application:,,,/WPFCommon;component/Theme/Theme.xaml"/>
 			</ResourceDictionary.MergedDictionaries>
+			<catel:BooleanToHidingVisibilityConverter x:Key="BooleanToHidingVisibilityConverter" />
 		</ResourceDictionary>
 	</Window.Resources>
 	<DockPanel Background="{StaticResource BackColorBrush}">
@@ -110,7 +111,7 @@
 						<TabControl Background="{StaticResource BackColorBrush}"
 						            Grid.Row="1"
 						            Width="Auto" Margin="5,5,10,5">
-							<TabItem Header="Product Info">
+							<TabItem Header="Product Info" IsSelected="{Binding IsProductViewSelected}">
 								<Grid>
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto"/>
@@ -155,7 +156,7 @@
 									<TextBlock Grid.Column="1" Grid.Row="9" Text="{Binding SelectedProduct.Notes}" Padding="5,0,0,0"/>
 								</Grid>
 							</TabItem>
-							<TabItem Header="Model Options">
+							<TabItem Header="Model Options" Visibility="{Binding IsModelValid, Converter={StaticResource BooleanToVisibilityConverter}}">
 								<ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
 									<ItemsControl Name="ModelOptions" ItemsSource="{Binding SelectedProduct.ModelLinks}">
 										<ItemsControl.ItemTemplate>


### PR DESCRIPTION
…endor browser.

Gilbert has several props in their inventory that do not have models. This was unexpected when the initial work was done to support the browser. Add logic to handle the missing models.

Add validation logic to a the wiring model to determine if it is valid by looking to see if a link to it exists.

Add logic to hide the Model tab in the browser for a selected product that does not have a valid model as defined above.

Add logic to select the product tab any time the product selection changes so the user gets a proper view if the model is not valid.