### PR TITLE
VIX-3072 Add logic to skip known specialty audio devices.

### DIFF
--- a/Common/FMOD/fmod_wrapper.cs
+++ b/Common/FMOD/fmod_wrapper.cs
@@ -115,7 +115,10 @@ namespace FMOD {
                 for(i = 0; i < driverCount; i++) {
                     GUID GUID = new GUID();
                     system.getDriverInfo(i, sb, sb.Capacity, ref GUID);
-                    m_deviceList.Add(sb.ToString());
+                    if (!sb.ToString().Contains("DAX"))
+                    {
+	                    m_deviceList.Add(sb.ToString());
+                    }
                 }
             }
 


### PR DESCRIPTION
This is not the most robust solution, but this whole sound driver setup needs to be replaced anyhow. This will provide a band aid for my unique situation until that comes along.