### PR TITLE
VIX-3078 Add logic to prevent crash on period entry.

### DIFF
--- a/Common/Controls/NumericTextBox.cs
+++ b/Common/Controls/NumericTextBox.cs
@@ -321,6 +321,8 @@ namespace Common.Controls
 				return 0;
 			if (txt.StartsWith("e"))
 				return 0;
+			if (txt == ".")
+				return 0;
 			if (txt.EndsWith("e") || txt.EndsWith("e" + NegativeSign))
 				return System.Convert.ToDouble(txt.Substring(0, txt.IndexOf('e')));
 			return System.Convert.ToDouble(txt);


### PR DESCRIPTION
The field is a double value, so a period is a valid character. Added logic to handle just a period intead of letting the parser fail trying to parse it.