### PR TITLE
VIX-3099   Resolve FastPicture frame rate issue.

### DIFF
--- a/Modules/Effect/LipSync/FastPictureEffect.cs
+++ b/Modules/Effect/LipSync/FastPictureEffect.cs
@@ -60,7 +60,7 @@ namespace VixenModules.Effect.LipSync
 		/// <inheritdoc />
 		protected override void RenderEffect(int frame, IPixelFrameBuffer frameBuffer)
 		{
-			var intervalPosFactor = ((double)100 / EffectEndTime.TotalMilliseconds) * (StartTime.TotalMilliseconds + frame * 50);
+			var intervalPosFactor = ((double)100 / EffectEndTime.TotalMilliseconds) * (StartTime.TotalMilliseconds + frame * FrameTime);
 			var yOffsetAdjust = CalculateYOffset(intervalPosFactor);
 			var xOffsetAdjust = CalculateXOffset(intervalPosFactor);
 			if (_fp != null)


### PR DESCRIPTION
The effect was not honoring the default update cycle setting and thus would not create the proper frames for other than 50 ms timing.