### PR TITLE
VIX-3107 Fix cross threading issue causing preview crash.

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/PreviewShapeBaseSetupControl.cs
+++ b/Modules/Preview/VixenPreview/Shapes/PreviewShapeBaseSetupControl.cs
@@ -37,8 +37,15 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 
 		private void OnPropertiesChanged(object sender, PreviewBaseShape shape)
 		{
-			propertyGrid.Refresh();
-		}
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Action(propertyGrid.Refresh));
+			}
+            else
+            {
+                propertyGrid.Refresh();
+			}
+        }
 
 		protected virtual void buttonHelp_Click(object sender, EventArgs e)
 		{


### PR DESCRIPTION
The change event can fire from a background thread and when it tries to invoke on the UI components, it needs to be on the UIThread. Add logic to detect and switch the thread context in the change event handler.