### PR TITLE
VIX-3035 Fix application crash in sequence import.

### DIFF
--- a/Common/WPFCommon/Converters/PercentageConverter.cs
+++ b/Common/WPFCommon/Converters/PercentageConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Windows.Data;
 
 namespace Common.WPFCommon.Converters
@@ -7,7 +8,7 @@ namespace Common.WPFCommon.Converters
 	{
 		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
 		{
-			return (int)(System.Convert.ToDouble(value) * System.Convert.ToDouble(parameter));
+			return (int)(System.Convert.ToDouble(value, CultureInfo.InvariantCulture) * System.Convert.ToDouble(parameter, CultureInfo.InvariantCulture));
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)


### PR DESCRIPTION
The Convert.ToDouble method is culture specific and users in cultures that use a comma for a decimal were seeing issues parsing the values in the PercentageConverter. Add option to parse with InvariantCulture to handle US decimal value coded in the percentage.