### PR TITLE
VIX-3122 Fix a math bug in the dimming curve.

### DIFF
--- a/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
+++ b/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
@@ -199,7 +199,7 @@ namespace VixenModules.OutputFilter.DimmingCurve
 		{
 			if (command is _8BitCommand cmd)
 			{
-				double newIntensity = (_curve.GetValue(cmd.CommandValue / 255d) / 100d) * Byte.MaxValue;
+				double newIntensity = _curve.GetValue(cmd.CommandValue / 255d) * Byte.MaxValue;
 				return CommandLookup8BitEvaluator.CommandLookup[(byte) newIntensity];
 			}
 


### PR DESCRIPTION
The logic for the command intent was dividing by 100 when it did not require and was creating incorrect values.