### PR TITLE
VIX-3122 Fix the math logic for real this time.

### DIFF
--- a/Modules/App/Curves/FunctionGenerator.resx
+++ b/Modules/App/Curves/FunctionGenerator.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="txtDescription.Text" xml:space="preserve">
-    <value>Enter the mathmatical f(x) that provides the value of y. The function will be run with values of x from 0 -100 incremented by the Draw Interval to produce the x,y values in the curve.  Example gamma correction function Pow(x/100, 2.8) * 100 +.5</value>
+    <value>Enter the mathmatical f(x) that provides the value of y. The function will be run with values of x from 0-100 incremented by the Draw Interval to get the x,y values in the curve.  Example gamma function where 2.2 is the gamma and 80 is the max level: Pow(x/100, 2.2) * 80.</value>
   </data>
 </root>

--- a/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
+++ b/Modules/PostFilter/DimmingCurve/DimmingCurveModule.cs
@@ -199,7 +199,10 @@ namespace VixenModules.OutputFilter.DimmingCurve
 		{
 			if (command is _8BitCommand cmd)
 			{
-				double newIntensity = _curve.GetValue(cmd.CommandValue / 255d) * Byte.MaxValue;
+				// convert command to 0 - 100 value for lookup in the curve.
+				// convert 0 - 100 return value from the curve to a percent
+				// and then mult by the max byte value to get new command value
+				double newIntensity = _curve.GetValue(cmd.CommandValue / 255d * 100d) / 100d * Byte.MaxValue;
 				return CommandLookup8BitEvaluator.CommandLookup[(byte) newIntensity];
 			}
 


### PR DESCRIPTION
Found other issues with the math logic converting back and forth when using more examples.

Added documentation as to how it works so it is easier to understand later.

Updated the text example of a Gamma curve formula to be more correct. A 2.8 Gamma is very aggressive. The formula also generated a small zero value that could keep items from being truly off at zero so I corrected the example and worded it in a way that hopefully makes it easier for a user to understand.