### PR TITLE
VIX-3142 Fix a bug in the profile selection screen that crashes Vixen.

### DIFF
--- a/Application/VixenApplication/SelectProfile.cs
+++ b/Application/VixenApplication/SelectProfile.cs
@@ -117,7 +117,8 @@ namespace VixenApplication
 
 
 			listBoxProfiles.BeginUpdate();
-            //Make sure we start with an empty listbox since we may repopulate after editing profiles
+			//Make sure we start with an empty listbox since we may repopulate after editing profiles
+	
             listBoxProfiles.Items.Clear();
 			int profileCount = profile.GetSetting(XMLProfileSettings.SettingType.Profiles, "ProfileCount", 0);
             for (int i = 0; i < profileCount; i++)
@@ -140,7 +141,10 @@ namespace VixenApplication
             }
 
 			profiles.Sort((x, y) => y.DateLastLoaded.CompareTo(x.DateLastLoaded));
-			listBoxProfiles.DataSource = profiles;
+			foreach (ProfileItem item in profiles)
+            {
+				listBoxProfiles.Items.Add(item);
+            }
 
 			listBoxProfiles.EndUpdate();
         }


### PR DESCRIPTION
Recent changes in VIX-988 introduced a bug that tries to clear the profile list box when a datasource is set. Changed the logic back to load the list items in a foreach after sorting to avoid using the datasource. This issue appears when the profile list is loaded a second time, most notably creating a new profile when others already exist.