### PR TITLE
VIX-3148 Work to reduce the size of the ModuleStore

### DIFF
--- a/Vixen.System/Module/ModuleDataModelBase.cs
+++ b/Vixen.System/Module/ModuleDataModelBase.cs
@@ -9,7 +9,6 @@ namespace Vixen.Module
 		/// <summary>
 		/// Module type that the data model belongs to.
 		/// </summary>
-		[DataMember]
 		public Guid ModuleTypeId { get; set; }
 
 		/// <summary>
@@ -20,7 +19,6 @@ namespace Vixen.Module
 		/// <summary>
 		/// The InstanceId of the of module that the data model belongs to.
 		/// </summary>
-		[DataMember]
 		public Guid ModuleInstanceId { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Remove the DataMember attribute from the field data for Module Instance and type ids as they are stored by the serializer as an attribute which duplicates them.