### PR TITLE
VIX-3119 Add no patch points found dialog.

### DIFF
--- a/Application/VixenApplication/Setup/SetupControllersSimple.cs
+++ b/Application/VixenApplication/Setup/SetupControllersSimple.cs
@@ -257,7 +257,18 @@ namespace VixenApplication.Setup
 				}
 			}
 
-			MasterForm.SelectElements(elementNodesToSelect, true);
+			if (elementNodesToSelect.Count == 0)
+			{
+				var msg = new MessageBoxForm("No element patch points found.", "Not Found", MessageBoxButtons.OK,
+					SystemIcons.Information);
+				msg.ShowDialog(this);
+			}
+			else
+			{
+				MasterForm.SelectElements(elementNodesToSelect, true);
+			}
+
+			
 		}
 
 		private IDataFlowComponent FindRootSourceOfDataComponent(IDataFlowComponent component)

--- a/Application/VixenApplication/Setup/SetupElementsTree.cs
+++ b/Application/VixenApplication/Setup/SetupElementsTree.cs
@@ -398,7 +398,17 @@ namespace VixenApplication.Setup
 				}
 			}
 
-			MasterForm.SelectControllersAndOutputs(controllersAndOutputs, true);
+			if (controllersAndOutputs.Count == 0)
+			{
+				var msg = new MessageBoxForm("No controller patch points found.", "Not Found", MessageBoxButtons.OK,
+					SystemIcons.Information);
+				msg.ShowDialog(this);
+			}
+			else
+			{
+				MasterForm.SelectControllersAndOutputs(controllersAndOutputs, true);
+			}
+			
 		}
 
 		private IEnumerable<IDataFlowComponent> _findComponentsOfTypeInTreeFromComponent(IDataFlowComponent dataFlowComponent, Type dfctype)


### PR DESCRIPTION
Added logic to both the element and controller logic that selects the patch points for the selected items. If none are found a informational dialog is presented to notify the user.