### PR TITLE
VIX-2586 Correct crash in Launcher setup.

### DIFF
--- a/Modules/Output/LauncherController/SetupForm.cs
+++ b/Modules/Output/LauncherController/SetupForm.cs
@@ -16,6 +16,7 @@ namespace VixenModules.Output.LauncherController
 			ForeColor = ThemeColorTable.ForeColor;
 			BackColor = ThemeColorTable.BackgroundColor;
 			ThemeUpdateControls.UpdateControls(this);
+			LauncherData = data;
 			chkHideLaunchedWindows.Checked= data.HideLaunchedWindows;
 		}
 


### PR DESCRIPTION
The data for the module was not being assigned in the constructor and this resulted in a null pointer when trying to set the option to hide the windows.