### PR TITLE
VIX-3195 Update the Display Setup Graphical View to display the Name …

### DIFF
--- a/Application/VixenApplication/Setup/SetupPatchingGraphical.cs
+++ b/Application/VixenApplication/Setup/SetupPatchingGraphical.cs
@@ -540,7 +540,7 @@ namespace VixenApplication.Setup
 		private FilterShape _MakeFilterShape(IOutputFilterModuleInstance filter)
 		{
 			FilterShape filterShape = (FilterShape)project.ShapeTypes["FilterShape"].CreateInstance();
-			filterShape.Title = filter.Descriptor.TypeName;
+			filterShape.Title = filter.Name;
 			filterShape.SecurityDomainName = SECURITY_DOMAIN_MOVABLE_SHAPE_WITH_CONNECTIONS;
 			filterShape.FillStyle = project.Design.FillStyles["Filter"];
 			filterShape.SetFilterInstance(filter);


### PR DESCRIPTION
…of the filter instead of the type name

VIX-3195 Update the Display Setup Graphical View to display the Name of the filter instead of the type name