### PR TITLE
VIX-3254 Fix export crash when controller is missing IP address.

### DIFF
--- a/Modules/Output/E1.31/E131OutputPlugin.cs
+++ b/Modules/Output/E1.31/E131OutputPlugin.cs
@@ -608,7 +608,9 @@ namespace VixenModules.Controller.E131
 			if (_data.Multicast == null)
 			{
 				config.TransmissionMethod = TransmissionMethods.Unicast;
-				config.IpAddress = DetermineIp().Address;
+				var ip = DetermineIp();
+				config.IpAddress = ip != null ? ip.Address : IPAddress.Loopback;
+				
 			}
 			else
 				config.TransmissionMethod = TransmissionMethods.Multicast;


### PR DESCRIPTION
If the controller does not have an IP address set, use the loopback as a default for the export configuration to prevent crashes.