### PR TITLE
VIX-3256 Include PDB files to dev installer.

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -294,7 +294,11 @@ Section "Application" SEC01
   ; only overwrite these if this installer has a newer version
   SetOverwrite ifnewer
   SetOutPath "$INSTDIR"
+!ifdef DEVBUILD
+  File /r /x *.res /x *.obj /x *.pch "${BUILD_DIR}\*.*"
+!else
   File /r /x *.res /x *.obj /x *.pch /x *.pdb "${BUILD_DIR}\*.*"
+!endif
 
   ; Shortcuts
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application


### PR DESCRIPTION
Add logic to include the PDB files when running the installer setup for a dev build.