### PR TITLE
VIX-3215 Fix white context menu issue in WPF controls.

### DIFF
--- a/Common/WPFCommon/Styles/DefaultHiddenStyleResourceDictionary.cs
+++ b/Common/WPFCommon/Styles/DefaultHiddenStyleResourceDictionary.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace Common.WPFCommon.Styles
+{
+	public class DefaultHiddenStyleResourceDictionary : ResourceDictionary
+	{
+		public DefaultHiddenStyleResourceDictionary()
+		{
+			// Run OnResourceDictionaryLoaded asynchronously to ensure other ResourceDictionary are already loaded before adding new entries
+			Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(OnResourceDictionaryLoaded));
+		}
+
+		private void OnResourceDictionaryLoaded()
+		{
+			var presentationFrameworkAssembly = typeof(Application).Assembly;
+
+			AddEditorContextMenuDefaultStyle(presentationFrameworkAssembly);
+			AddEditorMenuItemDefaultStyle(presentationFrameworkAssembly);
+		}
+
+		private void AddEditorContextMenuDefaultStyle(Assembly presentationFrameworkAssembly)
+		{
+			var contextMenuStyle = Application.Current.FindResource(typeof(ContextMenu)) as Style;
+			var editorContextMenuType = Type.GetType("System.Windows.Documents.TextEditorContextMenu+EditorContextMenu, " + presentationFrameworkAssembly);
+
+			if (editorContextMenuType != null)
+			{
+				var editorContextMenuStyle = new Style(editorContextMenuType, contextMenuStyle);
+				Add(editorContextMenuType, editorContextMenuStyle);
+			}
+		}
+
+		private void AddEditorMenuItemDefaultStyle(Assembly presentationFrameworkAssembly)
+		{
+			var menuItemStyle = Application.Current.FindResource(typeof(MenuItem)) as Style;
+			var editorMenuItemType = Type.GetType("System.Windows.Documents.TextEditorContextMenu+EditorMenuItem, " + presentationFrameworkAssembly);
+
+			if (editorMenuItemType != null)
+			{
+				var editorContextMenuStyle = new Style(editorMenuItemType, menuItemStyle);
+				Add(editorMenuItemType, editorContextMenuStyle);
+			}
+		}
+	}
+}

--- a/Common/WPFCommon/Theme/DefaultHiddenStyle.xaml
+++ b/Common/WPFCommon/Theme/DefaultHiddenStyle.xaml
@@ -1,0 +1,8 @@
+﻿<local:DefaultHiddenStyleResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="clr-namespace:Common.WPFCommon.Styles">
+
+	<!-- No entries are required -->
+
+</local:DefaultHiddenStyleResourceDictionary>

--- a/Common/WPFCommon/Theme/Theme.xaml
+++ b/Common/WPFCommon/Theme/Theme.xaml
@@ -9,6 +9,7 @@
 
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="Menu.xaml" />
+  <ResourceDictionary Source="DefaultHiddenStyle.xaml"></ResourceDictionary>
 	</ResourceDictionary.MergedDictionaries>
 
 
@@ -749,7 +750,7 @@
 		<Setter Property="CaretBrush" Value="{StaticResource ForeColorBrush}"></Setter>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBoxBase}">
+                <ControlTemplate TargetType="{x:Type TextBox}">
                     <Grid>
                         <Border x:Name="Background" Background="{StaticResource BackColorBrush}" CornerRadius="2" />
                         <Border x:Name="BackgroundHighlighted" BorderBrush="#808080" BorderThickness="0,0,0,1" CornerRadius="2" />

--- a/Common/WPFCommon/WPFCommon.csproj
+++ b/Common/WPFCommon/WPFCommon.csproj
@@ -48,6 +48,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Theme\DefaultHiddenStyle.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Theme\Menu.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -69,5 +72,8 @@
   <ItemGroup>
     <Compile Remove="obj\x64\Release\GeneratedInternalTypeHelper.g.cs" />
     <Compile Remove="obj\x64\Release\GeneratedInternalTypeHelper.g.i.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Theme\DefaultHiddenStyle.xaml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The default style for the context menu was not being applied on controls since it is hidden. Add a bit of logic to inject our style through code.

https://stackoverflow.com/questions/30940939/wpf-default-textbox-contextmenu-styling