### PR TITLE
VIX-3260 Intelligent Fixture Effects cause exception when pasting to another display element

### DIFF
--- a/Modules/Effect/Effect/FixtureEffectBase.cs
+++ b/Modules/Effect/Effect/FixtureEffectBase.cs
@@ -699,7 +699,6 @@ namespace VixenModules.Effect.Effect
 			set
 			{
 				Data = (T_Data)value;
-				UpdateFixtureCapabilities();
 				UpdateAttributes();
 			}
 		}

--- a/Modules/Effect/Effect/FixtureIndexEffectBase.cs
+++ b/Modules/Effect/Effect/FixtureIndexEffectBase.cs
@@ -217,8 +217,8 @@ namespace VixenModules.Effect.Effect
 				// If an applicable function is associated with at least one node then...
 				if (SupportsIndexFunction)
 				{
-					// Default the index value to the first index value
-					if (string.IsNullOrEmpty(indexValue))
+					// Default the index value to the first compatible index value
+					if (string.IsNullOrEmpty(indexValue) && IndexValues.Count > 0)
 					{
 						// Set the index value to the first index value
 						indexValue = IndexValues[0];
@@ -227,8 +227,17 @@ namespace VixenModules.Effect.Effect
 					// If the index value no longer exists in the collection then...
 					if (!IndexValues.Contains(indexValue))
 					{
-						// Set the index value to the first index value from the collection
-						indexValue = IndexValues[0];
+						// If compatible IndexValues were found then...
+						if (IndexValues.Count > 0)
+						{
+							// Set the index value to the first index value from the collection
+							indexValue = IndexValues[0];
+						}
+						else
+						{
+							// Otherwise clear out the index value
+							indexValue = string.Empty;
+						}
 					}
 				}				
 			}				

--- a/Modules/Effect/Gobo/GoboModule.cs
+++ b/Modules/Effect/Gobo/GoboModule.cs
@@ -177,7 +177,7 @@ namespace VixenModules.Effect.Gobo
 			bool useGoboImage = false;
 
 			// If a gobo value has been selected then...
-			if (!string.IsNullOrEmpty(GoboIndexValue))
+			if (!string.IsNullOrEmpty(GoboFunctionName) && !string.IsNullOrEmpty(GoboIndexValue))
 			{
 				// Get the first function associated with the gobo index
 				FixtureIndex fixtureIndex = (FixtureIndex)GetFunctionIndex(GoboIndexValue, GoboFunctionName, FunctionIdentity.Gobo);


### PR DESCRIPTION
VIX-3260 Intelligent Fixture Effects cause exception when pasting to another display element