### PR TITLE
VIX-3268 Fix scheduler crash with audio library.

### DIFF
--- a/Common/AudioPlayer/CoreAudioPlayer.cs
+++ b/Common/AudioPlayer/CoreAudioPlayer.cs
@@ -335,7 +335,6 @@ namespace Common.AudioPlayer
 		private void PlaybackDeviceOnPlaybackStopped(object sender, StoppedEventArgs e)
 		{
 			PlaybackEnded?.Invoke();
-			CleanupSoundOut();
 		}
 
 		#region Implementation of IDisposable

--- a/Common/AudioPlayer/SampleProvider/SoundTouchSource.cs
+++ b/Common/AudioPlayer/SampleProvider/SoundTouchSource.cs
@@ -12,7 +12,7 @@ namespace Common.AudioPlayer.SampleProvider
         private readonly float[] _sourceReadBuffer;
         private readonly float[] _soundTouchReadBuffer;
         private readonly object lockObject;
-        private float _tempo = 0f;
+        private float _tempo = 1f;
         private float _rate = 1f;
 
         private bool _seekRequested;


### PR DESCRIPTION
* Default the Sound Touch source tempo to a default of 1 so audio plays normal by default. This was causing the scheduler audio to be processed when it shouldn't. The sound touch processor has a read to end bug that was causing the playback to stick and the end which hangs the scheduler.

* Don't dispose the sound out in the playback ends event since it cannot be cleaned up from the play thread. This was causing crashes in the scheduler when the schedule is stopped.