### PR TITLE
VIX-3284 Fix drag drop in the layer editor.

### DIFF
--- a/Modules/Editor/LayerEditor/Themes/Generic.xaml
+++ b/Modules/Editor/LayerEditor/Themes/Generic.xaml
@@ -121,8 +121,7 @@
                         <Button Grid.Column="1" Grid.Row="0" Content="Remove Layer" Margin="5" Command="{x:Static commands:LayerEditorCommands.RemoveLayer}"
                                 CommandParameter="{Binding ElementName=_lbLayers, Path=SelectedItem}"></Button>
                         <ListBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Name="_lbLayers" HorizontalAlignment="Stretch"  VerticalAlignment="Stretch" 
-                                 ItemsSource="{Binding Layers}" input:DragDropManager.DropTargetAdvisor="{Binding}"
-                                 input:DragDropManager.DragSourceAdvisor="{Binding}" Style="{StaticResource ListBoxStyle}">
+                                 ItemsSource="{Binding Layers}" Style="{StaticResource ListBoxStyle}">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <StackPanel Margin="5">


### PR DESCRIPTION
For some reason the dependency property is not attaching correctly and then the drag drop logic does not work. No obvious code change in this area in a long time, so I can't determine when or why it stopped working. Manually added it in code as a work around.