### PR TITLE
VIX-3288 Intelligent Fixture Preview - Add the ability to strobe when color wheel color is generated directly from Fixture Effect

### DIFF
--- a/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
+++ b/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
@@ -520,6 +520,11 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 					// Spin the color wheel
 					SpinColorWheel(colorWheelFunction);
 				}
+				else
+				{
+					// Preview does not support half steps currently so the workaround is just to show white
+					MovingHead.BeamColor = Color.White;
+				}
 			}
 		}
 

--- a/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
+++ b/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
@@ -528,6 +528,8 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 					// Preview does not support half steps currently so the workaround is just to show white
 					MovingHead.BeamColor = Color.White;
 				}
+			}
+
 			// If color is present then...
 			if (_colorPresent)
 			{

--- a/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
+++ b/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
@@ -176,6 +176,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_legendValues.Clear();
 			MovingHead.Legend = String.Empty;
 
+			// Clear out the fixture intensity
+			MovingHead.Intensity = 0;
+
 			// Turn off strobing
 			_strobbing = false;
 
@@ -525,6 +528,11 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 					// Preview does not support half steps currently so the workaround is just to show white
 					MovingHead.BeamColor = Color.White;
 				}
+			// If color is present then...
+			if (_colorPresent)
+			{
+				// Open the fixture's shutter
+				OpenShutter();
 			}
 		}
 

--- a/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
+++ b/Modules/Preview/VixenPreview/Shapes/MovingHeadIntentHandler.cs
@@ -511,6 +511,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			{
 				// Set the beam color to the color wheel color
 				MovingHead.BeamColor = wheelEntry.Color1;
+
+				// Remember that we have color intents
+				_colorPresent = true;
 			}
 			else
 			{
@@ -527,6 +530,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 				{
 					// Preview does not support half steps currently so the workaround is just to show white
 					MovingHead.BeamColor = Color.White;
+
+					// Remember that we have color intents
+					_colorPresent = true;
 				}
 			}
 


### PR DESCRIPTION
VIX-3288 Intelligent Fixture Preview - Add the ability to strobe when color wheel color is generated directly from Fixture Effect