### PR TITLE
VIX-3299 Fixture Effect - 'None' is showing up a function the user can pick and add to the effect

### DIFF
--- a/Modules/Effect/Effect/FixtureEffectBase.cs
+++ b/Modules/Effect/Effect/FixtureEffectBase.cs
@@ -495,7 +495,7 @@ namespace VixenModules.Effect.Effect
 							FixtureFunction func = fixtureSpecification.FunctionDefinitions.Single(function => function.Name == channel.Function);
 
 							// If the function has not already been added then...
-							if (!fixtureFunctions.Contains(func))
+							if (func.FunctionType != FixtureFunctionType.None && !fixtureFunctions.Contains(func))
 							{
 								// Add the function to the collection of supported functions
 								fixtureFunctions.Add(func);


### PR DESCRIPTION
VIX-3299 Fixture Effect - 'None' is showing up a function the user can pick and add to the effect