### PR TITLE
VIX-3309 Fix issue where adding to maps would not work.

### DIFF
--- a/Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMap.cs
+++ b/Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMap.cs
@@ -133,7 +133,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 
 		public void AddRange(IEnumerable<ElementMapping> maps)
 		{
-			var mapsToAdd = maps.Where(x => !_sourceIds.ContainsKey(x.SourceId));
+			var mapsToAdd = maps.Where(x => !_sourceIds.ContainsKey(x.SourceId)).ToList();
 			_sourceIds.AddRange(mapsToAdd.Select(x => new KeyValuePair<Guid, ElementMapping>(x.SourceId, x)));
 			ElementMappings.AddItems(mapsToAdd);
 			SortByName();


### PR DESCRIPTION
The linq query was being re-evaluated once it was added to the source ids and the list was being modified. This was not allowing the map add to occur. Force the linq query to a one time evaluation by adding a toList.