### PR TITLE
VIX-3316 Fix issues related to VIX-3289 due to missing code commit.

### DIFF
--- a/Common/Controls/ElementTree.cs
+++ b/Common/Controls/ElementTree.cs
@@ -417,7 +417,6 @@ namespace Common.Controls
 
 		public event EventHandler DragFinished;
 		public event EventHandler ElementsChanged;
-		public event EventHandler BeforeElementsChanged;
 
 
 		public void OnDragFinished(EventArgs e = null)
@@ -433,14 +432,6 @@ namespace Common.Controls
 			if (e == null)
 				e = EventArgs.Empty;
 			EventHandler handler = ElementsChanged;
-			if (handler != null) handler(this, e);
-		}
-
-		public void OnBeforeElementsChanged(EventArgs e = null)
-		{
-			if (e == null)
-				e = EventArgs.Empty;
-			EventHandler handler = BeforeElementsChanged;
 			if (handler != null) handler(this, e);
 		}
 
@@ -602,9 +593,8 @@ namespace Common.Controls
 			ElementNode cn = tn.Tag as ElementNode;
 			ElementNode parent = (tn.Parent != null) ? tn.Parent.Tag as ElementNode : null;
 			var nodesToDelete = cn.GetNodeEnumerator().ToList();
-			OnBeforeElementsChanged(new ElementsChangedEventArgs(ElementsChangedEventArgs.ElementsChangedAction.Remove, new List<ElementNode>{cn}));
 			VixenSystem.Nodes.RemoveNode(cn, parent, true);
-			OnElementsChanged(new ElementsChangedEventArgs(ElementsChangedEventArgs.ElementsChangedAction.Remove, new List<ElementNode> { cn }));
+			OnElementsChanged(new ElementsChangedEventArgs(ElementsChangedEventArgs.ElementsChangedAction.Remove, nodesToDelete));
 		}
 
 		public IEnumerable<ElementNode> AddMultipleNodesWithPrompt(ElementNode parent = null)
@@ -1105,7 +1095,7 @@ namespace Common.Controls
 			}
 
 			PopulateNodeTree();
-			OnElementsChanged();
+			OnElementsChanged(new ElementsChangedEventArgs(ElementsChangedEventArgs.ElementsChangedAction.Remove, new List<ElementNode>()));
 		}
 
 		private void createGroupWithNodesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -1617,7 +1617,7 @@ namespace VixenModules.Preview.VixenPreview
 
 				foreach (PreviewPixel pixel in item.Shape.Pixels)
 				{
-					if (pixel.Node != null)
+					if (pixel.Node != null || pixel.NodeId != Guid.Empty)
 					{
 						//Validate the linked node still exists.
 						if (!VixenSystem.Nodes.ElementNodeExists(pixel.NodeId))
@@ -2073,7 +2073,14 @@ namespace VixenModules.Preview.VixenPreview
 			}
 			newDisplayItem.Shape.MoveTo(location.X, location.Y);
 			DisplayItems.Add(newDisplayItem);
+			AddNodeToPixelMapping(newDisplayItem);
 			SelectedDisplayItems.Clear();
+
+			if (elementsForm.SelectedNode != null)
+			{
+				HighlightNode(elementsForm.SelectedNode);
+			}
+			
 			OnSelectionChanged?.Invoke(this, EventArgs.Empty);
 			EndUpdate();
 		}

--- a/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
+++ b/Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
@@ -56,21 +56,6 @@ namespace VixenModules.Preview.VixenPreview
 			treeElements.treeviewAfterSelect += treeElements_AfterSelect;
 			treeElements.treeviewDeselected += TreeElementsOnTreeviewDeselected;
 			treeElements.ElementsChanged += TreeElements_ElementsChanged;
-			treeElements.BeforeElementsChanged += TreeElements_BeforeElementsChanged;
-		}
-
-		private void TreeElements_BeforeElementsChanged(object sender, EventArgs e)
-		{
-			if (e is ElementTree.ElementsChangedEventArgs ev)
-			{
-				if (ev.Action == ElementTree.ElementsChangedEventArgs.ElementsChangedAction.Remove)
-				{
-					foreach (var evAffectedNode in ev.AffectedNodes)
-					{
-						_preview.UnlinkNodesFromPixels(evAffectedNode);
-					}
-				}
-			}
 		}
 
 		private void TreeElements_ElementsChanged(object sender, EventArgs e)
@@ -79,6 +64,13 @@ namespace VixenModules.Preview.VixenPreview
 			{
 				if (ev.Action == ElementTree.ElementsChangedEventArgs.ElementsChangedAction.Remove)
 				{
+					foreach (var evAffectedNode in ev.AffectedNodes)
+					{
+						if (!VixenSystem.Nodes.ElementNodeExists(evAffectedNode.Id))
+						{
+							_preview.UnlinkNodesFromPixels(evAffectedNode);
+						}
+					}
 					UpdateSelectedDisplayItems();
 				}
 			}


### PR DESCRIPTION
Add logic to validate if the element still exists or not before unlinking to the delete routine. T

Add logic to trigger the remove action event args when nodes are deleted so they will properly update.

Fix a loop hole in the Reload method that could allow shapes to remained linked if just the nodeId is set. This is probably a corner case, but could happen.

Add logic to ensure when custom Props are added they are properly added to the NodeToPixel mapping and the highlight logic is called.

All of these changes were part of a final commit in the branch that I somehow lost in the original fix for VIX-3289 when I pushed the changes.