### PR TITLE
VIX-3332 Timeline Color is not getting initialized properly for user created fixture functions

### DIFF
--- a/Modules/App/Fixture/FixtureFunction.cs
+++ b/Modules/App/Fixture/FixtureFunction.cs
@@ -74,9 +74,13 @@ namespace VixenModules.App.Fixture
 
 			// Default the timeline color to a random color
 			Random rnd = new Random();
-			KnownColor[] colors = (KnownColor[])Enum.GetValues(typeof(KnownColor));			
-			int colorIndex = rnd.Next(colors.Length - 1);				
-			TimelineColor = Color.FromKnownColor(colors[colorIndex]);							
+			KnownColor[] colors = (KnownColor[])Enum.GetValues(typeof(KnownColor));
+
+			do
+			{
+				int colorIndex = rnd.Next(colors.Length - 1);
+				TimelineColor = Color.FromKnownColor(colors[colorIndex]);
+			} while (TimelineColor == Color.Transparent);
 		}
 
 		#endregion

--- a/Modules/Editor/FixturePropertyEditor/ViewModels/FunctionItemViewModel.cs
+++ b/Modules/Editor/FixturePropertyEditor/ViewModels/FunctionItemViewModel.cs
@@ -73,6 +73,16 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 			// This list applies to None, RGB, and RGBW function types
 			_defaultIdentities = new List<FunctionIdentity>();
 			_defaultIdentities.Add(FunctionIdentity.Custom);
+
+			// Default the timeline color to a random color
+			Random rnd = new Random();
+			KnownColor[] colors = (KnownColor[])Enum.GetValues(typeof(KnownColor));
+
+			do
+			{
+				int colorIndex = rnd.Next(colors.Length - 1);
+				TimelineColor = Color.FromKnownColor(colors[colorIndex]);
+			} while (TimelineColor == Color.Transparent);
 		}
 
 		/// <summary>


### PR DESCRIPTION
VIX-3332 Timeline Color is not getting initialized properly for user created fixture functions