### PR TITLE
VIX-3331 - SetLevel when applied to a group is not correctly creating an intent for the specific leaf node

### DIFF
--- a/Modules/Effect/SetLevel/SetLevel.cs
+++ b/Modules/Effect/SetLevel/SetLevel.cs
@@ -149,7 +149,7 @@ namespace VixenModules.Effect.SetLevel
 						continue;
 					}
 				}
-				var intent = CreateIntent(leafs.First(), Color, IntensityLevel, TimeSpan);
+				var intent = CreateIntent(elementNode, Color, IntensityLevel, TimeSpan);
 				effectIntents.AddIntentForElement(elementNode.Element.Id, intent, TimeSpan.Zero);
 			}
 


### PR DESCRIPTION
VIX-3331 - SetLevel when applied to a group is not correctly creating an intent for the specific leaf node