### PR TITLE
VIX-3354 Fix an issue that can cause the Balls effect to produce an e…

### DIFF
--- a/Modules/Effect/Balls/Balls.cs
+++ b/Modules/Effect/Balls/Balls.cs
@@ -737,8 +737,8 @@ namespace VixenModules.Effect.Balls
 
 				//Sets Radius size and Ball location
 				int radius = RandomRadius ? Rand(1, _radius + 1) : _radius;
-				m.LocationX = Rand(radius, _bufferWi - radius);
-				m.LocationY = Rand(radius, _bufferHt - radius);
+				m.LocationX = _bufferWi - radius >= radius? Rand(radius, _bufferWi - radius) : Rand(1, _bufferWi);
+				m.LocationY = _bufferHt - radius >= radius ? Rand(radius, _bufferHt - radius) : Rand(1, _bufferHt);
 
 				if (Collide)
 				{


### PR DESCRIPTION
…rror.

In cases where the radius of the ball exceeds the buffer width, the random logic was getting a value out of range. Add guardrail logic to protect in these cases and provide sensible default values.