### PR TITLE
VIX-3382 Fix Process.Start for areas that use a url

### DIFF
--- a/src/Vixen.Application/CheckForUpdates.cs
+++ b/src/Vixen.Application/CheckForUpdates.cs
@@ -240,7 +240,12 @@ namespace VixenApplication
 
 		private void linkLabelVixenDownLoadPage_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			Process.Start("www.vixenlights.com/downloads/vixen-3-downloads/");
+			var psi = new ProcessStartInfo()
+			{
+				FileName = "www.vixenlights.com/downloads/vixen-3-downloads/",
+				UseShellExecute = true
+			};
+			Process.Start(psi);
 		}
 
 		private void SetScrollbars()

--- a/src/Vixen.Common/Help/Help.cs
+++ b/src/Vixen.Common/Help/Help.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Common.VixenHelp
 {
@@ -49,7 +50,13 @@ namespace Common.VixenHelp
 		
 		public static void ShowHelp(HelpStrings helpString)
 		{
-			System.Diagnostics.Process.Start(GetEnumDescription(helpString));
+			var psi = new ProcessStartInfo()
+			{
+				FileName = GetEnumDescription(helpString),
+				UseShellExecute = true
+			}; 
+			
+			Process.Start(psi);
 		}
 
 		public static string GetEnumDescription(Enum value)

--- a/src/Vixen.Common/WPFCommon/Controls/NavigatableHyperLink.cs
+++ b/src/Vixen.Common/WPFCommon/Controls/NavigatableHyperLink.cs
@@ -13,7 +13,8 @@ namespace Common.WPFCommon.Controls
 			{
 				StartInfo = new ProcessStartInfo()
 				{
-					FileName = this.NavigateUri.AbsoluteUri
+					FileName = this.NavigateUri.AbsoluteUri,
+					UseShellExecute = true
 				}
 			};
 			p.Start();

--- a/src/Vixen.Modules/App/Curves/FunctionGenerator.cs
+++ b/src/Vixen.Modules/App/Curves/FunctionGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Common.Controls.Theme;
+﻿using System.Diagnostics;
+using Common.Controls.Theme;
 using Common.Resources.Properties;
 
 namespace VixenModules.App.Curves
@@ -28,7 +29,12 @@ namespace VixenModules.App.Curves
 
 		private void lnkHelp_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			System.Diagnostics.Process.Start("http://www.vixenlights.com/vixen-3-documentation/basic-concepts-of-vixen-3/curve-editor/");
+			var psi = new ProcessStartInfo()
+			{
+				FileName = "http://www.vixenlights.com/vixen-3-documentation/basic-concepts-of-vixen-3/curve-editor/",
+				UseShellExecute = true
+			};
+			Process.Start(psi);
 		}
 	}
 }

--- a/src/Vixen.Modules/App/Curves/ZedGraph/ZedGraphControl.Events.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ZedGraphControl.Events.cs
@@ -18,6 +18,7 @@
 //=============================================================================
 
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace ZedGraph {
 	partial class ZedGraphControl {
@@ -436,8 +437,14 @@ namespace ZedGraph {
 						else
 							url = link._url;
 
-						if (url != string.Empty) {
-							System.Diagnostics.Process.Start(url);
+						if (url != string.Empty)
+						{
+							var psi = new ProcessStartInfo()
+							{
+								FileName = url,
+								UseShellExecute = true
+							};
+							Process.Start(psi);
 							// linkable objects override any other actions with mouse
 							return;
 						}

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows;
@@ -1034,7 +1035,12 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		private void Help()
 		{
 			var url = "http://www.vixenlights.com/vixen-3-documentation/preview/custom-prop-editor/";
-			System.Diagnostics.Process.Start(url);
+			var psi = new ProcessStartInfo()
+			{
+				FileName = url,
+				UseShellExecute = true
+			};
+			Process.Start(psi);
 		}
 
 		#endregion

--- a/src/Vixen.Modules/App/Modeling/ElementModeling.cs
+++ b/src/Vixen.Modules/App/Modeling/ElementModeling.cs
@@ -1,4 +1,5 @@
-﻿using Svg;
+﻿using System.Diagnostics;
+using Svg;
 using Vixen.Sys;
 using VixenModules.Property.Location;
 using VixenModules.Property.Order;
@@ -71,7 +72,12 @@ namespace VixenModules.App.Modeling
 				var filePath = System.IO.Path.ChangeExtension(file, "svg");
 				//var filePath = $"{file}{System.IO.Path.PathSeparator}{nodes.First()}.svg";
 				doc.Write(filePath);
-				System.Diagnostics.Process.Start(filePath);
+				var psi = new ProcessStartInfo()
+				{
+					FileName = filePath,
+					UseShellExecute = true
+				};
+				Process.Start(psi);
 			}
 
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using Catel;
@@ -570,7 +571,12 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		private void Help()
 		{
 			var url = "http://www.vixenlights.com/vixen-3-documentation/sequencer/sequence-import/";
-			System.Diagnostics.Process.Start(url);
+			var psi = new ProcessStartInfo()
+			{
+				FileName = url,
+				UseShellExecute = true
+			};
+			Process.Start(psi);
 		}
 
 		#endregion

--- a/src/Vixen.Modules/App/WebServer/Settings.cs
+++ b/src/Vixen.Modules/App/WebServer/Settings.cs
@@ -1,4 +1,5 @@
-﻿using Common.Controls;
+﻿using System.Diagnostics;
+using Common.Controls;
 using Common.Controls.Theme;
 using Resources = Common.Resources.Properties.Resources;
 
@@ -68,7 +69,12 @@ namespace VixenModules.App.WebServer
 
 		private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			System.Diagnostics.Process.Start(linkLabel1.Text);
+			var pi = new ProcessStartInfo()
+			{
+				FileName = linkLabel1.Text,
+				UseShellExecute = true
+			};
+			Process.Start(pi);
 		}
 
 		private void buttonBackground_MouseHover(object sender, EventArgs e)

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorWindowView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorWindowView.xaml.cs
@@ -67,7 +67,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 		private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
 		{
 			// Launch a browser with the URL
-			Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+			Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
 			e.Handled = true;
 		}
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FunctionTypeWindowView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FunctionTypeWindowView.xaml.cs
@@ -88,7 +88,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 		private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
 		{
 			// Launch a browser with the URL
-			Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+			Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri){UseShellExecute = true });
 			e.Handled = true;
 		}
 

--- a/src/Vixen.Modules/Editor/FixtureWizard/Wizard/Models/IntelligentFixtureWizard.cs
+++ b/src/Vixen.Modules/Editor/FixtureWizard/Wizard/Models/IntelligentFixtureWizard.cs
@@ -139,12 +139,15 @@ namespace VixenModules.Editor.FixtureWizard.Wizard
             if (CurrentPage is SummaryWizardPage)
 			{
                 // Launch a browser with the help URL
-                return Task.FromResult(Process.Start(new ProcessStartInfo("http://www.vixenlights.com/vixen-3-documentation/setup-configuration/setup-display-elements/intelligent-fixture-wizard/summary/")));
+                return Task.FromResult(Process.Start(new ProcessStartInfo("http://www.vixenlights.com/vixen-3-documentation/setup-configuration/setup-display-elements/intelligent-fixture-wizard/summary/")
+                {
+                    UseShellExecute = true
+                }));
             }
             else
             { 
                 // Otherwise launch a browser with the help URL for the current page
-                return Task.FromResult(Process.Start(new ProcessStartInfo(((FixtureWizardPageBase)CurrentPage).HelpURL)));                                       
+                return Task.FromResult(Process.Start(new ProcessStartInfo(((FixtureWizardPageBase)CurrentPage).HelpURL){UseShellExecute = true}));                                       
             }
         }
 

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -1,4 +1,5 @@
-﻿using Common.Controls;
+﻿using System.Diagnostics;
+using Common.Controls;
 using Common.Controls.Theme;
 using Common.Resources;
 using System.IO;
@@ -853,7 +854,12 @@ namespace VixenModules.Preview.VixenPreview
 
 		private void buttonCustomPropLibrary_Click(object sender, EventArgs e)
 		{
-			System.Diagnostics.Process.Start(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+			var psi = new ProcessStartInfo()
+			{
+				FileName = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+				UseShellExecute = true
+			};
+			Process.Start(psi);
 		}
 
 		private void btnBulbDecrease_Click(object sender, EventArgs e)


### PR DESCRIPTION
* Add UseShellExecute = true in areas that use a url or file path so the OS can determine the proper application. This was defaulted to true in .NET Framework and now defaults to false in .NET Core.