### PR TITLE
VIX-3417 Catel Deprecations.

### DIFF
--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
@@ -150,11 +150,18 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 			if (ElementMapFilePath == String.Empty || !File.Exists(ElementMapFilePath))
 			{
 				var saveFileService = dependencyResolver.Resolve<ISaveFileService>();
-				saveFileService.Filter = $"Element Map|*.{Constants.MapExtension}";
-				saveFileService.Title = @"Save Element Map";
-				if (await saveFileService.DetermineFileAsync())
+
+				var determineFileContext = new DetermineSaveFileContext()
 				{
-					ElementMapFilePath = saveFileService.FileName;
+					Filter = $"Element Map|*.{Constants.MapExtension}",
+					Title = @"Save Element Map"
+				};
+
+				var result = await saveFileService.DetermineFileAsync(determineFileContext);
+
+				if (result.Result)
+				{
+					ElementMapFilePath = result.FileName;
 					_elementMapService.ElementMap.Name = Path.GetFileNameWithoutExtension(ElementMapFilePath);
 				}
 				else
@@ -399,23 +406,26 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 			var dependencyResolver = this.GetDependencyResolver();
 			var openFileService = dependencyResolver.Resolve<IOpenFileService>();
 
-			openFileService.IsMultiSelect = false;
-			//_openFileService.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			openFileService.CheckFileExists = true;
-			openFileService.Title = @"Open Element Mapping";
-			openFileService.Filter = $"Element Map (*.{Constants.MapExtension}) | *.{Constants.MapExtension}";
-			if (await openFileService.DetermineFileAsync())
+			var determineFileContext = new DetermineOpenFileContext()
 			{
+				IsMultiSelect = false,
+				CheckFileExists = true,
+				Title = @"Open Element Mapping",
+				Filter = $"Element Map (*.{Constants.MapExtension}) | *.{Constants.MapExtension}"
+			};
 
+			var ofResult = await openFileService.DetermineFileAsync(determineFileContext);
+			if (ofResult.Result)
+			{
 				var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
 				//var modelPersistenceService = dependencyResolver.Resolve<IModelPersistenceService<ElementMap>>();
 
 				pleaseWaitService.Show();
-				var success = await _elementMapService.LoadMapAsync(openFileService.FileName);
+				var success = await _elementMapService.LoadMapAsync(ofResult.FileName);
 
 				if (success)
 				{
-					ElementMapFilePath = openFileService.FileName;
+					ElementMapFilePath = ofResult.FileName;
 					_elementMapService.ElementMap.Name = Path.GetFileNameWithoutExtension(ElementMapFilePath);
 					MapModified = false;
 
@@ -518,14 +528,19 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 			var dependencyResolver = this.GetDependencyResolver();
 			var openFileService = dependencyResolver.Resolve<IOpenFileService>();
 
-			openFileService.IsMultiSelect = false;
-			//_openFileService.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			openFileService.CheckFileExists = true;
-			openFileService.Title = @"Load Element Tree";
-			openFileService.Filter = $"Element Tree (*.{Constants.ElementTreeExtension}) | *.{Constants.ElementTreeExtension}";
-			if (await openFileService.DetermineFileAsync())
+			var determineFileContext = new DetermineOpenFileContext()
 			{
-				await LoadElementTree(openFileService.FileName);
+				IsMultiSelect = false,
+				CheckFileExists = true,
+				Title = @"Load Element Tree",
+				Filter = $"Element Tree (*.{Constants.ElementTreeExtension}) | *.{Constants.ElementTreeExtension}"
+			};
+
+			var result = await openFileService.DetermineFileAsync(determineFileContext);
+
+			if (result.Result)
+			{
+				await LoadElementTree(result.FileName);
 			}
 		}
 		public async Task LoadElementTree(string fileName)

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Marks.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Marks.cs
@@ -23,7 +23,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			
 			_mdvm = new MarkDockerViewModel(sequence.LabeledMarkCollections);
 			_markDockerView = new MarkDockerView(_mdvm);
-			_markDockerView.CloseViewModelOnUnloaded = true;
 			host.Child = _markDockerView;
 
 			Controls.Add(host);

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -2311,16 +2311,21 @@ namespace VixenModules.Preview.VixenPreview
 		{
 			var dependencyResolver = this.GetDependencyResolver();
 			var openFileService = dependencyResolver.Resolve<IOpenFileService>();
-			openFileService.IsMultiSelect = false;
-			if (openFileService.InitialDirectory == null)
+
+			var determineFileContext = new DetermineOpenFileContext()
 			{
-				openFileService.InitialDirectory = Paths.DataRootPath;
-			}
-			openFileService.Filter = "Prop Files(*.prp)|*.prp";
-			if (await openFileService.DetermineFileAsync())
+				IsMultiSelect = false,
+				Filter = "Prop Files(*.prp)|*.prp",
+				Title = @"Import Custom Prop",
+				InitialDirectory = Paths.DataRootPath
+
+			};
+
+			var result = await openFileService.DetermineFileAsync(determineFileContext);
+
+			if (result.Result)
 			{
-				openFileService.InitialDirectory = Path.GetDirectoryName(openFileService.FileName);
-				string path = openFileService.FileName;
+				string path = result.FileName;
 				await ImportCustomPropFromFile(path);
 			}
 			EndUpdate();


### PR DESCRIPTION
* Introduce the use of DetermineOpenFileContext and DetermineSaveFileContext to the open and save file usages. This is mainly reorganizing how the parameters are passed to setup the file dialog.
* Some minor changes to the initial directory settings were made to conform with the new pattern. This should mostly behave the same or default to the root of the profile.
* Remove deprecated CloseViewModelOnUnloaded call. This was just setting it to the default behavior, so should be no harm in removing.