### PR TITLE
VIX-3416 Remove deprecated security attributes

### DIFF
--- a/src/Vixen.Modules/App/Curves/ZedGraph/ArrowObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ArrowObj.cs
@@ -228,7 +228,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Axis.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Axis.cs
@@ -448,7 +448,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/AxisLabel.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/AxisLabel.cs
@@ -162,7 +162,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Bar.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Bar.cs
@@ -189,7 +189,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/BarItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/BarItem.cs
@@ -182,7 +182,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/BarSettings.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/BarSettings.cs
@@ -262,7 +262,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Border.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Border.cs
@@ -153,7 +153,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/BoxObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/BoxObj.cs
@@ -246,7 +246,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Chart.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Chart.cs
@@ -196,7 +196,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/CurveItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/CurveItem.cs
@@ -309,7 +309,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/DateAsOrdinalScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/DateAsOrdinalScale.cs
@@ -324,7 +324,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/DateScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/DateScale.cs
@@ -920,7 +920,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/EllipseObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/EllipseObj.cs
@@ -166,7 +166,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/ErrorBar.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ErrorBar.cs
@@ -259,7 +259,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/ErrorBarItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ErrorBarItem.cs
@@ -201,7 +201,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/ExponentScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ExponentScale.cs
@@ -381,7 +381,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Fill.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Fill.cs
@@ -617,7 +617,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/FontSpec.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/FontSpec.cs
@@ -668,7 +668,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/GapLabel.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/GapLabel.cs
@@ -145,7 +145,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/GasGaugeNeedle.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/GasGaugeNeedle.cs
@@ -287,7 +287,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/GasGaugeRegion.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/GasGaugeRegion.cs
@@ -131,7 +131,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/GraphObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/GraphObj.cs
@@ -431,7 +431,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/GraphPane.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/GraphPane.cs
@@ -536,7 +536,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/HiLowBar.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/HiLowBar.cs
@@ -193,7 +193,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/HiLowBarItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/HiLowBarItem.cs
@@ -131,17 +131,6 @@ namespace ZedGraph
 			int sch = info.GetInt32("schema3");
 		}
 
-		/// <summary>
-		/// Populates a <see cref="SerializationInfo"/> instance with the data needed to serialize the target object
-		/// </summary>
-		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
-		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
-		public override void GetObjectData(SerializationInfo info, StreamingContext context)
-		{
-			base.GetObjectData(info, context);
-		}
-
 		#endregion
 	}
 }

--- a/src/Vixen.Modules/App/Curves/ZedGraph/ImageObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/ImageObj.cs
@@ -241,7 +241,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/JapaneseCandleStick.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/JapaneseCandleStick.cs
@@ -264,7 +264,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/JapaneseCandleStickItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/JapaneseCandleStickItem.cs
@@ -193,7 +193,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Label.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Label.cs
@@ -187,7 +187,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Legend.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Legend.cs
@@ -551,7 +551,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Line.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Line.cs
@@ -335,7 +335,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LineBase.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LineBase.cs
@@ -388,7 +388,6 @@ namespace ZedGraph
 		/// serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the
 		/// serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema0", schema0);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LineItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LineItem.cs
@@ -253,7 +253,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LineObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LineObj.cs
@@ -179,7 +179,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LinearAsOrdinalScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LinearAsOrdinalScale.cs
@@ -224,7 +224,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LinearScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LinearScale.cs
@@ -218,7 +218,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Link.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Link.cs
@@ -284,7 +284,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Location.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Location.cs
@@ -436,7 +436,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/LogScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/LogScale.cs
@@ -422,7 +422,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/MajorGrid.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/MajorGrid.cs
@@ -129,7 +129,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/MajorTic.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/MajorTic.cs
@@ -137,7 +137,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Margin.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Margin.cs
@@ -212,7 +212,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/MasterPane.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/MasterPane.cs
@@ -382,7 +382,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/MinorGrid.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/MinorGrid.cs
@@ -205,7 +205,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/MinorTic.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/MinorTic.cs
@@ -337,7 +337,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/OHLCBar.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/OHLCBar.cs
@@ -237,7 +237,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/OHLCBarItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/OHLCBarItem.cs
@@ -190,7 +190,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/OrdinalScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/OrdinalScale.cs
@@ -213,7 +213,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PaneBase.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PaneBase.cs
@@ -566,7 +566,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PaneLayoutMgr.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PaneLayoutMgr.cs
@@ -142,7 +142,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PaneList.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PaneList.cs
@@ -102,7 +102,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PieItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PieItem.cs
@@ -508,7 +508,6 @@ namespace ZedGraph {
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context) {
 			base.GetObjectData(info, context);
 			info.AddValue("schema2", schema2);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PointPair.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PointPair.cs
@@ -193,7 +193,6 @@ namespace ZedGraph {
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context) {
 			base.GetObjectData(info, context);
 			info.AddValue("schema2", schema2);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PointPair4.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PointPair4.cs
@@ -114,7 +114,6 @@ namespace ZedGraph {
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context) {
 			base.GetObjectData(info, context);
 			info.AddValue("schema2", schema3);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PointPairBase.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PointPairBase.cs
@@ -132,7 +132,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PointPairCV.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PointPairCV.cs
@@ -89,7 +89,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/PolyObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/PolyObj.cs
@@ -207,7 +207,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/RollingPointPairList.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/RollingPointPairList.cs
@@ -633,7 +633,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Scale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Scale.cs
@@ -937,7 +937,6 @@ namespace ZedGraph
 		/// </remarks>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/StickItem.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/StickItem.cs
@@ -204,7 +204,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/StockPt.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/StockPt.cs
@@ -182,7 +182,6 @@ namespace ZedGraph {
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context) {
 			base.GetObjectData(info, context);
 			info.AddValue("schema3", schema2);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Symbol.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Symbol.cs
@@ -357,7 +357,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("schema", schema);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/TextObj.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/TextObj.cs
@@ -346,7 +346,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/TextScale.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/TextScale.cs
@@ -301,7 +301,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/X2Axis.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/X2Axis.cs
@@ -144,7 +144,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/XAxis.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/XAxis.cs
@@ -143,7 +143,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/Y2Axis.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/Y2Axis.cs
@@ -143,7 +143,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/Vixen.Modules/App/Curves/ZedGraph/YAxis.cs
+++ b/src/Vixen.Modules/App/Curves/ZedGraph/YAxis.cs
@@ -144,7 +144,6 @@ namespace ZedGraph
 		/// </summary>
 		/// <param name="info">A <see cref="SerializationInfo"/> instance that defines the serialized data</param>
 		/// <param name="context">A <see cref="StreamingContext"/> instance that contains the serialized data</param>
-		[SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);


### PR DESCRIPTION
* SecurityPermissionAttribute is obsolete and no longer used by the runtime. These can be removed since this feature was not used in the code.