### PR TITLE
VIX-3421 Fix variety of basic warnings.

### DIFF
--- a/src/Vixen.Common/Controls/TimeLineControl/Waveform.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Waveform.cs
@@ -128,7 +128,7 @@ namespace Common.Controls.Timeline
 						BeginInvoke((Action) FinishedSamples);
 					}
 				}
-				catch (OperationCanceledException e)
+				catch (OperationCanceledException)
 				{
 					Logging.Info("Waveform create samples canceled.");
 				}

--- a/src/Vixen.Common/NShape/Project.cs
+++ b/src/Vixen.Common/NShape/Project.cs
@@ -950,9 +950,9 @@ namespace Dataweb.NShape
 			try {
 				InitializeLibrary(library);
 			}
-			catch (Exception exc) {
+			catch (Exception) {
 				DoRemoveLibrary(library);
-				throw exc;
+				throw;
 			}
 			finally {
 				addingLibrary = false;

--- a/src/Vixen.Common/NShape/XmlStore.cs
+++ b/src/Vixen.Common/NShape/XmlStore.cs
@@ -448,9 +448,9 @@ namespace Dataweb.NShape
 					// in OpenComplete.
 					ReadProjectSettings(cache, xmlReader);
 				}
-				catch (Exception exc) {
+				catch (Exception) {
 					CloseFile();
-					throw exc;
+					throw;
 				}
 			}
 			isOpen = true;

--- a/src/Vixen.Common/NShapeWinFormsUI/LibraryManagementDialog.cs
+++ b/src/Vixen.Common/NShapeWinFormsUI/LibraryManagementDialog.cs
@@ -91,7 +91,7 @@ namespace Dataweb.NShape.WinFormsUI
 		private string GetAssemblyFilePath(Assembly assembly)
 		{
 			// Get assembly file path
-			UriBuilder uriBuilder = new UriBuilder(assembly.CodeBase);
+			UriBuilder uriBuilder = new UriBuilder(assembly.Location);
 			return Uri.UnescapeDataString(uriBuilder.Path);
 		}
 

--- a/src/Vixen.Common/WpfPropertyGrid/Internal/MergedPropertyDescriptor.cs
+++ b/src/Vixen.Common/WpfPropertyGrid/Internal/MergedPropertyDescriptor.cs
@@ -22,6 +22,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
+#pragma warning disable SYSLIB0011
 
 namespace System.Windows.Controls.WpfPropertyGrid.Internal
 {

--- a/src/Vixen.Core/Execution/DataSource/EffectNodeDataPump.cs
+++ b/src/Vixen.Core/Execution/DataSource/EffectNodeDataPump.cs
@@ -88,7 +88,7 @@ namespace Vixen.Execution.DataSource
 		{
 			if (disposing) {
 				if (_dataPumpThread != null)
-					_dataPumpThread.Abort();
+					_StopThread();
 			}
 			_dataPumpThread = null;
 		}

--- a/src/Vixen.Core/Execution/DataSource/SequenceDataPump.cs
+++ b/src/Vixen.Core/Execution/DataSource/SequenceDataPump.cs
@@ -79,7 +79,7 @@ namespace Vixen.Execution.DataSource
 			if (disposing)
 			{
 				if (_dataPumpThread != null)
-					_dataPumpThread.Abort();
+					_StopThread();
 				_dataPumpThread = null;
 				Sequence = null;
 				_effectNodeQueue = null;

--- a/src/Vixen.Modules/App/CustomPropEditor/Model/InternalVendorInventory/Product.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Model/InternalVendorInventory/Product.cs
@@ -19,7 +19,6 @@ namespace VixenModules.App.CustomPropEditor.Model.InternalVendorInventory
 		private string _pixelSpacing;
 		private string _notes;
 		private List<ModelLink> _modelLinks;
-		private Uri _vixenPropLink;
 
 		/// <summary>
 		/// Unique Id within the Vendor for the product.

--- a/src/Vixen.Modules/App/Marks/Annotations.cs
+++ b/src/Vixen.Modules/App/Marks/Annotations.cs
@@ -1,4 +1,6 @@
-﻿namespace Marks
+﻿#nullable enable
+
+namespace VixenModules.App.Marks
 {
 	internal class Annotations
 	{

--- a/src/Vixen.Modules/App/Marks/BindableBase.cs
+++ b/src/Vixen.Modules/App/Marks/BindableBase.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using Marks;
 
 namespace VixenModules.App.Marks
 {

--- a/src/Vixen.Modules/App/Marks/MarkDecorator.cs
+++ b/src/Vixen.Modules/App/Marks/MarkDecorator.cs
@@ -10,8 +10,6 @@ namespace VixenModules.App.Marks
 		private bool _isBold;
 		private bool _isSolidLine;
 		private Color _color;
-		private bool _showLabels;
-		private bool _showLines;
 
 		public MarkDecorator()
 		{

--- a/src/Vixen.Modules/App/WebServer/Module.cs
+++ b/src/Vixen.Modules/App/WebServer/Module.cs
@@ -1,4 +1,6 @@
-﻿using NLog;
+﻿#nullable enable
+
+using NLog;
 using Vixen.Execution.Context;
 using Vixen.Module;
 using Vixen.Module.App;
@@ -13,9 +15,14 @@ namespace VixenModules.App.WebServer
 		
 		internal static LiveContext? LiveContext { get; set; }
 
-		private Data? _data;
+		private Data _data;
 		private IApplication? _application;
 		private WebHost? _webHost;
+
+		public Module()
+		{
+			_data = new Data();
+		}
 		
 		public override IModuleDataModel StaticModuleData
 		{

--- a/src/Vixen.Modules/App/WebServer/WebHost.cs
+++ b/src/Vixen.Modules/App/WebServer/WebHost.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿#nullable enable
+
+using Microsoft.AspNetCore.Hosting;
 using NLog.Extensions.Logging;
 
 namespace VixenModules.App.WebServer
@@ -8,7 +10,7 @@ namespace VixenModules.App.WebServer
 	{ 
 		private IWebHost? _host;
 		private readonly Data _data;
-		private bool _isRunning = false;
+		private bool _isRunning;
 		private static CancellationTokenSource _cancelTokenSource = new CancellationTokenSource();
 
 		public WebHost(Data data)
@@ -20,7 +22,7 @@ namespace VixenModules.App.WebServer
 		{
 			var host = new WebHostBuilder()
 				.UseKestrel()
-				.ConfigureLogging((hostingContext, logging) => {
+				.ConfigureLogging((_, logging) => {
 					logging.AddNLog();
 				})
 				.CaptureStartupErrors(true)

--- a/src/Vixen.Modules/Controller/E131/AboutBox.cs
+++ b/src/Vixen.Modules/Controller/E131/AboutBox.cs
@@ -84,7 +84,7 @@ namespace VixenModules.Controller.E131
 					}
 				}
 
-				return Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly().CodeBase);
+				return Path.GetFileNameWithoutExtension(Assembly.GetExecutingAssembly().Location);
 			}
 		}
 

--- a/src/Vixen.Modules/Editor/EffectEditor/Editors/PolygonContainerTypeEditor.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/Editors/PolygonContainerTypeEditor.cs
@@ -67,7 +67,7 @@ namespace VixenModules.Editor.EffectEditor.Editors
 					value = polygonContainerUpdated;
 				}					
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				var messageBox = new MessageBoxForm("An error occurred loading the polygon editor.", "Polygon Error", MessageBoxButtons.OK, SystemIcons.Error);
 				messageBox.ShowDialog();				

--- a/src/Vixen.Modules/Editor/EffectEditor/Internal/MergedPropertyDescriptor.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/Internal/MergedPropertyDescriptor.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Vixen.Module.Effect;
 using Vixen.TypeConverters;
+#pragma warning disable SYSLIB0011
 
 namespace VixenModules.Editor.EffectEditor.Internal
 {

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/ColorWheelView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/ColorWheelView.xaml.cs
@@ -132,7 +132,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 				IEditableCollectionView collectionView = (IEditableCollectionView)CollectionViewSource.GetDefaultView(vm.Items);
 				collectionView.CancelEdit();
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				// Testing revealed deleting 2nd or 3rd incomplete row seemed to trigger an exception
 			}

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorView.xaml.cs
@@ -138,7 +138,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 				IEditableCollectionView collectionView = (IEditableCollectionView)CollectionViewSource.GetDefaultView(vm.Items);
 				collectionView.CancelEdit();
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				// Testing revealed deleting 2nd or 3rd incomplete row seemed to trigger an exception
 			}

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FunctionTypeView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FunctionTypeView.xaml.cs
@@ -267,7 +267,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 				IEditableCollectionView collectionView = (IEditableCollectionView)CollectionViewSource.GetDefaultView(vm.Items);
 				collectionView.CancelEdit();
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				// Testing revealed deleting 2nd or 3rd incomplete row seemed to trigger an exception
 			}

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/IndexedView.xaml.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/IndexedView.xaml.cs
@@ -133,7 +133,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.Views
 				IEditableCollectionView collectionView = (IEditableCollectionView)CollectionViewSource.GetDefaultView(vm.Items);
 				collectionView.CancelEdit();
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
 				// Testing revealed deleting 2nd or 3rd incomplete row seemed to trigger an exception
 			}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Toolstrip.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm_Toolstrip.cs
@@ -35,7 +35,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private ToolStripButton _selectedButton;
 		private bool _toolStripButtonAlreadyChecked;
 		private ToolStrip _contextToolStrip;
-		private string _lastFolder;
 		private bool _itemMove;
 		private bool _dragValid;
 

--- a/src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs
+++ b/src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs
@@ -539,12 +539,6 @@ namespace VixenModules.Effect.Effect
 			return ConvertRange(minimum, maximum, 0, 100, value);
 		}
 
-		private static double ConvertRange(double originalStart, double originalEnd, double newStart, double newEnd, double value) // value to convert
-		{
-			double scale = (newEnd - newStart) / (originalEnd - originalStart);
-			return newStart + (value - originalStart) * scale;
-		}
-
 		protected static bool IsAngleBetween(double a, double b, double n)
 		{
 			n = (360 + (n % 360)) % 360;

--- a/src/Vixen.Modules/Effect/Morph/Directory.Build.props
+++ b/src/Vixen.Modules/Effect/Morph/Directory.Build.props
@@ -2,6 +2,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../../'))" />
     <PropertyGroup>
         <AssemblyName>Module.Effect.$(MSBuildProjectName)</AssemblyName>
+		<Nullable>disable</Nullable>
     </PropertyGroup>
 </Project>
 

--- a/src/Vixen.Modules/Effect/Morph/Morph/Morph.cs
+++ b/src/Vixen.Modules/Effect/Morph/Morph/Morph.cs
@@ -1783,7 +1783,7 @@ namespace VixenModules.Effect.Morph
 
 			// Flip me over so and offset my coordinates I can act like the string version
 			y = Math.Abs((BufferHtOffset - _marginOffsetY) + bufferHt - y - 1);
-			y = y;
+			
 			x = x - (BufferWiOffset - _marginOffsetX);
 
 			// Retrieve the color from the bitmap

--- a/src/Vixen.Modules/Effect/Video/Video.cs
+++ b/src/Vixen.Modules/Effect/Video/Video.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#nullable enable
+
+using System.ComponentModel;
 using Common.Controls;
 using Common.Controls.ColorManagement.ColorModels;
 using Vixen.Attributes;

--- a/src/Vixen.Modules/Media/Audio/SampleProviders/MonoSampleProvider.cs
+++ b/src/Vixen.Modules/Media/Audio/SampleProviders/MonoSampleProvider.cs
@@ -6,8 +6,7 @@ namespace VixenModules.Media.Audio.SampleProviders
 	public class MonoSampleProvider:ISampleProvider
 	{
 		private readonly ISampleProvider _sourceProvider;
-		private float[] _sourceBuffer;
-		
+
 		public MonoSampleProvider(CachedSoundSampleProvider sourceProvider)
 		{
 			_sourceProvider = sourceProvider.ToMono();

--- a/src/Vixen.Modules/OutputFilter/DimmingCurve/DimmingCurveModule.cs
+++ b/src/Vixen.Modules/OutputFilter/DimmingCurve/DimmingCurveModule.cs
@@ -336,7 +336,6 @@ namespace VixenModules.OutputFilter.DimmingCurve
 		private readonly List<IIntentState> _states = new List<IIntentState>();
 		private readonly CommandDataFlowData _commandState;
 		private IntentsDataFlowData _intentData;
-		private CommandDataFlowData _data;
 
 		public DimmingCurveOutput(Curve curve)
 		{

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
@@ -17,12 +17,8 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 	[DataContract]
 	public abstract class PreviewLightBaseShape : PreviewBaseShape, ICloneable, IDisposable
 	{
-		private static NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();
 		private List<float> _points = new List<float>();
-		public string _name;
-		public static int SevenFloatDataSize = 7 * Marshal.SizeOf(typeof(float));
 		public static int EightFloatDataSize = 8 * Marshal.SizeOf(typeof(float));
-		public static int FloatDataSize = Marshal.SizeOf(typeof(float));
 		public bool connectStandardStrings = false;
 		public StringTypes _stringType = StringTypes.Standard;
 		private bool _isHighPrecision;

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
@@ -54,7 +54,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		}
 				
 		[OnDeserialized]
-		private new void OnDeserialized(StreamingContext context)
+		private void OnDeserialized(StreamingContext context)
 		{			
 			Layout();						
 		}


### PR DESCRIPTION
* Remove many unused variables.
* Suppress warnings for BinaryFormatter since the usage here is fine.
* Fix nullable warnings for several classes either by adding nullable attribute to file, or fixing the build props.