### PR TITLE
VIX-3428 Fix null check code

### DIFF
--- a/src/Vixen.Core/Sys/ElementNode.cs
+++ b/src/Vixen.Core/Sys/ElementNode.cs
@@ -222,11 +222,11 @@ namespace Vixen.Sys
 
 		public IEnumerable<Element> GetElementEnumerator()
 		{
-			if (Element == null)
-			{
-				return Enumerable.Empty<Element>();
-			}
 			if (IsLeaf) {
+				if (Element == null)
+				{
+					return Enumerable.Empty<Element>();
+				}
 				// Element is already an enumerable, so AsEnumerable<> won't work.
 				return (new[] {Element});
 			}


### PR DESCRIPTION
* The null check added for the nullable logic was placed int he wrong area. Refactored to move it to the correct place to restore previous functionality.