### PR TITLE
VIX-3431 Remove logic looking for Vixen Prop files

### DIFF
--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -1140,29 +1140,15 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 			}
 			else
 			{
-				//The vendors provide a link to the xModel, but may have a Vixen prop of the same name alongside it.
-				//If it exists we will prefer it.
-				string propUrl = modelLink.Link.AbsoluteUri.Replace(@".xmodel", @".prp");
-
-				bool success = await ds.GetFileAsync(new Uri(propUrl), targetPath);
-				
+				bool success = await ds.GetFileAsync(modelLink.Link, targetPath);
 				if (success)
 				{
-					LoadPropFromPath(targetPath);
-					status = new Tuple<bool, ModelType>(true, ModelType.Prop); ;
+					await ImportProp(targetPath);
+					status = new Tuple<bool, ModelType>(true, ModelType.XModel);
 				}
 				else
 				{
-					success = await ds.GetFileAsync(modelLink.Link, targetPath);
-					if (success)
-					{
-						await ImportProp(targetPath);
-						status = new Tuple<bool, ModelType>(true, ModelType.XModel);
-					}
-					else
-					{
-						mbs.ShowError("Unable to download the model from the vendor.\nEnsure you have an active internet connection.", "Error Downloading Model.");
-					}
+					mbs.ShowError("Unable to download the model from the vendor.\nEnsure you have an active internet connection.", "Error Downloading Model.");
 				}
 			}
 


### PR DESCRIPTION
* Vendors may not use a direct link to the file so the logic trying to look for another file with a different extension does not work correctly. With the pervasive use of drop box style file shares, the assumption made when this code was written is not valid. Removed the logic since it is not being used anyway.