### PR TITLE
VIX-3454 Fix events occuring across mutiple editors

### DIFF
--- a/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
@@ -52,12 +52,16 @@ namespace Common.Controls.Timeline
 
 		//We turn these into snap points for effects.
 		private ObservableCollection<IMarkCollection> _markCollections;
+		private readonly TimeLineGlobalEventManager _timelineGlobalEventManager;
+		private readonly TimeLineGlobalStateManager _timelineGlobalStateManager;
 
 		#region Initialization
 
-		public Grid(TimeInfo timeinfo)
+		public Grid(TimeInfo timeinfo, Guid instanceId)
 			: base(timeinfo)
 		{
+			_timelineGlobalStateManager = TimeLineGlobalStateManager.Manager(instanceId);
+			_timelineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			AutoScroll = true;
 			AllowGridResize = true;
 			AutoScrollMargin = new Size(24, 24);
@@ -78,6 +82,7 @@ namespace Common.Controls.Timeline
 			StaticSnapPoints = new SortedDictionary<TimeSpan, List<SnapDetails>>();
 			SnapPriorityForElements = 5;
 			ClickingGridSetsCursor = true;
+			
 
 			m_rows = new List<Row>();
 
@@ -90,7 +95,8 @@ namespace Common.Controls.Timeline
 			Row.RowToggled += RowToggledHandler;
             Row.RowHeightChanged += RowHeightChangedHandler;
 			Row.RowVisibilityChanged += RowVisibilityChangedHandler;
-			TimeLineGlobalEventManager.Manager.AlignmentActivity += TimeLineAlignmentHandler;
+			
+			_timelineGlobalEventManager.AlignmentActivity += TimeLineAlignmentHandler;
 
 			// Drag & Drop
 			AllowDrop = true;
@@ -133,7 +139,7 @@ namespace Common.Controls.Timeline
 			Row.RowSelectedChanged -= RowSelectedChangedHandler;
 			Row.RowToggled -= RowToggledHandler;
 			Row.RowHeightChanged -= RowHeightChangedHandler;
-			TimeLineGlobalEventManager.Manager.AlignmentActivity -= TimeLineAlignmentHandler;
+			_timelineGlobalEventManager.AlignmentActivity -= TimeLineAlignmentHandler;
 
 			TimeInfo= null;
 
@@ -329,10 +335,10 @@ namespace Common.Controls.Timeline
 
 		private TimeSpan CursorPosition
 		{
-			get => TimeLineGlobalStateManager.Manager.CursorPosition;
+			get => _timelineGlobalStateManager.CursorPosition;
 			set
 			{
-				TimeLineGlobalStateManager.Manager.CursorPosition = value;
+				_timelineGlobalStateManager.CursorPosition = value;
 				Invalidate();
 			}
 		}
@@ -2610,7 +2616,7 @@ namespace Common.Controls.Timeline
 
 			if (m_dragState == DragState.HResizing) //Draw line at start or end of effect, depending which end the user grabbed
 			{
-				TimeLineGlobalEventManager.Manager.OnAlignmentActivity(new AlignmentEventArgs(true, new []{ _workingElement.EndTime }));
+				_timelineGlobalEventManager.OnAlignmentActivity(new AlignmentEventArgs(true, new []{ _workingElement.EndTime }));
 				using (Pen p = new Pen(Color.FromName(ResizeIndicator_Color), 1))
 				{
 					var X = (m_mouseResizeZone == ResizeZone.Front ? timeToPixels(_workingElement.StartTime) : timeToPixels(_workingElement.EndTime) - 1);
@@ -2620,7 +2626,7 @@ namespace Common.Controls.Timeline
 
 			if (m_dragState == DragState.Waiting || m_dragState == DragState.Moving) //Draw line at both ends, the user is dragging the entire effect
 			{
-				TimeLineGlobalEventManager.Manager.OnAlignmentActivity(new AlignmentEventArgs(true, new[] { _workingElement. StartTime, _workingElement.EndTime }));
+				_timelineGlobalEventManager.OnAlignmentActivity(new AlignmentEventArgs(true, new[] { _workingElement. StartTime, _workingElement.EndTime }));
 				using (Pen p = new Pen(Color.FromName(ResizeIndicator_Color), 1))
 				{
 					g.DrawLine(p, timeToPixels(_workingElement.StartTime), 0, timeToPixels(_workingElement.StartTime), AutoScrollMinSize.Height);

--- a/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -181,7 +181,7 @@ namespace Common.Controls.Timeline
 		{
 			base.OnMouseUp(e);
 
-			TimeLineGlobalEventManager.Manager.OnAlignmentActivity(new AlignmentEventArgs(false, null));
+			_timelineGlobalEventManager.OnAlignmentActivity(new AlignmentEventArgs(false, null));
 
 			Point gridLocation = mouseUpGridLocation = TranslateLocation(e.Location);
 

--- a/src/Vixen.Common/Controls/TimeLineControl/LabeledMarks/TimeLineGlobalEventManager.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/LabeledMarks/TimeLineGlobalEventManager.cs
@@ -1,10 +1,11 @@
-﻿using Common.Controls.Timeline;
+﻿using System.Diagnostics;
+using Common.Controls.Timeline;
 
 namespace Common.Controls.TimelineControl.LabeledMarks
 {
 	public class TimeLineGlobalEventManager
 	{
-		private static TimeLineGlobalEventManager _manager;
+		private static readonly Dictionary<Guid, TimeLineGlobalEventManager> Instances = new();
 
 		public event EventHandler<MarksTextChangedEventArgs> MarksTextChanged;
 		public event EventHandler<MarksMovedEventArgs> MarksMoved;
@@ -16,12 +17,34 @@ namespace Common.Controls.TimelineControl.LabeledMarks
 		public event EventHandler<PlayRangeEventArgs> PlayRangeAction;
 		public event EventHandler<TimeSpanEventArgs> CursorMoved;
 
-		private TimeLineGlobalEventManager()
+
+
+		private TimeLineGlobalEventManager(Guid id)
 		{
-			
+			InstanceId = id;
 		}
 
-		public static TimeLineGlobalEventManager Manager => _manager ?? (_manager = new TimeLineGlobalEventManager());
+		public static TimeLineGlobalEventManager Manager(Guid id)
+		{
+			if (Instances.TryGetValue(id, out var instance))
+			{
+				return instance;
+			}
+			else
+			{
+				instance = new TimeLineGlobalEventManager(id);
+				Instances.Add(id, instance);
+			}
+
+			return instance;
+		}
+
+		public static bool CloseManager(Guid id)
+		{
+			return Instances.Remove(id);
+		}
+
+		public Guid InstanceId { get; init; }
 
 		public void OnAlignmentActivity(AlignmentEventArgs e)
 		{

--- a/src/Vixen.Common/Controls/TimeLineControl/MarksBar.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/MarksBar.cs
@@ -30,12 +30,12 @@ namespace Common.Controls.TimelineControl
 		private List<IMark> _clipboard = new List<IMark>();
 
 		/// <inheritdoc />
-		public MarksBar(TimeInfo timeinfo) : base(timeinfo)
+		public MarksBar(TimeInfo timeinfo, Guid instanceId) : base(timeinfo)
 		{
 			BackColor = Color.Gray;
 			_textFont = Font;
 			_marksSelectionManager = MarksSelectionManager.Manager();
-			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager;
+			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			_timeLineGlobalEventManager.MarksMoving += TimeLineGlobalEventManagerTimeLineGlobalMoving;
 			_timeLineGlobalEventManager.MarksMoved += TimeLineGlobalEventManager_MarksMoved;
 			_timeLineGlobalEventManager.DeleteMark += TimeLineGlobalEventManagerDeleteTimeLineGlobal;
@@ -852,7 +852,7 @@ the target {insertRow.MarkCollection.Name} is of type {insertRow.MarkCollection.
 					changedMarks.Add(mti);
 					mark.Text = menuItem.Text;
 				}
-				TimeLineGlobalEventManager.Manager.OnMarksTextChanged(new MarksTextChangedEventArgs(changedMarks));
+				_timeLineGlobalEventManager.OnMarksTextChanged(new MarksTextChangedEventArgs(changedMarks));
 			}
 			
 		}
@@ -871,7 +871,7 @@ the target {insertRow.MarkCollection.Name} is of type {insertRow.MarkCollection.
 					changedMarks.Add(mti);
 					mark.Text = td.Response;
 				}
-				TimeLineGlobalEventManager.Manager.OnMarksTextChanged(new MarksTextChangedEventArgs(changedMarks));
+				_timeLineGlobalEventManager.OnMarksTextChanged(new MarksTextChangedEventArgs(changedMarks));
 			}
 		}
 

--- a/src/Vixen.Common/Controls/TimeLineControl/Ruler.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Ruler.cs
@@ -23,16 +23,18 @@ namespace Common.Controls.Timeline
 		private ObservableCollection<IMarkCollection> _markCollections;
 		private readonly MarksSelectionManager _marksSelectionManager;
 		private readonly TimeLineGlobalEventManager _timeLineGlobalEventManager;
+		private readonly TimeLineGlobalStateManager _timeLineGlobalStateManager;
 
 		private MarksMoveResizeInfo _marksMoveResizeInfo;
 
-		public Ruler(TimeInfo timeinfo)
+		public Ruler(TimeInfo timeinfo, Guid instanceId)
 			: base(timeinfo)
 		{
 			AutoScaleMode = AutoScaleMode.Font;
 			BackColor = Color.Gray;
 			_marksSelectionManager = MarksSelectionManager.Manager();
-			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager;
+			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager(instanceId);
+			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			_timeLineGlobalEventManager.MarksMoving += TimeLineGlobalEventManagerTimeLineGlobalMoving;
 			_timeLineGlobalEventManager.DeleteMark += TimeLineGlobalEventManagerDeleteTimeLineGlobal;
 			_timeLineGlobalEventManager.CursorMoved += OnCursorMoved;
@@ -220,7 +222,7 @@ namespace Common.Controls.Timeline
 		{
 			using (Pen p = new Pen(Color.Blue, 1))
 			{
-				var curPos = timeToPixels(TimeLineGlobalStateManager.Manager.CursorPosition);
+				var curPos = timeToPixels(_timeLineGlobalStateManager.CursorPosition);
 				g.DrawLine(p, curPos, 0, curPos, Height);
 			}
 		}

--- a/src/Vixen.Common/Controls/TimeLineControl/TimeLineGlobalStateManager.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/TimeLineGlobalStateManager.cs
@@ -5,15 +5,36 @@ namespace Common.Controls.TimelineControl
 	public class TimeLineGlobalStateManager
 	{
 
-		private static TimeLineGlobalStateManager _manager;
 		private TimeSpan _cursorPosition = TimeSpan.Zero;
 
-		private TimeLineGlobalStateManager()
-		{
+		private static readonly Dictionary<Guid, TimeLineGlobalStateManager> Instances = new();
 
+		private TimeLineGlobalStateManager(Guid id)
+		{
+			InstanceId = id;
 		}
 
-		public static TimeLineGlobalStateManager Manager => _manager ?? (_manager = new TimeLineGlobalStateManager());
+		public static TimeLineGlobalStateManager Manager(Guid id)
+		{
+			if (Instances.TryGetValue(id, out var instance))
+			{
+				return instance;
+			}
+			else
+			{
+				instance = new TimeLineGlobalStateManager(id);
+				Instances.Add(id, instance);
+			}
+
+			return instance;
+		}
+
+		public static bool CloseManager(Guid id)
+		{
+			return Instances.Remove(id);
+		}
+
+		public Guid InstanceId { get; init; }
 
 		public TimeSpan CursorPosition
 		{
@@ -21,7 +42,7 @@ namespace Common.Controls.TimelineControl
 			set
 			{
 				_cursorPosition = value;
-				TimeLineGlobalEventManager.Manager.OnCursorMoved(value);
+				TimeLineGlobalEventManager.Manager(InstanceId).OnCursorMoved(value);
 			}
 		}
 	}

--- a/src/Vixen.Common/Controls/TimeLineControl/TimelineControl.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/TimelineControl.cs
@@ -47,9 +47,12 @@ namespace Common.Controls.Timeline
 			}
 		}
 
-		public TimelineControl()
+		protected Guid InstanceId { get; init; }
+
+		public TimelineControl(Guid id)
 			: base(new TimeInfo()) // This is THE TimeInfo object for the whole control (and all sub-controls).
 		{
+			InstanceId = id;
 			rowHeight = (int)(DefaultRowHeight*ScalingTools.GetScaleFactor());
 			TimeInfo.TimePerPixel = TimeSpan.FromTicks(100000);
 			TimeInfo.VisibleTimeStart = TimeSpan.Zero;
@@ -181,7 +184,7 @@ namespace Common.Controls.Timeline
 			splitContainer.Panel2.SuspendLayout();
 
 			// Grid
-			grid = new Grid(TimeInfo)
+			grid = new Grid(TimeInfo, InstanceId)
 			       	{
 			       		Dock = DockStyle.Fill,
 			       	};
@@ -191,7 +194,7 @@ namespace Common.Controls.Timeline
 
 
 			//Marks
-			MarksBar = new MarksBar(TimeInfo)
+			MarksBar = new MarksBar(TimeInfo, InstanceId)
 			{
 				Dock = DockStyle.Top,
 				Height = 50
@@ -200,7 +203,7 @@ namespace Common.Controls.Timeline
 			splitContainer.Panel2.Controls.Add(MarksBar);
 
 			// Ruler
-			ruler = new Ruler(TimeInfo)
+			ruler = new Ruler(TimeInfo, InstanceId)
 			        	{
 			        		Dock = DockStyle.Top,
 			        		Height = 50,
@@ -210,7 +213,7 @@ namespace Common.Controls.Timeline
 			//WaveForm
 			//TODO deal with positioning, can we dock two controls to the top
 			//Looks like the last one wins.
-			waveform = new Waveform(TimeInfo)
+			waveform = new Waveform(TimeInfo, InstanceId)
 			           	{
 			           		Dock = DockStyle.Top,
 			           		Height = 50

--- a/src/Vixen.Common/Controls/TimeLineControl/Waveform.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Waveform.cs
@@ -29,12 +29,13 @@ namespace Common.Controls.Timeline
 		private CancellationTokenSource _updateCancellationTokenSource;
 
 		private readonly TimeLineGlobalEventManager _timeLineGlobalEventManager;
+		private readonly TimeLineGlobalStateManager _timeLineGlobalStateManager;
 
 		/// <summary>
 		/// Creates a waveform view of the <code>Audio</code> that is associated scaled to the timeinfo.
 		/// </summary>
 		/// <param name="timeinfo"></param>
-		public Waveform(TimeInfo timeinfo)
+		public Waveform(TimeInfo timeinfo, Guid instanceId)
 			: base(timeinfo)
 		{
 			samples = new List<Sample>();
@@ -42,7 +43,8 @@ namespace Common.Controls.Timeline
 			Visible = false;
 			_timePerPixelChangeSubject = new Subject<TimeSpan>();
 			_timePerPixelChangeSubject.Throttle(TimeSpan.FromMilliseconds(125)).Subscribe(x => CreateSamples());
-			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager;
+			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager(instanceId);
+			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			_timeLineGlobalEventManager.AlignmentActivity += WaveFormSelectedTimeLineGlobalMove;
 			_timeLineGlobalEventManager.CursorMoved += CursorMoved;
 		}
@@ -296,7 +298,7 @@ namespace Common.Controls.Timeline
 		{
 			using (Pen p = new Pen(Color.Blue, 1))
 			{
-				var curPos = timeToPixels(TimeLineGlobalStateManager.Manager.CursorPosition);
+				var curPos = timeToPixels(_timeLineGlobalStateManager.CursorPosition);
 				g.DrawLine(p, curPos, 0, curPos, Height);
 			}
 		}

--- a/src/Vixen.Modules/Analysis/BeatsAndBars/PreviewWaveform.cs
+++ b/src/Vixen.Modules/Analysis/BeatsAndBars/PreviewWaveform.cs
@@ -1,4 +1,6 @@
 ﻿using Common.Controls.Timeline;
+using Common.Controls.TimelineControl;
+using Common.Controls.TimelineControl.LabeledMarks;
 using VixenModules.Media.Audio;
 
 namespace VixenModules.Analysis.BeatsAndBars
@@ -7,6 +9,7 @@ namespace VixenModules.Analysis.BeatsAndBars
 	{
 		private Waveform m_waveform;
 		private TimeInfo m_info;
+		private Guid _instanceId = Guid.NewGuid();
 		
 		public PreviewWaveform(Audio audio)
 		{
@@ -14,7 +17,7 @@ namespace VixenModules.Analysis.BeatsAndBars
 
 			m_info = new TimeInfo();
 			m_info.TotalTime = new TimeSpan(0, 0, 0, 1);
-			m_waveform = new Waveform(m_info);
+			m_waveform = new Waveform(m_info, _instanceId);
 			m_waveform.WaveformStyle = WaveformStyle.Full;
 			m_waveform.BorderStyle = BorderStyle.FixedSingle;
 			m_waveform.Audio = audio;
@@ -113,6 +116,8 @@ namespace VixenModules.Analysis.BeatsAndBars
 
 		private void _DisposePreviewWaveform()
 		{
+			TimeLineGlobalEventManager.CloseManager(_instanceId);
+			TimeLineGlobalStateManager.CloseManager(_instanceId);
 			if (m_waveform != null)
 			{
 				m_waveform.Paint += PreviewWaveform_Paint;

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Grid.Designer.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Grid.Designer.cs
@@ -28,7 +28,7 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.timelineControl = new Common.Controls.Timeline.TimelineControl();
+			this.timelineControl = new Common.Controls.Timeline.TimelineControl(InstanceId);
 			this.SuspendLayout();
 			// 
 			// timelineControl

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Grid.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Grid.cs
@@ -4,10 +4,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 {
 	public partial class Form_Grid : DockContent
 	{
-		public Form_Grid()
+		public Form_Grid(Guid id)
 		{
+			InstanceId = id;
 			InitializeComponent();
 		}
+
+		protected Guid InstanceId { get; init; }
 
 		public Common.Controls.Timeline.TimelineControl TimelineControl 
 		{ 

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -224,8 +224,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			_autoSaveTimer.Tick += AutoSaveEventProcessor;
 
 			//So we can be aware of mark changes.
-			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager;
-			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager;
+			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(InstanceId);
+			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager(InstanceId);
 		}
 
 		private IDockContent DockingPanels_GetContentFromPersistString(string persistString)
@@ -804,6 +804,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				_sequence = null;
 			}
 
+			TimeLineGlobalEventManager.CloseManager(InstanceId);
+			TimeLineGlobalStateManager.CloseManager(InstanceId);
+
 			dockPanel.Dispose();
 
 			base.Dispose(disposing);
@@ -1100,7 +1103,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		private Form_Grid GridForm
 		{
-			get { return _gridForm ?? (_gridForm = new Form_Grid()); }
+			get { return _gridForm ?? (_gridForm = new Form_Grid(InstanceId)); }
 		}
 
 		internal TimelineControl TimelineControl
@@ -4789,6 +4792,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		#region Overridden form functions (On___)
 
 		public bool IgnoreKeyDownEvents { get; set; }
+
+		public Guid InstanceId { get; set; } = Guid.NewGuid();
 
 		protected override void OnFormClosed(FormClosedEventArgs e)
 		{


### PR DESCRIPTION
* Modify the global event handlers to accept an id so they can maintain multiple versions for each editor that requests to use it.
* Modify the sequence editor to have a unique id that can be used to request a per editor event manager.
* Modify the child components that require use of the event managers to accept the parent id so they can request the proper event manager.