### PR TITLE
VIX-3437 Add null checking on context release.

### DIFF
--- a/src/Vixen.Core/Sys/Managers/ContextManager.cs
+++ b/src/Vixen.Core/Sys/Managers/ContextManager.cs
@@ -87,6 +87,7 @@ namespace Vixen.Sys.Managers
 
 		public void ReleaseContext(IContext context)
 		{
+			if (context == null) return;
 			if (_instances.ContainsKey(context.Id)) {
 				_ReleaseContext(context);
 			}


### PR DESCRIPTION
* Looks like the the editor was closing and the context may have already been released.