### PR TITLE
VIX-3405 Fix improper tool tips in the Shapes effect

### DIFF
--- a/src/Vixen.Modules/Effect/Shapes/Shapes.cs
+++ b/src/Vixen.Modules/Effect/Shapes/Shapes.cs
@@ -107,8 +107,8 @@ namespace VixenModules.Effect.Shapes
 
 		[Value]
 		[ProviderCategory(@"Config", 1)]
-		[ProviderDisplayName(@"Mark Collection")]
-		[ProviderDescription(@"Mark Collection that has the phonemes to align to.")]
+		[ProviderDisplayName(@"MarkCollection")]
+		[ProviderDescription(@"MarkCollectionMarks")]
 		[TypeConverter(typeof(IMarkCollectionNameConverter))]
 		[PropertyEditor("SelectionEditor")]
 		[PropertyOrder(1)]

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -460,7 +460,7 @@
     <value>Changes direction of effect.</value>
   </data>
   <data name="Movement" xml:space="preserve">
-    <value>Controls variance of the motion over time.</value>
+    <value>Controls motion over time.</value>
   </data>
   <data name="BorderType" xml:space="preserve">
     <value>Enable Single or Independent Border width control.</value>
@@ -718,7 +718,7 @@
     <value>Adjusts the thickness of the shape outline.</value>
   </data>
   <data name="CenterSize" xml:space="preserve">
-    <value>Randomly adjust the Shape size around the Size level by the amount of variation.</value>
+    <value>Core size of the shapes.</value>
   </data>
   <data name="SizeChange" xml:space="preserve">
     <value>Enable increase/decrease of shape size based on size variation.</value>
@@ -1280,5 +1280,11 @@
   </data>
   <data name="TreeIntensity" xml:space="preserve">
     <value>Controls the overall intensity envelope of the entire effect over the duration of the effect.</value>
+  </data>
+  <data name="MarkCollectionMarks" xml:space="preserve">
+    <value>Mark Collection that has the marks to align to.</value>
+  </data>
+  <data name="ShapeFade" xml:space="preserve">
+    <value>Type of Fade applied to each Shape.</value>
   </data>
 </root>

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
@@ -652,7 +652,7 @@
     <value>Cross Size Ratio</value>
   </data>
   <data name="FirstFillColors" xml:space="preserve">
-    <value>Fill Colors 1</value>
+    <value>Fill Colors</value>
   </data>
   <data name="GeometricShapes" xml:space="preserve">
     <value>Geometric Shapes</value>


### PR DESCRIPTION
* Fix the Marks Collection tool tip to use the proper name and description from the resource file.
* Fix the Movement tool tip.
* Add a shape specific fade type tool tip to the resource file.
* Correct the Size setting description.