### PR TITLE
VIX-3448 Fix controller limit

### DIFF
--- a/src/Vixen.Common/Controls/ControllerTree.cs
+++ b/src/Vixen.Common/Controls/ControllerTree.cs
@@ -461,16 +461,17 @@ namespace Common.Controls
 					name = defaultName;
 			}
 
+			ControllerFactory controllerFactory = new ControllerFactory();
+			OutputController oc = (OutputController)controllerFactory.CreateDevice(controllerTypeId, name);
+
 			int outputCount;
-			using (NumberDialog nd = new NumberDialog("Controller Output Count", "Outputs on this controller?", 0)) {
+			using (NumberDialog nd = new NumberDialog("Controller Output Count", "Outputs on this controller?", 1, 1,  oc.OutputLimit)) {
 				if (nd.ShowDialog() != DialogResult.OK)
 					return false;
 
 				outputCount = nd.Value;
 			}
 
-			ControllerFactory controllerFactory = new ControllerFactory();
-			OutputController oc = (OutputController)controllerFactory.CreateDevice(controllerTypeId, name);
 			oc.OutputCount = outputCount;
 			VixenSystem.OutputControllers.Add(oc);
 

--- a/src/Vixen.Core/Module/Controller/ControllerModuleInstanceBase.cs
+++ b/src/Vixen.Core/Module/Controller/ControllerModuleInstanceBase.cs
@@ -47,6 +47,8 @@ namespace Vixen.Module.Controller
 
 		public virtual int OutputCount { get; set; }
 
+		public virtual int OutputLimit { get; } = Int32.MaxValue;
+
 		#region Equality
 
 		public bool Equals(IControllerModuleInstance x, IControllerModuleInstance y)

--- a/src/Vixen.Core/Module/SmartController/SmartControllerModuleInstanceBase.cs
+++ b/src/Vixen.Core/Module/SmartController/SmartControllerModuleInstanceBase.cs
@@ -13,6 +13,13 @@ namespace Vixen.Module.SmartController
 
 		public abstract int OutputCount { get; set; }
 
+		#region Implementation of IUpdatableOutputCount
+
+		/// <inheritdoc />
+		public abstract int OutputLimit { get; }
+
+		#endregion
+
 		#region Equality
 
 		public bool Equals(ISmartControllerModuleInstance x, ISmartControllerModuleInstance y)

--- a/src/Vixen.Core/Sys/Output/IUpdatableOutputCount.cs
+++ b/src/Vixen.Core/Sys/Output/IUpdatableOutputCount.cs
@@ -3,5 +3,7 @@
 	public interface IUpdatableOutputCount
 	{
 		int OutputCount { get; set; }
+
+		int OutputLimit { get; }
 	}
 }

--- a/src/Vixen.Core/Sys/Output/OutputController.cs
+++ b/src/Vixen.Core/Sys/Output/OutputController.cs
@@ -222,6 +222,13 @@ namespace Vixen.Sys.Output
 			return _outputModuleConsumer.Setup();
 		}
 
+		#region Implementation of IHasOutputs
+
+		/// <inheritdoc />
+		public virtual int OutputLimit => ControllerModule.OutputLimit;
+
+		#endregion
+
 		public int OutputCount
 		{
 			get { return _outputMediator.OutputCount; }

--- a/src/Vixen.Modules/Controller/OpenDMX/OpenDMXInstance.cs
+++ b/src/Vixen.Modules/Controller/OpenDMX/OpenDMXInstance.cs
@@ -17,6 +17,13 @@ namespace VixenModules.Controller.OpenDMX
 			DataPolicyFactory = new DataPolicyFactory();
 		}
 
+		#region Overrides of ControllerModuleInstanceBase
+
+		/// <inheritdoc />
+		public override int OutputLimit => 512;
+
+		#endregion
+
 		public override int OutputCount
 		{
 			get { return _outputCount; }


### PR DESCRIPTION
* Add logic to allow controller instances to set an output limit they support.
* Add logic to pass the controller limit to the input dialog to constrain the input limit.
* Set default channel count to 1 instead of 0.