### PR TITLE
VIX-3339 Add ability to align effects to mark start and end time

### DIFF
--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.Designer.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.Designer.cs
@@ -28,390 +28,405 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.label1 = new System.Windows.Forms.Label();
-			this.label2 = new System.Windows.Forms.Label();
-			this.label3 = new System.Windows.Forms.Label();
-			this.label4 = new System.Windows.Forms.Label();
-			this.btnOK = new System.Windows.Forms.Button();
-			this.btnCancel = new System.Windows.Forms.Button();
-			this.txtStartTime = new System.Windows.Forms.MaskedTextBox();
-			this.txtDuration = new System.Windows.Forms.MaskedTextBox();
-			this.txtDurationBetween = new System.Windows.Forms.MaskedTextBox();
-			this.toolTip = new System.Windows.Forms.ToolTip();
-			this.txtEffectCount = new System.Windows.Forms.NumericUpDown();
-			this.lblPossibleEffects = new System.Windows.Forms.Label();
-			this.listBoxMarkCollections = new System.Windows.Forms.ListView();
-			this.checkBoxAlignToBeatMarks = new System.Windows.Forms.CheckBox();
-			this.checkBoxFillDuration = new System.Windows.Forms.CheckBox();
-			this.checkBoxSelectEffects = new System.Windows.Forms.CheckBox();
-			this.btnShowBeatMarkOptions = new System.Windows.Forms.Button();
-			this.lblShowBeatMarkOptions = new System.Windows.Forms.Label();
-			this.btnHideBeatMarkOptions = new System.Windows.Forms.Button();
-			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-			this.panelMain = new System.Windows.Forms.Panel();
-			this.lblEndingTime = new System.Windows.Forms.Label();
-			this.txtEndTime = new System.Windows.Forms.MaskedTextBox();
-			this.panelBeatAlignment = new System.Windows.Forms.Panel();
-			this.checkBoxSkipEOBeat = new System.Windows.Forms.CheckBox();
-			this.panelOKCancel = new System.Windows.Forms.Panel();
-			((System.ComponentModel.ISupportInitialize)(this.txtEffectCount)).BeginInit();
-			this.flowLayoutPanel1.SuspendLayout();
-			this.panelMain.SuspendLayout();
-			this.panelBeatAlignment.SuspendLayout();
-			this.panelOKCancel.SuspendLayout();
-			this.SuspendLayout();
+			components = new System.ComponentModel.Container();
+			label1 = new Label();
+			label2 = new Label();
+			label3 = new Label();
+			label4 = new Label();
+			btnOK = new Button();
+			btnCancel = new Button();
+			txtStartTime = new MaskedTextBox();
+			txtDuration = new MaskedTextBox();
+			txtDurationBetween = new MaskedTextBox();
+			toolTip = new ToolTip(components);
+			txtEffectCount = new NumericUpDown();
+			lblPossibleEffects = new Label();
+			listBoxMarkCollections = new ListView();
+			checkBoxAlignToBeatMarks = new CheckBox();
+			checkBoxFillDuration = new CheckBox();
+			checkBoxSelectEffects = new CheckBox();
+			btnShowBeatMarkOptions = new Button();
+			lblShowBeatMarkOptions = new Label();
+			btnHideBeatMarkOptions = new Button();
+			flowLayoutPanel1 = new FlowLayoutPanel();
+			panelMain = new Panel();
+			lblEndingTime = new Label();
+			txtEndTime = new MaskedTextBox();
+			panelBeatAlignment = new Panel();
+			chkUseMarkStartEnd = new CheckBox();
+			checkBoxSkipEOBeat = new CheckBox();
+			panelOKCancel = new Panel();
+			((System.ComponentModel.ISupportInitialize)txtEffectCount).BeginInit();
+			flowLayoutPanel1.SuspendLayout();
+			panelMain.SuspendLayout();
+			panelBeatAlignment.SuspendLayout();
+			panelOKCancel.SuspendLayout();
+			SuspendLayout();
 			// 
 			// label1
 			// 
-			this.label1.AutoSize = true;
-			this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.label1.Location = new System.Drawing.Point(17, 45);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(140, 15);
-			this.label1.TabIndex = 0;
-			this.label1.Text = "Number of effects to add";
+			label1.AutoSize = true;
+			label1.ForeColor = Color.FromArgb(221, 221, 221);
+			label1.Location = new Point(17, 45);
+			label1.Name = "label1";
+			label1.Size = new Size(140, 15);
+			label1.TabIndex = 0;
+			label1.Text = "Number of effects to add";
 			// 
 			// label2
 			// 
-			this.label2.AutoSize = true;
-			this.label2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.label2.Location = new System.Drawing.Point(17, 75);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(75, 15);
-			this.label2.TabIndex = 2;
-			this.label2.Text = "Starting time";
+			label2.AutoSize = true;
+			label2.ForeColor = Color.FromArgb(221, 221, 221);
+			label2.Location = new Point(17, 75);
+			label2.Name = "label2";
+			label2.Size = new Size(75, 15);
+			label2.TabIndex = 2;
+			label2.Text = "Starting time";
 			// 
 			// label3
 			// 
-			this.label3.AutoSize = true;
-			this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.label3.Location = new System.Drawing.Point(17, 135);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(53, 15);
-			this.label3.TabIndex = 4;
-			this.label3.Text = "Duration";
+			label3.AutoSize = true;
+			label3.ForeColor = Color.FromArgb(221, 221, 221);
+			label3.Location = new Point(17, 135);
+			label3.Name = "label3";
+			label3.Size = new Size(53, 15);
+			label3.TabIndex = 4;
+			label3.Text = "Duration";
 			// 
 			// label4
 			// 
-			this.label4.AutoSize = true;
-			this.label4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.label4.Location = new System.Drawing.Point(17, 165);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(101, 15);
-			this.label4.TabIndex = 6;
-			this.label4.Text = "Duration between";
+			label4.AutoSize = true;
+			label4.ForeColor = Color.FromArgb(221, 221, 221);
+			label4.Location = new Point(17, 165);
+			label4.Name = "label4";
+			label4.Size = new Size(101, 15);
+			label4.TabIndex = 6;
+			label4.Text = "Duration between";
 			// 
 			// btnOK
 			// 
-			this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.btnOK.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-			this.btnOK.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-			this.btnOK.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-			this.btnOK.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-			this.btnOK.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnOK.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.btnOK.Location = new System.Drawing.Point(17, 30);
-			this.btnOK.Name = "btnOK";
-			this.btnOK.Size = new System.Drawing.Size(87, 27);
-			this.btnOK.TabIndex = 13;
-			this.btnOK.Text = "OK";
-			this.btnOK.UseVisualStyleBackColor = true;
-			this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-			this.btnOK.MouseLeave += new System.EventHandler(this.buttonBackground_MouseLeave);
-			this.btnOK.MouseHover += new System.EventHandler(this.buttonBackground_MouseHover);
+			btnOK.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+			btnOK.DialogResult = DialogResult.OK;
+			btnOK.FlatAppearance.BorderColor = Color.Black;
+			btnOK.FlatAppearance.CheckedBackColor = Color.Transparent;
+			btnOK.FlatAppearance.MouseDownBackColor = Color.Transparent;
+			btnOK.FlatAppearance.MouseOverBackColor = Color.Transparent;
+			btnOK.FlatStyle = FlatStyle.Flat;
+			btnOK.ForeColor = Color.FromArgb(221, 221, 221);
+			btnOK.Location = new Point(17, 30);
+			btnOK.Name = "btnOK";
+			btnOK.Size = new Size(87, 27);
+			btnOK.TabIndex = 13;
+			btnOK.Text = "OK";
+			btnOK.UseVisualStyleBackColor = true;
+			btnOK.Click += btnOK_Click;
+			btnOK.MouseLeave += buttonBackground_MouseLeave;
+			btnOK.MouseHover += buttonBackground_MouseHover;
 			// 
 			// btnCancel
 			// 
-			this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.btnCancel.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-			this.btnCancel.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
-			this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-			this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-			this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnCancel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.btnCancel.Location = new System.Drawing.Point(198, 30);
-			this.btnCancel.Name = "btnCancel";
-			this.btnCancel.Size = new System.Drawing.Size(87, 27);
-			this.btnCancel.TabIndex = 14;
-			this.btnCancel.Text = "Cancel";
-			this.btnCancel.UseVisualStyleBackColor = true;
-			this.btnCancel.MouseLeave += new System.EventHandler(this.buttonBackground_MouseLeave);
-			this.btnCancel.MouseHover += new System.EventHandler(this.buttonBackground_MouseHover);
+			btnCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+			btnCancel.DialogResult = DialogResult.Cancel;
+			btnCancel.FlatAppearance.BorderColor = Color.Black;
+			btnCancel.FlatAppearance.CheckedBackColor = Color.Transparent;
+			btnCancel.FlatAppearance.MouseDownBackColor = Color.Transparent;
+			btnCancel.FlatAppearance.MouseOverBackColor = Color.Transparent;
+			btnCancel.FlatStyle = FlatStyle.Flat;
+			btnCancel.ForeColor = Color.FromArgb(221, 221, 221);
+			btnCancel.Location = new Point(198, 30);
+			btnCancel.Name = "btnCancel";
+			btnCancel.Size = new Size(87, 27);
+			btnCancel.TabIndex = 14;
+			btnCancel.Text = "Cancel";
+			btnCancel.UseVisualStyleBackColor = true;
+			btnCancel.MouseLeave += buttonBackground_MouseLeave;
+			btnCancel.MouseHover += buttonBackground_MouseHover;
 			// 
 			// txtStartTime
 			// 
-			this.txtStartTime.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-			this.txtStartTime.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtStartTime.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.txtStartTime.Location = new System.Drawing.Point(169, 72);
-			this.txtStartTime.Name = "txtStartTime";
-			this.txtStartTime.Size = new System.Drawing.Size(116, 23);
-			this.txtStartTime.TabIndex = 2;
-			this.txtStartTime.MaskInputRejected += new System.Windows.Forms.MaskInputRejectedEventHandler(this.txtStartTime_MaskInputRejected);
-			this.txtStartTime.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtStartTime_KeyDown);
-			this.txtStartTime.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtStartTime_KeyUp);
+			txtStartTime.BackColor = Color.FromArgb(90, 90, 90);
+			txtStartTime.BorderStyle = BorderStyle.FixedSingle;
+			txtStartTime.ForeColor = Color.FromArgb(221, 221, 221);
+			txtStartTime.Location = new Point(169, 72);
+			txtStartTime.Name = "txtStartTime";
+			txtStartTime.Size = new Size(116, 23);
+			txtStartTime.TabIndex = 2;
+			txtStartTime.MaskInputRejected += txtStartTime_MaskInputRejected;
+			txtStartTime.KeyDown += txtStartTime_KeyDown;
+			txtStartTime.KeyUp += txtStartTime_KeyUp;
 			// 
 			// txtDuration
 			// 
-			this.txtDuration.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-			this.txtDuration.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtDuration.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.txtDuration.Location = new System.Drawing.Point(169, 132);
-			this.txtDuration.Name = "txtDuration";
-			this.txtDuration.Size = new System.Drawing.Size(116, 23);
-			this.txtDuration.TabIndex = 4;
-			this.txtDuration.MaskInputRejected += new System.Windows.Forms.MaskInputRejectedEventHandler(this.txtDuration_MaskInputRejected);
-			this.txtDuration.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtDuration_KeyDown);
-			this.txtDuration.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtDuration_KeyUp);
+			txtDuration.BackColor = Color.FromArgb(90, 90, 90);
+			txtDuration.BorderStyle = BorderStyle.FixedSingle;
+			txtDuration.ForeColor = Color.FromArgb(221, 221, 221);
+			txtDuration.Location = new Point(169, 132);
+			txtDuration.Name = "txtDuration";
+			txtDuration.Size = new Size(116, 23);
+			txtDuration.TabIndex = 4;
+			txtDuration.MaskInputRejected += txtDuration_MaskInputRejected;
+			txtDuration.KeyDown += txtDuration_KeyDown;
+			txtDuration.KeyUp += txtDuration_KeyUp;
 			// 
 			// txtDurationBetween
 			// 
-			this.txtDurationBetween.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-			this.txtDurationBetween.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtDurationBetween.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.txtDurationBetween.Location = new System.Drawing.Point(169, 162);
-			this.txtDurationBetween.Name = "txtDurationBetween";
-			this.txtDurationBetween.Size = new System.Drawing.Size(116, 23);
-			this.txtDurationBetween.TabIndex = 5;
-			this.txtDurationBetween.MaskInputRejected += new System.Windows.Forms.MaskInputRejectedEventHandler(this.txtDurationBetween_MaskInputRejected);
-			this.txtDurationBetween.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtDurationBetween_KeyDown);
-			this.txtDurationBetween.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtDurationBetween_KeyUp);
+			txtDurationBetween.BackColor = Color.FromArgb(90, 90, 90);
+			txtDurationBetween.BorderStyle = BorderStyle.FixedSingle;
+			txtDurationBetween.ForeColor = Color.FromArgb(221, 221, 221);
+			txtDurationBetween.Location = new Point(169, 162);
+			txtDurationBetween.Name = "txtDurationBetween";
+			txtDurationBetween.Size = new Size(116, 23);
+			txtDurationBetween.TabIndex = 5;
+			txtDurationBetween.MaskInputRejected += txtDurationBetween_MaskInputRejected;
+			txtDurationBetween.KeyDown += txtDurationBetween_KeyDown;
+			txtDurationBetween.KeyUp += txtDurationBetween_KeyUp;
 			// 
 			// txtEffectCount
 			// 
-			this.txtEffectCount.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-			this.txtEffectCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtEffectCount.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.txtEffectCount.Location = new System.Drawing.Point(169, 42);
-			this.txtEffectCount.Name = "txtEffectCount";
-			this.txtEffectCount.Size = new System.Drawing.Size(117, 23);
-			this.txtEffectCount.TabIndex = 1;
+			txtEffectCount.BackColor = Color.FromArgb(90, 90, 90);
+			txtEffectCount.BorderStyle = BorderStyle.FixedSingle;
+			txtEffectCount.ForeColor = Color.FromArgb(221, 221, 221);
+			txtEffectCount.Location = new Point(169, 42);
+			txtEffectCount.Name = "txtEffectCount";
+			txtEffectCount.Size = new Size(117, 23);
+			txtEffectCount.TabIndex = 1;
 			// 
 			// lblPossibleEffects
 			// 
-			this.lblPossibleEffects.AutoSize = true;
-			this.lblPossibleEffects.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.lblPossibleEffects.Location = new System.Drawing.Point(89, 10);
-			this.lblPossibleEffects.Name = "lblPossibleEffects";
-			this.lblPossibleEffects.Size = new System.Drawing.Size(101, 15);
-			this.lblPossibleEffects.TabIndex = 15;
-			this.lblPossibleEffects.Text = "n effects possible.";
-			this.lblPossibleEffects.DoubleClick += new System.EventHandler(this.lblPossibleEffects_DoubleClick);
+			lblPossibleEffects.AutoSize = true;
+			lblPossibleEffects.ForeColor = Color.FromArgb(221, 221, 221);
+			lblPossibleEffects.Location = new Point(89, 10);
+			lblPossibleEffects.Name = "lblPossibleEffects";
+			lblPossibleEffects.Size = new Size(101, 15);
+			lblPossibleEffects.TabIndex = 15;
+			lblPossibleEffects.Text = "n effects possible.";
+			lblPossibleEffects.DoubleClick += lblPossibleEffects_DoubleClick;
 			// 
 			// listBoxMarkCollections
 			// 
-			this.listBoxMarkCollections.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(68)))), ((int)(((byte)(68)))), ((int)(((byte)(68)))));
-			this.listBoxMarkCollections.CheckBoxes = true;
-			this.listBoxMarkCollections.Enabled = false;
-			this.listBoxMarkCollections.Location = new System.Drawing.Point(21, 83);
-			this.listBoxMarkCollections.Name = "listBoxMarkCollections";
-			this.listBoxMarkCollections.Size = new System.Drawing.Size(250, 137);
-			this.listBoxMarkCollections.TabIndex = 10;
-			this.listBoxMarkCollections.UseCompatibleStateImageBehavior = false;
-			this.listBoxMarkCollections.View = System.Windows.Forms.View.List;
-			this.listBoxMarkCollections.Visible = false;
-			this.listBoxMarkCollections.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.listBoxMarkCollections_ItemChecked);
+			listBoxMarkCollections.BackColor = Color.FromArgb(68, 68, 68);
+			listBoxMarkCollections.CheckBoxes = true;
+			listBoxMarkCollections.Enabled = false;
+			listBoxMarkCollections.Location = new Point(17, 118);
+			listBoxMarkCollections.Name = "listBoxMarkCollections";
+			listBoxMarkCollections.Size = new Size(268, 111);
+			listBoxMarkCollections.TabIndex = 10;
+			listBoxMarkCollections.UseCompatibleStateImageBehavior = false;
+			listBoxMarkCollections.View = View.List;
+			listBoxMarkCollections.Visible = false;
+			listBoxMarkCollections.ItemChecked += listBoxMarkCollections_ItemChecked;
 			// 
 			// checkBoxAlignToBeatMarks
 			// 
-			this.checkBoxAlignToBeatMarks.AutoSize = true;
-			this.checkBoxAlignToBeatMarks.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.checkBoxAlignToBeatMarks.Location = new System.Drawing.Point(21, 3);
-			this.checkBoxAlignToBeatMarks.Name = "checkBoxAlignToBeatMarks";
-			this.checkBoxAlignToBeatMarks.Size = new System.Drawing.Size(129, 19);
-			this.checkBoxAlignToBeatMarks.TabIndex = 7;
-			this.checkBoxAlignToBeatMarks.Text = "Align to beat marks";
-			this.checkBoxAlignToBeatMarks.UseVisualStyleBackColor = true;
-			this.checkBoxAlignToBeatMarks.CheckedChanged += new System.EventHandler(this.checkBoxAlignToBeatMarks_CheckStateChanged);
+			checkBoxAlignToBeatMarks.AutoSize = true;
+			checkBoxAlignToBeatMarks.ForeColor = Color.FromArgb(221, 221, 221);
+			checkBoxAlignToBeatMarks.Location = new Point(21, 3);
+			checkBoxAlignToBeatMarks.Name = "checkBoxAlignToBeatMarks";
+			checkBoxAlignToBeatMarks.Size = new Size(129, 19);
+			checkBoxAlignToBeatMarks.TabIndex = 7;
+			checkBoxAlignToBeatMarks.Text = "Align to beat marks";
+			checkBoxAlignToBeatMarks.UseVisualStyleBackColor = true;
+			checkBoxAlignToBeatMarks.CheckedChanged += checkBoxAlignToBeatMarks_CheckStateChanged;
 			// 
 			// checkBoxFillDuration
 			// 
-			this.checkBoxFillDuration.AutoCheck = false;
-			this.checkBoxFillDuration.AutoSize = true;
-			this.checkBoxFillDuration.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.checkBoxFillDuration.Location = new System.Drawing.Point(21, 57);
-			this.checkBoxFillDuration.Name = "checkBoxFillDuration";
-			this.checkBoxFillDuration.Size = new System.Drawing.Size(172, 19);
-			this.checkBoxFillDuration.TabIndex = 9;
-			this.checkBoxFillDuration.Text = "Fill duration between marks";
-			this.checkBoxFillDuration.UseVisualStyleBackColor = true;
-			this.checkBoxFillDuration.CheckedChanged += new System.EventHandler(this.checkBoxFillDuration_CheckStateChanged);
+			checkBoxFillDuration.AutoCheck = false;
+			checkBoxFillDuration.AutoSize = true;
+			checkBoxFillDuration.ForeColor = Color.FromArgb(221, 221, 221);
+			checkBoxFillDuration.Location = new Point(21, 57);
+			checkBoxFillDuration.Name = "checkBoxFillDuration";
+			checkBoxFillDuration.Size = new Size(172, 19);
+			checkBoxFillDuration.TabIndex = 9;
+			checkBoxFillDuration.Text = "Fill duration between marks";
+			checkBoxFillDuration.UseVisualStyleBackColor = true;
+			checkBoxFillDuration.CheckedChanged += checkBoxFillDuration_CheckStateChanged;
 			// 
 			// checkBoxSelectEffects
 			// 
-			this.checkBoxSelectEffects.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.checkBoxSelectEffects.AutoSize = true;
-			this.checkBoxSelectEffects.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.checkBoxSelectEffects.Location = new System.Drawing.Point(21, 4);
-			this.checkBoxSelectEffects.Name = "checkBoxSelectEffects";
-			this.checkBoxSelectEffects.Size = new System.Drawing.Size(126, 19);
-			this.checkBoxSelectEffects.TabIndex = 11;
-			this.checkBoxSelectEffects.Text = "Select / Edit effects";
-			this.checkBoxSelectEffects.UseVisualStyleBackColor = true;
+			checkBoxSelectEffects.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+			checkBoxSelectEffects.AutoSize = true;
+			checkBoxSelectEffects.ForeColor = Color.FromArgb(221, 221, 221);
+			checkBoxSelectEffects.Location = new Point(21, 4);
+			checkBoxSelectEffects.Name = "checkBoxSelectEffects";
+			checkBoxSelectEffects.Size = new Size(126, 19);
+			checkBoxSelectEffects.TabIndex = 11;
+			checkBoxSelectEffects.Text = "Select / Edit effects";
+			checkBoxSelectEffects.UseVisualStyleBackColor = true;
 			// 
 			// btnShowBeatMarkOptions
 			// 
-			this.btnShowBeatMarkOptions.FlatAppearance.BorderSize = 0;
-			this.btnShowBeatMarkOptions.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-			this.btnShowBeatMarkOptions.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-			this.btnShowBeatMarkOptions.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnShowBeatMarkOptions.Location = new System.Drawing.Point(17, 192);
-			this.btnShowBeatMarkOptions.Name = "btnShowBeatMarkOptions";
-			this.btnShowBeatMarkOptions.Size = new System.Drawing.Size(28, 27);
-			this.btnShowBeatMarkOptions.TabIndex = 21;
-			this.btnShowBeatMarkOptions.Text = "+";
-			this.btnShowBeatMarkOptions.UseVisualStyleBackColor = true;
-			this.btnShowBeatMarkOptions.Click += new System.EventHandler(this.btnShowBeatMarkOptions_Click);
+			btnShowBeatMarkOptions.FlatAppearance.BorderSize = 0;
+			btnShowBeatMarkOptions.FlatAppearance.MouseDownBackColor = Color.Transparent;
+			btnShowBeatMarkOptions.FlatAppearance.MouseOverBackColor = Color.Transparent;
+			btnShowBeatMarkOptions.FlatStyle = FlatStyle.Flat;
+			btnShowBeatMarkOptions.Location = new Point(17, 192);
+			btnShowBeatMarkOptions.Name = "btnShowBeatMarkOptions";
+			btnShowBeatMarkOptions.Size = new Size(28, 27);
+			btnShowBeatMarkOptions.TabIndex = 21;
+			btnShowBeatMarkOptions.Text = "+";
+			btnShowBeatMarkOptions.UseVisualStyleBackColor = true;
+			btnShowBeatMarkOptions.Click += btnShowBeatMarkOptions_Click;
 			// 
 			// lblShowBeatMarkOptions
 			// 
-			this.lblShowBeatMarkOptions.AutoSize = true;
-			this.lblShowBeatMarkOptions.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.lblShowBeatMarkOptions.Location = new System.Drawing.Point(52, 197);
-			this.lblShowBeatMarkOptions.Name = "lblShowBeatMarkOptions";
-			this.lblShowBeatMarkOptions.Size = new System.Drawing.Size(192, 15);
-			this.lblShowBeatMarkOptions.TabIndex = 22;
-			this.lblShowBeatMarkOptions.Text = "Show beat mark alignment options";
+			lblShowBeatMarkOptions.AutoSize = true;
+			lblShowBeatMarkOptions.ForeColor = Color.FromArgb(221, 221, 221);
+			lblShowBeatMarkOptions.Location = new Point(52, 197);
+			lblShowBeatMarkOptions.Name = "lblShowBeatMarkOptions";
+			lblShowBeatMarkOptions.Size = new Size(192, 15);
+			lblShowBeatMarkOptions.TabIndex = 22;
+			lblShowBeatMarkOptions.Text = "Show beat mark alignment options";
 			// 
 			// btnHideBeatMarkOptions
 			// 
-			this.btnHideBeatMarkOptions.FlatAppearance.BorderSize = 0;
-			this.btnHideBeatMarkOptions.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Transparent;
-			this.btnHideBeatMarkOptions.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Transparent;
-			this.btnHideBeatMarkOptions.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.btnHideBeatMarkOptions.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.btnHideBeatMarkOptions.Location = new System.Drawing.Point(17, 192);
-			this.btnHideBeatMarkOptions.Name = "btnHideBeatMarkOptions";
-			this.btnHideBeatMarkOptions.Size = new System.Drawing.Size(28, 27);
-			this.btnHideBeatMarkOptions.TabIndex = 6;
-			this.btnHideBeatMarkOptions.Text = "+";
-			this.btnHideBeatMarkOptions.UseVisualStyleBackColor = true;
-			this.btnHideBeatMarkOptions.Visible = false;
-			this.btnHideBeatMarkOptions.Click += new System.EventHandler(this.btnHideBeatMarkOptions_Click);
+			btnHideBeatMarkOptions.FlatAppearance.BorderSize = 0;
+			btnHideBeatMarkOptions.FlatAppearance.MouseDownBackColor = Color.Transparent;
+			btnHideBeatMarkOptions.FlatAppearance.MouseOverBackColor = Color.Transparent;
+			btnHideBeatMarkOptions.FlatStyle = FlatStyle.Flat;
+			btnHideBeatMarkOptions.ForeColor = Color.FromArgb(221, 221, 221);
+			btnHideBeatMarkOptions.Location = new Point(17, 192);
+			btnHideBeatMarkOptions.Name = "btnHideBeatMarkOptions";
+			btnHideBeatMarkOptions.Size = new Size(28, 27);
+			btnHideBeatMarkOptions.TabIndex = 6;
+			btnHideBeatMarkOptions.Text = "+";
+			btnHideBeatMarkOptions.UseVisualStyleBackColor = true;
+			btnHideBeatMarkOptions.Visible = false;
+			btnHideBeatMarkOptions.Click += btnHideBeatMarkOptions_Click;
 			// 
 			// flowLayoutPanel1
 			// 
-			this.flowLayoutPanel1.AutoSize = true;
-			this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.flowLayoutPanel1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-			this.flowLayoutPanel1.Controls.Add(this.panelMain);
-			this.flowLayoutPanel1.Controls.Add(this.panelBeatAlignment);
-			this.flowLayoutPanel1.Controls.Add(this.panelOKCancel);
-			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-			this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-			this.flowLayoutPanel1.Size = new System.Drawing.Size(321, 542);
-			this.flowLayoutPanel1.TabIndex = 25;
+			flowLayoutPanel1.AutoSize = true;
+			flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+			flowLayoutPanel1.BorderStyle = BorderStyle.Fixed3D;
+			flowLayoutPanel1.Controls.Add(panelMain);
+			flowLayoutPanel1.Controls.Add(panelBeatAlignment);
+			flowLayoutPanel1.Controls.Add(panelOKCancel);
+			flowLayoutPanel1.Dock = DockStyle.Fill;
+			flowLayoutPanel1.FlowDirection = FlowDirection.TopDown;
+			flowLayoutPanel1.Location = new Point(0, 0);
+			flowLayoutPanel1.Name = "flowLayoutPanel1";
+			flowLayoutPanel1.Size = new Size(321, 557);
+			flowLayoutPanel1.TabIndex = 25;
 			// 
 			// panelMain
 			// 
-			this.panelMain.Controls.Add(this.lblEndingTime);
-			this.panelMain.Controls.Add(this.txtEndTime);
-			this.panelMain.Controls.Add(this.label1);
-			this.panelMain.Controls.Add(this.label2);
-			this.panelMain.Controls.Add(this.btnHideBeatMarkOptions);
-			this.panelMain.Controls.Add(this.label3);
-			this.panelMain.Controls.Add(this.lblShowBeatMarkOptions);
-			this.panelMain.Controls.Add(this.label4);
-			this.panelMain.Controls.Add(this.btnShowBeatMarkOptions);
-			this.panelMain.Controls.Add(this.txtStartTime);
-			this.panelMain.Controls.Add(this.txtDuration);
-			this.panelMain.Controls.Add(this.txtDurationBetween);
-			this.panelMain.Controls.Add(this.lblPossibleEffects);
-			this.panelMain.Controls.Add(this.txtEffectCount);
-			this.panelMain.Location = new System.Drawing.Point(3, 3);
-			this.panelMain.Name = "panelMain";
-			this.panelMain.Size = new System.Drawing.Size(303, 222);
-			this.panelMain.TabIndex = 0;
+			panelMain.Controls.Add(lblEndingTime);
+			panelMain.Controls.Add(txtEndTime);
+			panelMain.Controls.Add(label1);
+			panelMain.Controls.Add(label2);
+			panelMain.Controls.Add(btnHideBeatMarkOptions);
+			panelMain.Controls.Add(label3);
+			panelMain.Controls.Add(lblShowBeatMarkOptions);
+			panelMain.Controls.Add(label4);
+			panelMain.Controls.Add(btnShowBeatMarkOptions);
+			panelMain.Controls.Add(txtStartTime);
+			panelMain.Controls.Add(txtDuration);
+			panelMain.Controls.Add(txtDurationBetween);
+			panelMain.Controls.Add(lblPossibleEffects);
+			panelMain.Controls.Add(txtEffectCount);
+			panelMain.Location = new Point(3, 3);
+			panelMain.Name = "panelMain";
+			panelMain.Size = new Size(303, 222);
+			panelMain.TabIndex = 0;
 			// 
 			// lblEndingTime
 			// 
-			this.lblEndingTime.AutoSize = true;
-			this.lblEndingTime.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.lblEndingTime.Location = new System.Drawing.Point(17, 105);
-			this.lblEndingTime.Name = "lblEndingTime";
-			this.lblEndingTime.Size = new System.Drawing.Size(71, 15);
-			this.lblEndingTime.TabIndex = 24;
-			this.lblEndingTime.Text = "Ending time";
+			lblEndingTime.AutoSize = true;
+			lblEndingTime.ForeColor = Color.FromArgb(221, 221, 221);
+			lblEndingTime.Location = new Point(17, 105);
+			lblEndingTime.Name = "lblEndingTime";
+			lblEndingTime.Size = new Size(71, 15);
+			lblEndingTime.TabIndex = 24;
+			lblEndingTime.Text = "Ending time";
 			// 
 			// txtEndTime
 			// 
-			this.txtEndTime.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
-			this.txtEndTime.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtEndTime.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.txtEndTime.Location = new System.Drawing.Point(169, 102);
-			this.txtEndTime.Name = "txtEndTime";
-			this.txtEndTime.Size = new System.Drawing.Size(116, 23);
-			this.txtEndTime.TabIndex = 3;
-			this.txtEndTime.MaskInputRejected += new System.Windows.Forms.MaskInputRejectedEventHandler(this.txtEndTime_MaskInputRejected);
-			this.txtEndTime.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtEndTime_KeyDown);
-			this.txtEndTime.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtEndTime_KeyUp);
+			txtEndTime.BackColor = Color.FromArgb(90, 90, 90);
+			txtEndTime.BorderStyle = BorderStyle.FixedSingle;
+			txtEndTime.ForeColor = Color.FromArgb(221, 221, 221);
+			txtEndTime.Location = new Point(169, 102);
+			txtEndTime.Name = "txtEndTime";
+			txtEndTime.Size = new Size(116, 23);
+			txtEndTime.TabIndex = 3;
+			txtEndTime.MaskInputRejected += txtEndTime_MaskInputRejected;
+			txtEndTime.KeyDown += txtEndTime_KeyDown;
+			txtEndTime.KeyUp += txtEndTime_KeyUp;
 			// 
 			// panelBeatAlignment
 			// 
-			this.panelBeatAlignment.Controls.Add(this.checkBoxSkipEOBeat);
-			this.panelBeatAlignment.Controls.Add(this.checkBoxAlignToBeatMarks);
-			this.panelBeatAlignment.Controls.Add(this.checkBoxFillDuration);
-			this.panelBeatAlignment.Controls.Add(this.listBoxMarkCollections);
-			this.panelBeatAlignment.Location = new System.Drawing.Point(3, 231);
-			this.panelBeatAlignment.Name = "panelBeatAlignment";
-			this.panelBeatAlignment.Size = new System.Drawing.Size(303, 224);
-			this.panelBeatAlignment.TabIndex = 1;
+			panelBeatAlignment.Controls.Add(chkUseMarkStartEnd);
+			panelBeatAlignment.Controls.Add(checkBoxSkipEOBeat);
+			panelBeatAlignment.Controls.Add(checkBoxAlignToBeatMarks);
+			panelBeatAlignment.Controls.Add(checkBoxFillDuration);
+			panelBeatAlignment.Controls.Add(listBoxMarkCollections);
+			panelBeatAlignment.Location = new Point(3, 231);
+			panelBeatAlignment.Name = "panelBeatAlignment";
+			panelBeatAlignment.Size = new Size(303, 238);
+			panelBeatAlignment.TabIndex = 1;
+			// 
+			// chkUseMarkStartEnd
+			// 
+			chkUseMarkStartEnd.AutoCheck = false;
+			chkUseMarkStartEnd.AutoSize = true;
+			chkUseMarkStartEnd.ForeColor = Color.FromArgb(221, 221, 221);
+			chkUseMarkStartEnd.Location = new Point(21, 82);
+			chkUseMarkStartEnd.Name = "chkUseMarkStartEnd";
+			chkUseMarkStartEnd.Size = new Size(155, 19);
+			chkUseMarkStartEnd.TabIndex = 11;
+			chkUseMarkStartEnd.Text = "Align to mark start / end";
+			chkUseMarkStartEnd.UseVisualStyleBackColor = true;
+			chkUseMarkStartEnd.CheckStateChanged += chkUseMarkStartEnd_CheckStateChanged;
 			// 
 			// checkBoxSkipEOBeat
 			// 
-			this.checkBoxSkipEOBeat.AutoCheck = false;
-			this.checkBoxSkipEOBeat.AutoSize = true;
-			this.checkBoxSkipEOBeat.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(221)))), ((int)(((byte)(221)))));
-			this.checkBoxSkipEOBeat.Location = new System.Drawing.Point(21, 30);
-			this.checkBoxSkipEOBeat.Name = "checkBoxSkipEOBeat";
-			this.checkBoxSkipEOBeat.Size = new System.Drawing.Size(136, 19);
-			this.checkBoxSkipEOBeat.TabIndex = 8;
-			this.checkBoxSkipEOBeat.Text = "Skip every other beat";
-			this.checkBoxSkipEOBeat.UseVisualStyleBackColor = true;
-			this.checkBoxSkipEOBeat.CheckedChanged += new System.EventHandler(this.checkBoxSkipEOBeat_CheckedChanged);
+			checkBoxSkipEOBeat.AutoCheck = false;
+			checkBoxSkipEOBeat.AutoSize = true;
+			checkBoxSkipEOBeat.ForeColor = Color.FromArgb(221, 221, 221);
+			checkBoxSkipEOBeat.Location = new Point(21, 30);
+			checkBoxSkipEOBeat.Name = "checkBoxSkipEOBeat";
+			checkBoxSkipEOBeat.Size = new Size(136, 19);
+			checkBoxSkipEOBeat.TabIndex = 8;
+			checkBoxSkipEOBeat.Text = "Skip every other beat";
+			checkBoxSkipEOBeat.UseVisualStyleBackColor = true;
+			checkBoxSkipEOBeat.CheckedChanged += checkBoxSkipEOBeat_CheckedChanged;
 			// 
 			// panelOKCancel
 			// 
-			this.panelOKCancel.Controls.Add(this.checkBoxSelectEffects);
-			this.panelOKCancel.Controls.Add(this.btnOK);
-			this.panelOKCancel.Controls.Add(this.btnCancel);
-			this.panelOKCancel.Location = new System.Drawing.Point(3, 461);
-			this.panelOKCancel.Name = "panelOKCancel";
-			this.panelOKCancel.Size = new System.Drawing.Size(303, 66);
-			this.panelOKCancel.TabIndex = 2;
+			panelOKCancel.Controls.Add(checkBoxSelectEffects);
+			panelOKCancel.Controls.Add(btnOK);
+			panelOKCancel.Controls.Add(btnCancel);
+			panelOKCancel.Location = new Point(3, 475);
+			panelOKCancel.Name = "panelOKCancel";
+			panelOKCancel.Size = new Size(303, 66);
+			panelOKCancel.TabIndex = 2;
 			// 
 			// Form_AddMultipleEffects
 			// 
-			this.AcceptButton = this.btnOK;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.AutoSize = true;
-			this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(68)))), ((int)(((byte)(68)))), ((int)(((byte)(68)))));
-			this.CancelButton = this.btnCancel;
-			this.ClientSize = new System.Drawing.Size(321, 542);
-			this.ControlBox = false;
-			this.Controls.Add(this.flowLayoutPanel1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Name = "Form_AddMultipleEffects";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Add Multiple Effects";
-			this.Load += new System.EventHandler(this.Form_AddMultipleEffects_Load);
-			((System.ComponentModel.ISupportInitialize)(this.txtEffectCount)).EndInit();
-			this.flowLayoutPanel1.ResumeLayout(false);
-			this.panelMain.ResumeLayout(false);
-			this.panelMain.PerformLayout();
-			this.panelBeatAlignment.ResumeLayout(false);
-			this.panelBeatAlignment.PerformLayout();
-			this.panelOKCancel.ResumeLayout(false);
-			this.panelOKCancel.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
-
+			AcceptButton = btnOK;
+			AutoScaleDimensions = new SizeF(7F, 15F);
+			AutoScaleMode = AutoScaleMode.Font;
+			AutoSize = true;
+			AutoSizeMode = AutoSizeMode.GrowAndShrink;
+			BackColor = Color.FromArgb(68, 68, 68);
+			CancelButton = btnCancel;
+			ClientSize = new Size(321, 557);
+			ControlBox = false;
+			Controls.Add(flowLayoutPanel1);
+			FormBorderStyle = FormBorderStyle.FixedDialog;
+			Name = "Form_AddMultipleEffects";
+			StartPosition = FormStartPosition.CenterParent;
+			Text = "Add Multiple Effects";
+			Load += Form_AddMultipleEffects_Load;
+			((System.ComponentModel.ISupportInitialize)txtEffectCount).EndInit();
+			flowLayoutPanel1.ResumeLayout(false);
+			panelMain.ResumeLayout(false);
+			panelMain.PerformLayout();
+			panelBeatAlignment.ResumeLayout(false);
+			panelBeatAlignment.PerformLayout();
+			panelOKCancel.ResumeLayout(false);
+			panelOKCancel.PerformLayout();
+			ResumeLayout(false);
+			PerformLayout();
 		}
 
 		#endregion
@@ -442,5 +457,6 @@
 		private System.Windows.Forms.Label lblEndingTime;
 		private System.Windows.Forms.MaskedTextBox txtEndTime;
 		private System.Windows.Forms.CheckBox checkBoxSkipEOBeat;
+		private CheckBox chkUseMarkStartEnd;
 	}
 }

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.cs
@@ -15,13 +15,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		public ListView.CheckedListViewItemCollection CheckedMarks
 		{
-			get	{ return listBoxMarkCollections.CheckedItems; }
+			get { return listBoxMarkCollections.CheckedItems; }
 		}
 
 		public int EffectCount
 		{
-			get	{ return int.Parse(txtEffectCount.Text); }
-			set	{ txtEffectCount.Text = value.ToString(); }
+			get { return int.Parse(txtEffectCount.Text); }
+			set { txtEffectCount.Text = value.ToString(); }
 		}
 
 		public string EffectName
@@ -76,9 +76,11 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		}
 
 		public bool AlignToBeatMarks { get { return checkBoxAlignToBeatMarks.Checked; } }
-		public bool FillDuration { get { return checkBoxFillDuration.Checked; }	}
-		public bool SelectEffects {	get { return checkBoxSelectEffects.Checked; } }
+		public bool FillDuration { get { return checkBoxFillDuration.Checked; } }
+		public bool SelectEffects { get { return checkBoxSelectEffects.Checked; } }
 		public bool SkipEOBeat { get { return checkBoxSkipEOBeat.Checked; } }
+
+		public bool AlignToMarkStartEnd => chkUseMarkStartEnd.Checked;
 
 		#endregion
 
@@ -96,17 +98,20 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			btnShowBeatMarkOptions.Text = "";
 			btnHideBeatMarkOptions.Image = Resources.bullet_toggle_minus;
 			btnHideBeatMarkOptions.Text = "";
+			listBoxMarkCollections.Visible = false;
 			ThemeUpdateControls.UpdateControls(this);
 			panelBeatAlignment.Visible = false;
 		}
 
 		private void Form_AddMultipleEffects_Load(object sender, EventArgs e)
 		{
+			SetCheckboxStates();
 			txtStartTime.Culture = txtEndTime.Culture =
 				txtDuration.Culture = txtDurationBetween.Culture = CultureInfo.InvariantCulture;
 			txtStartTime.Mask = txtEndTime.Mask = txtDuration.Mask = txtDurationBetween.Mask = "0:00.000";
 			PopulateMarksList();
 			CalculatePossibleEffects();
+			//SetCheckboxStates();
 		}
 
 		#endregion
@@ -330,7 +335,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				DialogResult = DialogResult.None;
 			}
 			//Double check for calculations
-			if (!TimeExistsForAddition() && !checkBoxAlignToBeatMarks.Checked && !checkBoxFillDuration.Checked )
+			if (!TimeExistsForAddition() && !checkBoxAlignToBeatMarks.Checked && !checkBoxFillDuration.Checked)
 			{
 				//messageBox Arguments are (Text, Title, No Button Visible, Cancel Button Visible)
 				MessageBoxForm.msgIcon = SystemIcons.Exclamation; //this is used if you want to add a system icon to the message form.
@@ -347,9 +352,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		{
 			txtDurationBetween.Enabled = (checkBoxAlignToBeatMarks.Checked ? false : true);
 			listBoxMarkCollections.Visible = !listBoxMarkCollections.Visible;
-			listBoxMarkCollections.Enabled = checkBoxFillDuration.AutoCheck = checkBoxSkipEOBeat.AutoCheck = checkBoxAlignToBeatMarks.Checked;
-			checkBoxSkipEOBeat.ForeColor = checkBoxAlignToBeatMarks.Checked ? ThemeColorTable.ForeColor : ThemeColorTable.ForeColorDisabled;
-			checkBoxFillDuration.ForeColor = checkBoxAlignToBeatMarks.Checked ? ThemeColorTable.ForeColor : ThemeColorTable.ForeColorDisabled;
+			SetCheckboxStates();
 			if (checkBoxAlignToBeatMarks.Checked)
 			{
 				CalculatePossibleEffectsByBeatMarks();
@@ -373,8 +376,24 @@ namespace VixenModules.Editor.TimedSequenceEditor
 						break;
 					}
 				}
-				
+
 			}
+		}
+
+		private void SetCheckboxStates()
+		{
+			listBoxMarkCollections.Enabled = checkBoxFillDuration.AutoCheck =
+				checkBoxSkipEOBeat.AutoCheck = checkBoxAlignToBeatMarks.Checked;
+			chkUseMarkStartEnd.AutoCheck = checkBoxAlignToBeatMarks.Checked;
+			checkBoxSkipEOBeat.ForeColor = checkBoxAlignToBeatMarks.Checked
+				? ThemeColorTable.ForeColor
+				: ThemeColorTable.ForeColorDisabled;
+			checkBoxFillDuration.ForeColor = checkBoxAlignToBeatMarks.Checked
+				? ThemeColorTable.ForeColor
+				: ThemeColorTable.ForeColorDisabled;
+			chkUseMarkStartEnd.ForeColor = checkBoxAlignToBeatMarks.Checked
+				? ThemeColorTable.ForeColor
+				: ThemeColorTable.ForeColorDisabled;
 		}
 
 		private void checkBoxSkipEOBeat_CheckedChanged(object sender, EventArgs e)
@@ -405,7 +424,35 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		private void checkBoxFillDuration_CheckStateChanged(object sender, EventArgs e)
 		{
+			if (checkBoxFillDuration.Checked)
+			{
+				chkUseMarkStartEnd.AutoCheck = false;
+				chkUseMarkStartEnd.ForeColor = ThemeColorTable.ForeColorDisabled;
+			}
+			else
+			{
+				chkUseMarkStartEnd.AutoCheck = true;
+				chkUseMarkStartEnd.ForeColor = ThemeColorTable.ForeColor;
+			}
+
 			txtDuration.Enabled = (checkBoxFillDuration.Checked ? false : true);
+			CalculatePossibleEffectsByBeatMarks();
+		}
+
+		private void chkUseMarkStartEnd_CheckStateChanged(object sender, EventArgs e)
+		{
+			if (chkUseMarkStartEnd.Checked)
+			{
+				checkBoxFillDuration.AutoCheck = false;
+				checkBoxFillDuration.ForeColor = ThemeColorTable.ForeColorDisabled;
+
+				txtDuration.Enabled = false;
+			}
+			else
+			{
+				checkBoxFillDuration.AutoCheck = true;
+				checkBoxFillDuration.ForeColor = ThemeColorTable.ForeColor;
+			}
 			CalculatePossibleEffectsByBeatMarks();
 		}
 
@@ -414,7 +461,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			btnShowBeatMarkOptions.Visible = false;
 			btnHideBeatMarkOptions.Visible = true;
 			panelBeatAlignment.Visible = true;
-			panelBeatAlignment.Visible = true;
 		}
 
 		private void btnHideBeatMarkOptions_Click(object sender, EventArgs e)
@@ -422,10 +468,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			btnHideBeatMarkOptions.Visible = false;
 			btnShowBeatMarkOptions.Visible = true;
 			panelBeatAlignment.Visible = false;
-			panelBeatAlignment.Visible = false;
 		}
 
-		#endregion 
+		#endregion
 
 		#endregion
 
@@ -448,7 +493,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 		private bool TimeExistsForAddition()
 		{
-			TimeSpan LastEffectEndTime = StartTime + (TimeSpan.FromTicks(Duration.Ticks * EffectCount) + TimeSpan.FromTicks(DurationBetween.Ticks * (EffectCount -1)));
+			TimeSpan LastEffectEndTime = StartTime + (TimeSpan.FromTicks(Duration.Ticks * EffectCount) + TimeSpan.FromTicks(DurationBetween.Ticks * (EffectCount - 1)));
 			//return (LastEffectEndTime > SequenceLength ? false : true);
 			return (LastEffectEndTime > EndTime ? false : true);
 		}
@@ -499,8 +544,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			}
 			var possibleEffects = (checkBoxFillDuration.Checked ? Times.Count() - 1 : Times.Count());
 			if (possibleEffects < 0) possibleEffects = 0;
-			txtEffectCount.Maximum = (checkBoxSkipEOBeat.Checked ? possibleEffects / 2 : possibleEffects);
-			lblPossibleEffects.Text = string.Format("{0} effects possible.", (checkBoxSkipEOBeat.Checked ? possibleEffects / 2 : possibleEffects));
+			txtEffectCount.Maximum = (int)(checkBoxSkipEOBeat.Checked ? Math.Ceiling(possibleEffects / 2d) : possibleEffects);
+			lblPossibleEffects.Text = $"{txtEffectCount.Maximum} effects possible.";
 			btnOK.Enabled = (Times.Count() == 0 ? false : true);
 		}
 
@@ -518,5 +563,6 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			btn.BackgroundImage = Resources.ButtonBackgroundImage;
 
 		}
+
 	}
 }

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.resx
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_AddMultipleEffects.resx
@@ -1,64 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -119,5 +59,8 @@
   </resheader>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>52</value>
   </metadata>
 </root>

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -2470,7 +2470,8 @@ namespace VixenModules.Editor.TimedSequenceEditor
 				var newEffects = new List<EffectNode>();
 				if (eDialog.AlignToBeatMarks)
 				{
-					newEffects = AddEffectsToBeatMarks(eDialog.CheckedMarks, eDialog.EffectCount, effectId, eDialog.StartTime, eDialog.Duration, row, eDialog.FillDuration, eDialog.SkipEOBeat);
+					newEffects = AddEffectsToBeatMarks(eDialog.CheckedMarks, eDialog.EffectCount, effectId, eDialog.StartTime, 
+						eDialog.Duration, row, eDialog.FillDuration, eDialog.SkipEOBeat, eDialog.AlignToMarkStartEnd);
 				}
 				else
 				{
@@ -2507,7 +2508,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			}
 		}
 		
-		private List<EffectNode> AddEffectsToBeatMarks(ListView.CheckedListViewItemCollection checkedMarks, int effectCount, Guid effectGuid, TimeSpan startTime, TimeSpan duration, Row row, Boolean fillDuration, Boolean skipEoBeat)
+		private List<EffectNode> AddEffectsToBeatMarks(ListView.CheckedListViewItemCollection checkedMarks, int effectCount, Guid effectGuid, TimeSpan startTime, TimeSpan duration, Row row, Boolean fillDuration, Boolean skipEoBeat, bool alignToMarkDuration)
 		{
 			bool skipThisBeat = false;
 			List<IMark> times = (from ListViewItem listItem in checkedMarks from mcItem in _sequence.LabeledMarkCollections where mcItem.Name == listItem.Text from mark in mcItem.Marks where mark.StartTime >= startTime select mark).ToList();
@@ -2530,6 +2531,9 @@ namespace VixenModules.Editor.TimedSequenceEditor
 										break; //We're done -- There are no more marks to fill, don't create it
 									duration = times[times.IndexOf(mark) + 1].StartTime - mark.StartTime;
 									if (duration < TimeSpan.FromSeconds(.01)) duration = TimeSpan.FromSeconds(.01);
+								}else if (alignToMarkDuration)
+								{
+									duration = mark.Duration;
 								}
 								newEffects.Add(CreateEffectNode(newEffect, row, mark.StartTime, duration));
 							}


### PR DESCRIPTION
* Add new checkbox to select the option for mark start and end time for alignment.
* Fix longstanding issues with checkbnoxes being enabled and disabled based on the choices.
* Fix skip logic to allow for the proper count when an odd number of marks are available.