### PR TITLE
VIX-3461 Vixen crashes after a sequence is played

### DIFF
--- a/src/Vixen.Common/AudioPlayer/CoreAudioPlayer.cs
+++ b/src/Vixen.Common/AudioPlayer/CoreAudioPlayer.cs
@@ -113,8 +113,7 @@ namespace Common.AudioPlayer
 		{
 			_soundOut?.Stop();
 			PlaybackStopped?.Invoke();
-			_soundOut?.Dispose();
-			_soundOut = null;
+			CleanupSoundOut();
 		}
 
 		/// <inheritdoc />
@@ -353,6 +352,7 @@ namespace Common.AudioPlayer
 		private void PlaybackDeviceOnPlaybackStopped(object? sender, StoppedEventArgs e)
 		{
 			PlaybackEnded?.Invoke();
+			CleanupSoundOut();
 		}
 
 		#region Implementation of IDisposable


### PR DESCRIPTION
VIX-3461 Vixen crashes after a sequence is played

Adding dispose logic after sequence is done playing.