### PR TITLE
VIX-3465 Fixing audio looping logic to avoid already initialized exception

### DIFF
--- a/src/Vixen.Common/AudioPlayer/AudioPlayer.csproj
+++ b/src/Vixen.Common/AudioPlayer/AudioPlayer.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="7.0.0" />
-    <PackageReference Include="NAudio.Core" Version="2.1.0" />
+    <PackageReference Include="NAudio.Core" Version="2.2.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NAudio.Wasapi" Version="2.1.0" />
-    <PackageReference Include="NAudio.WinMM" Version="2.1.0" />
+    <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
+    <PackageReference Include="NAudio.WinMM" Version="2.2.1" />
     <PackageReference Include="NLog" Version="5.1.2" />
   </ItemGroup>
 

--- a/src/Vixen.Common/AudioPlayer/CoreAudioPlayer.cs
+++ b/src/Vixen.Common/AudioPlayer/CoreAudioPlayer.cs
@@ -119,6 +119,13 @@ namespace Common.AudioPlayer
 		/// <inheritdoc />
 		public void Play()
 		{
+			// If the play back state is stopped then
+			// make sure the sound out wave player has been properly disposed.
+			if (PlaybackState == PlaybackState.Stopped)
+			{
+				CleanupSoundOut();
+			}
+
 			if ((IsPaused || IsStopped) && EnsureDeviceCreated())
 			{
 				if (_soundOut == null) return;


### PR DESCRIPTION
VIX-3465 Fixing audio looping logic to avoid already initialized exception

