### PR TITLE
VIX-3454 Fix additional issue with Mark selection events overlapping

### DIFF
--- a/src/Vixen.Common/Controls/TimeLineControl/LabeledMarks/MarksSelectionManager.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/LabeledMarks/MarksSelectionManager.cs
@@ -5,20 +5,38 @@ namespace Common.Controls.TimelineControl.LabeledMarks
 {
 	public class MarksSelectionManager
 	{
-		private static MarksSelectionManager _manager;
-		private static List<IMark> _selectedMarks;
+		private static readonly Dictionary<Guid, MarksSelectionManager> Instances = new();
+		private readonly List<IMark> _selectedMarks;
 		public event EventHandler SelectionChanged ;
 
-		private MarksSelectionManager()
+		private MarksSelectionManager(Guid id)
 		{
+			InstanceId = id;
 			_selectedMarks = new List<IMark>();
 			SelectedMarks = _selectedMarks.AsReadOnly();
 		}
 
-		public static MarksSelectionManager Manager()
+		public static MarksSelectionManager Manager(Guid id)
 		{
-			return _manager ?? (_manager = new MarksSelectionManager());
+			if (Instances.TryGetValue(id, out var instance))
+			{
+				return instance;
+			}
+			else
+			{
+				instance = new MarksSelectionManager(id);
+				Instances.Add(id, instance);
+			}
+
+			return instance;
 		}
+
+		public static bool CloseManager(Guid id)
+		{
+			return Instances.Remove(id);
+		}
+
+		public Guid InstanceId { get; init; }
 
 		public ReadOnlyCollection<IMark> SelectedMarks { get; }
 

--- a/src/Vixen.Common/Controls/TimeLineControl/MarksBar.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/MarksBar.cs
@@ -34,7 +34,7 @@ namespace Common.Controls.TimelineControl
 		{
 			BackColor = Color.Gray;
 			_textFont = Font;
-			_marksSelectionManager = MarksSelectionManager.Manager();
+			_marksSelectionManager = MarksSelectionManager.Manager(instanceId);
 			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			_timeLineGlobalEventManager.MarksMoving += TimeLineGlobalEventManagerTimeLineGlobalMoving;
 			_timeLineGlobalEventManager.MarksMoved += TimeLineGlobalEventManager_MarksMoved;

--- a/src/Vixen.Common/Controls/TimeLineControl/Ruler.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Ruler.cs
@@ -33,7 +33,7 @@ namespace Common.Controls.Timeline
 		{
 			AutoScaleMode = AutoScaleMode.Font;
 			BackColor = Color.Gray;
-			_marksSelectionManager = MarksSelectionManager.Manager();
+			_marksSelectionManager = MarksSelectionManager.Manager(instanceId);
 			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager(instanceId);
 			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(instanceId);
 			_timeLineGlobalEventManager.MarksMoving += TimeLineGlobalEventManagerTimeLineGlobalMoving;

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -140,6 +140,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		
 		private readonly TimeLineGlobalEventManager _timeLineGlobalEventManager;
 		private readonly TimeLineGlobalStateManager _timeLineGlobalStateManager;
+		private readonly MarksSelectionManager _marksSelectionManager;
 
 		//List to hold removed nodes so we can clean them up later. Due to how the undo works, nodes are sticky and 
 		//live on past removal so they can can be added back
@@ -226,6 +227,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			//So we can be aware of mark changes.
 			_timeLineGlobalEventManager = TimeLineGlobalEventManager.Manager(InstanceId);
 			_timeLineGlobalStateManager = TimeLineGlobalStateManager.Manager(InstanceId);
+			_marksSelectionManager = MarksSelectionManager.Manager(InstanceId);
 		}
 
 		private IDockContent DockingPanels_GetContentFromPersistString(string persistString)
@@ -806,6 +808,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 			TimeLineGlobalEventManager.CloseManager(InstanceId);
 			TimeLineGlobalStateManager.CloseManager(InstanceId);
+			MarksSelectionManager.CloseManager(InstanceId);
 
 			dockPanel.Dispose();
 
@@ -2140,7 +2143,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			//TimelineControl.ruler.ClearSelectedMarks();
 			if (e.Button != MouseButtons.Right)
 			{
-				MarksSelectionManager.Manager().ClearSelected();
+				_marksSelectionManager.ClearSelected();
 				Invalidate(true);
 			}
 		}


### PR DESCRIPTION
* Apply the same changes to the MarkSelectionManager as were applied to TimelineGlobalEventManager in the previous fix.