### PR TITLE
VIX-3472 Add logic for making a prop have a central location

### DIFF
--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewBaseShape.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewBaseShape.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using System.Windows;
 using System.Xml.Serialization;
 using Vixen.Sys;
+using Point = System.Drawing.Point;
 
 namespace VixenModules.Preview.VixenPreview.Shapes
 {
@@ -43,6 +44,12 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 				FireOnPropertiesChanged(this, this);
 			}
 		}
+
+		[DataMember(EmitDefaultValue = false),
+		Category("Location"),
+		Description("Uses a common location for all lights based on the center of the prop."),
+		DisplayName("Common Location")]
+		public bool UseCommonLocation { get; set; }
 		
 		/// <summary>
 		/// Display name for the type of shape.
@@ -73,6 +80,19 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// </summary>
         [Browsable(false)]
         public abstract int Right { get; }
+
+		/// <summary>
+		/// Center most pixel location
+		/// </summary>
+		[Browsable(false)]
+		public Point Center {
+			get
+			{
+				var x = Left + (Right - Left) / 2;
+				var y = Top + (Bottom - Top) / 2;
+				return new Point(x, y);
+			}
+		}
 
 		public abstract void Match(PreviewBaseShape matchShape);
 

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -2785,8 +2785,19 @@ namespace VixenModules.Preview.VixenPreview
 						if (!p.Node.Properties.Contains(LocationDescriptor._typeId))
 							p.Node.Properties.Add(LocationDescriptor._typeId);
 						var prop = p.Node.Properties.Get(LocationDescriptor._typeId);
-						((LocationData)prop.ModuleData).X = p.IsHighPrecision ? (int)p.Location.X : p.X + Convert.ToInt32(Data.LocationOffset.X);
-						((LocationData)prop.ModuleData).Y = p.IsHighPrecision ? (int)p.Location.Y : p.Y + Convert.ToInt32(Data.LocationOffset.Y);
+
+						if (displayItem.Shape.UseCommonLocation)
+						{
+							var c = displayItem.Shape.Center;
+							((LocationData)prop.ModuleData).X = c.X + Convert.ToInt32(Data.LocationOffset.X);
+							((LocationData)prop.ModuleData).Y = c.Y + Convert.ToInt32(Data.LocationOffset.Y);
+						}
+						else
+						{
+							((LocationData)prop.ModuleData).X = p.IsHighPrecision ? (int)p.Location.X + Convert.ToInt32(Data.LocationOffset.X) : p.X + Convert.ToInt32(Data.LocationOffset.X);
+							((LocationData)prop.ModuleData).Y = p.IsHighPrecision ? (int)p.Location.Y + Convert.ToInt32(Data.LocationOffset.Y) : p.Y + Convert.ToInt32(Data.LocationOffset.Y);
+						}
+						
 						((LocationData)prop.ModuleData).Y = p.Z;
 					}
 				}

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetup3.cs
@@ -671,8 +671,19 @@ namespace VixenModules.Preview.VixenPreview
 								p.Node.Properties.Add(LocationDescriptor._typeId);
 
 							var prop = p.Node.Properties.Get(LocationDescriptor._typeId);
-							((LocationData)prop.ModuleData).X = p.IsHighPrecision ? (int)(p.Location.X + Data.LocationOffset.X) : p.X + Convert.ToInt32(Data.LocationOffset.X);
-							((LocationData)prop.ModuleData).Y = p.IsHighPrecision ? (int)(p.Location.Y + Data.LocationOffset.Y) : p.Y + Convert.ToInt32(Data.LocationOffset.Y);
+							if (d.Shape.UseCommonLocation)
+							{
+								var c = d.Shape.Center;
+								((LocationData)prop.ModuleData).X = c.X + Convert.ToInt32(Data.LocationOffset.X);
+								((LocationData)prop.ModuleData).Y = c.Y + Convert.ToInt32(Data.LocationOffset.Y);
+							}
+							else
+							{
+								((LocationData)prop.ModuleData).X = p.IsHighPrecision ? (int)(p.Location.X + Data.LocationOffset.X)
+									: p.X + Convert.ToInt32(Data.LocationOffset.X);
+								((LocationData)prop.ModuleData).Y = p.IsHighPrecision ? (int)(p.Location.Y + Data.LocationOffset.Y)
+									: p.Y + Convert.ToInt32(Data.LocationOffset.Y);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
* Add property to the settings grid to set if the prop uses common location for all nodes.
* Add logic to the location assignment to check the property and update the locations with real or center location.
* Fix a bug in the location assignment that was not using the location offset.