### PR TITLE
VIX-3486 Add logic to catch sequence load errors in the export

### DIFF
--- a/src/Vixen.Core/Delegates/Delegates.cs
+++ b/src/Vixen.Core/Delegates/Delegates.cs
@@ -13,5 +13,7 @@
 		public delegate void GenericVoidString(string s);
 
 		public delegate string GenericStringValue();
+
+		public delegate bool GenericBoolString(string value);
 	}
 }


### PR DESCRIPTION
* Catch exceptions during the sequence load and prompt the user with the sequence that failed and ask if they would like to continue.