### PR TITLE
VIX-3482 Fix patching order logic in the Matrix wizard

### DIFF
--- a/src/Vixen.Application/Setup/ElementTemplates/PixelGrid.cs
+++ b/src/Vixen.Application/Setup/ElementTemplates/PixelGrid.cs
@@ -148,11 +148,25 @@ namespace VixenApplication.Setup.ElementTemplates
 
 			if (_startLocation == StartLocation.BottomRight)
 			{
-				leafNodes = result.First().Children.SelectMany(x => x.GetLeafEnumerator().Reverse());
+				if (radioButtonHorizontalFirst.Checked)
+				{
+					leafNodes = result.First().Children.SelectMany(x => x.GetLeafEnumerator()).Reverse();
+				}
+				else
+				{
+					leafNodes = result.First().Children.Reverse().SelectMany(x => x.GetLeafEnumerator());
+				}
 			}
 			else if (_startLocation == StartLocation.TopLeft)
 			{
-				leafNodes = result.First().Children.Reverse().SelectMany(x => x.GetLeafEnumerator());
+				if (radioButtonHorizontalFirst.Checked)
+				{
+					leafNodes = result.First().Children.Reverse().SelectMany(x => x.GetLeafEnumerator());
+				}
+				else
+				{
+					leafNodes = result.First().Children.SelectMany(x => x.GetLeafEnumerator().Reverse());
+				}
 			}
 			else if (_startLocation == StartLocation.TopRight)
 			{


### PR DESCRIPTION
* Top Left and Bottom Right need additional logic to correctly order the patching when they are in a vertical orientation.