### PR TITLE
VIX-3496 Enable function to export wire diagram in the preview elemen…

### DIFF
--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
@@ -24,6 +24,7 @@
 				<ProjectReference Include="..\..\..\Vixen.Core\Vixen.Core.csproj" />
 				<ProjectReference Include="..\..\App\CustomPropEditor\CustomPropEditor.csproj" />
 				<ProjectReference Include="..\..\App\Fixture\Fixture.csproj" />
+				<ProjectReference Include="..\..\App\Modeling\Modeling.csproj" />
 				<ProjectReference Include="..\..\Editor\FixtureGraphics\FixtureGraphics.csproj" />
 				<ProjectReference Include="..\..\OutputFilter\ColorWheelFilter\ColorWheelFilter.csproj" />
 				<ProjectReference Include="..\..\OutputFilter\DimmingCurve\DimmingCurve.csproj" />

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewSetupElementsDocument.cs
@@ -8,6 +8,7 @@ using WeifenLuo.WinFormsUI.Docking;
 using Vixen.Rule;
 using Vixen.Services;
 using Vixen.Sys;
+using VixenModules.App.Modeling;
 
 namespace VixenModules.Preview.VixenPreview
 {
@@ -35,7 +36,13 @@ namespace VixenModules.Preview.VixenPreview
 			ThemeUpdateControls.UpdateControls(this);
 			_preview = preview;
 			treeElements.AllowPropertyEdit = false;
-			treeElements.AllowWireExport = false;
+			treeElements.AllowWireExport = true;
+			treeElements.ExportDiagram = ExportWireDiagram;
+		}
+
+		private void ExportWireDiagram(ElementNode node)
+		{
+			ElementModeling.ElementsToSvg(node);
 		}
 
 		private void VixenPreviewSetupElementsDocument_Load(object sender, EventArgs e)


### PR DESCRIPTION
…t tree

* Set the option to enable the context menu item on the ElementTree control.
* Include the modeling project and set the delegate for how to export to the same funciton used in the Display Setup.