### PR TITLE
VIX-3499  Condense Universe lines for FPP export so that there is one line per controller when universes are same size.

### DIFF
--- a/src/Vixen.Core/Export/Export.cs
+++ b/src/Vixen.Core/Export/Export.cs
@@ -219,27 +219,12 @@ namespace Vixen.Export
                                     u.UniverseType = isMulticast ? UniverseTypes.E131_Multicast : UniverseTypes.E131_Unicast;
                                     u.Address = ip;
                                     u.Monitor = !isMulticast;
-                                    u.DeDuplicate = true; //maybe check sACN advanced config settings to set this by vixen settings
+                                    u.DeDuplicate = controller.ControllerNetworkConfiguration.SupportsDeDuplication; //maybe check sACN advanced config settings to set this by vixen settings
                                     
                                     channelOutputs.Universes.Add(u);
                                     fppStartChannel = fppStartChannel + uc.Size;
                                 }
                             }
-                            /* OLD CODE*/
-                            /*foreach (var uc in universes)
-                            {
-                                Universe u = new Universe();
-                                u.Address = ip;
-                                u.Description = controller.Name;
-                                u.UniverseType = isMulticast ? UniverseTypes. E131_Multicast:UniverseTypes.E131_Unicast;
-                                u.Active = uc.Active;
-                                u.ChannelCount = uc.Size;
-                                u.StartChannel = fppStartChannel;
-                                u.UniverseId = uc.UniverseNumber;
-                                channelOutputs.Universes.Add(u);
-                                fppStartChannel = fppStartChannel + uc.Size;
-                            }*/
-                            /* END OLD CODE*/
                             break;
 
                         case ProtocolTypes.DDP:

--- a/src/Vixen.Core/Export/Export.cs
+++ b/src/Vixen.Core/Export/Export.cs
@@ -199,7 +199,7 @@ namespace Vixen.Export
                             
                             for (var uIndex = 0; uIndex < universes.Count(); uIndex++)
                             {
-                                if (uIndex > 0 && (universes[uIndex].Size == channelOutputs.Universes.Last().ChannelCount) )
+                                if (uIndex>0 && channelOutputs.Universes.Any() && (universes[uIndex].Size == channelOutputs.Universes.Last().ChannelCount) )
                                 {
                                     channelOutputs.Universes.Last().UniverseCount++;
                                     fppStartChannel = fppStartChannel + universes[uIndex].Size;
@@ -219,7 +219,7 @@ namespace Vixen.Export
                                     u.UniverseType = isMulticast ? UniverseTypes.E131_Multicast : UniverseTypes.E131_Unicast;
                                     u.Address = ip;
                                     u.Monitor = !isMulticast;
-                                    u.DeDuplicate = controller.ControllerNetworkConfiguration.SupportsDeDuplication; //maybe check sACN advanced config settings to set this by vixen settings
+                                    u.DeDuplicate = controller.ControllerNetworkConfiguration.ThrottlingEnabled;
                                     
                                     channelOutputs.Universes.Add(u);
                                     fppStartChannel = fppStartChannel + uc.Size;

--- a/src/Vixen.Core/Export/FPP/Universe.cs
+++ b/src/Vixen.Core/Export/FPP/Universe.cs
@@ -40,6 +40,8 @@ namespace Vixen.Export.FPP
 
 		public int StartChannel { get; set; }
 
+		public int UniverseCount { get; set; }
+
 		public int ChannelCount { get; set; }
 
 		public UniverseTypes UniverseType { get; set; }
@@ -49,5 +51,11 @@ namespace Vixen.Export.FPP
 		public string Address { get; set; }
 
 		public int Priority { get; set; }
+
+        [JsonConverter(typeof(BoolConverter))]
+        public bool Monitor {  get; set; }
+
+        [JsonConverter(typeof(BoolConverter))]
+        public bool DeDuplicate {  get; set; }
 	}
 }

--- a/src/Vixen.Core/Module/Controller/ControllerNetworkConfiguration.cs
+++ b/src/Vixen.Core/Module/Controller/ControllerNetworkConfiguration.cs
@@ -13,7 +13,7 @@ namespace Vixen.Module.Controller
 		//public string HostName { get; set; }
 		public bool SupportsUniverses { get; set; }
 
-		public bool SupportsDeDuplication { get; set; }
+		public bool ThrottlingEnabled { get; set; }
 
 		public List<UniverseConfiguration> Universes { get; set; }
 	}

--- a/src/Vixen.Core/Module/Controller/ControllerNetworkConfiguration.cs
+++ b/src/Vixen.Core/Module/Controller/ControllerNetworkConfiguration.cs
@@ -13,6 +13,8 @@ namespace Vixen.Module.Controller
 		//public string HostName { get; set; }
 		public bool SupportsUniverses { get; set; }
 
+		public bool SupportsDeDuplication { get; set; }
+
 		public List<UniverseConfiguration> Universes { get; set; }
 	}
 

--- a/src/Vixen.Modules/Controller/E131/E131OutputPlugin.cs
+++ b/src/Vixen.Modules/Controller/E131/E131OutputPlugin.cs
@@ -641,7 +641,7 @@ namespace VixenModules.Controller.E131
 				config.TransmissionMethod = TransmissionMethods.Multicast;
 
 
-			config.SupportsDeDuplication = _data.EventRepeatCount>0;
+			config.ThrottlingEnabled = _data.EventRepeatCount>0;
 			
 			List<UniverseConfiguration> universes = new List<UniverseConfiguration>(_data.Universes.Count);
 			foreach (var universeEntry in _data.Universes)

--- a/src/Vixen.Modules/Controller/E131/E131OutputPlugin.cs
+++ b/src/Vixen.Modules/Controller/E131/E131OutputPlugin.cs
@@ -640,6 +640,9 @@ namespace VixenModules.Controller.E131
 			else
 				config.TransmissionMethod = TransmissionMethods.Multicast;
 
+
+			config.SupportsDeDuplication = _data.EventRepeatCount>0;
+			
 			List<UniverseConfiguration> universes = new List<UniverseConfiguration>(_data.Universes.Count);
 			foreach (var universeEntry in _data.Universes)
 			{


### PR DESCRIPTION
Condense Universe lines for FPP export so that there is one line per controller when universes are same size.  Also added fields for monitor and dedup to set them accordingly from the vixen controller settings.