### PR TITLE
VIX-3529 Add delete unicast destination logic

### DIFF
--- a/src/Vixen.Modules/Controller/E131/SetupForm.cs
+++ b/src/Vixen.Modules/Controller/E131/SetupForm.cs
@@ -642,6 +642,7 @@ namespace VixenModules.Output.E131
             {
                 comboDestination.Items.Add("Unicast " + ipAddr);
             }
+            btnDeleteUnicast.Enabled = comboDestination.SelectedIndex>-1;
         }
 
         // -------------------------------------------------------------


### PR DESCRIPTION
This prevents a user from clicking the delete unicast destination button without a destination selected.