### PR TITLE
VIX-3513  Intelligent fixture wizard doesn't copy pan/tilt start/end properties

### DIFF
--- a/src/Vixen.Core/Commands/Named8BitCommand.cs
+++ b/src/Vixen.Core/Commands/Named8BitCommand.cs
@@ -58,6 +58,18 @@
 		/// </summary>		
 		public string Label { get; set; }
 
+		/// <summary>
+		/// Minimum value of the index type range.
+		/// </summary>
+		/// <remarks>This property only applies if the index type is part of a range</remarks>
+		public byte RangeMinimum { get; set; }
+
+		/// <summary>
+		/// Maximum value of the index type range.
+		/// </summary>
+		/// <remarks>This property only applies if the index type is part of a range</remarks>
+		public byte RangeMaximum { get; set; }
+
 		#endregion
 	}
 }

--- a/src/Vixen.Modules/Editor/FixtureGraphics/IMovingHead.cs
+++ b/src/Vixen.Modules/Editor/FixtureGraphics/IMovingHead.cs
@@ -103,5 +103,10 @@ namespace VixenModules.Editor.FixtureGraphics
 		/// </summary>
 		/// <returns>+1 or -1 based on the orientation of the fixture</returns>
 		double GetOrientationSign();
+
+		/// <summary>
+		/// Strobe rate represented in milliseconds between pulses.
+		/// </summary>
+		int StrobeRate { get; set; }
 	}
 }

--- a/src/Vixen.Modules/Editor/FixtureGraphics/MovingHeadSettings.cs
+++ b/src/Vixen.Modules/Editor/FixtureGraphics/MovingHeadSettings.cs
@@ -107,11 +107,9 @@ namespace VixenModules.Editor.FixtureGraphics
 		/// </summary>
 		public int FixtureIntensity { get; set; }
 
-		/// <summary>
 		/// <inheritdoc/>
-		/// </summary>
 		public int StrobeRate { get; set; }
-
+		
 		/// <summary>
 		/// Refer to interface documentation.
 		/// </summary>
@@ -135,6 +133,7 @@ namespace VixenModules.Editor.FixtureGraphics
 				EnableGDI = EnableGDI,
 				FixtureIntensity = FixtureIntensity,
 				MountingPosition = MountingPosition,
+				StrobeRate = StrobeRate,
 			};
 		}
 
@@ -186,7 +185,8 @@ namespace VixenModules.Editor.FixtureGraphics
 				   movingHead.IncludeLegend == IncludeLegend &&
 				   movingHead.LegendColor == LegendColor &&
 				   movingHead.FixtureIntensity == FixtureIntensity &&
-				   movingHead.MountingPosition == MountingPosition);
+				   movingHead.MountingPosition == MountingPosition &&
+				   movingHead.StrobeRate == StrobeRate);
 		}
 
 		#endregion

--- a/src/Vixen.Modules/Editor/FixtureGraphics/MovingHeadSettings.cs
+++ b/src/Vixen.Modules/Editor/FixtureGraphics/MovingHeadSettings.cs
@@ -108,6 +108,11 @@ namespace VixenModules.Editor.FixtureGraphics
 		public int FixtureIntensity { get; set; }
 
 		/// <summary>
+		/// <inheritdoc/>
+		/// </summary>
+		public int StrobeRate { get; set; }
+
+		/// <summary>
 		/// Refer to interface documentation.
 		/// </summary>
 		/// <returns>Clone of the moving head settings.</returns>

--- a/src/Vixen.Modules/Effect/Effect/FixtureEffectBase.cs
+++ b/src/Vixen.Modules/Effect/Effect/FixtureEffectBase.cs
@@ -577,7 +577,7 @@ namespace VixenModules.Effect.Effect
 				CommandValue commandValue = new CommandValue(namedCommand);
 
 				// Create the command intent from the command value and the time span
-				CommandIntent commandIntent = new CommandIntent(commandValue, TimeSpan);
+				CommandIntent commandIntent = new CommandIntent(commandValue, frameTs);
 
 				// Add the command to the effect intents
 				EffectIntentCollection.AddIntentForElement(node.Element.Id, commandIntent, startTime);

--- a/src/Vixen.Modules/Effect/Effect/FixtureEffectBase.cs
+++ b/src/Vixen.Modules/Effect/Effect/FixtureEffectBase.cs
@@ -531,6 +531,10 @@ namespace VixenModules.Effect.Effect
 				// Declare the index value to use for the command
 				int indexValue;
 
+				// Default the index range
+				int minValue = 0;
+				int maxValue = 0;
+
 				// If the index uses a curve then...
 				if (fixtureIndex.UseCurve)
 				{
@@ -542,6 +546,10 @@ namespace VixenModules.Effect.Effect
 
 					// Scale the value based on the start and stop values of the index
 					indexValue = (int)Math.Round(ScaleCurveToValue(curve.GetValue(intervalPosFactor), fixtureIndex.EndValue, fixtureIndex.StartValue));
+
+					// Save off the index range 
+					minValue = fixtureIndex.StartValue;
+					maxValue = fixtureIndex.EndValue;
 				}
 				else
 				{
@@ -560,6 +568,10 @@ namespace VixenModules.Effect.Effect
 
 				// Assign the label to the command
 				namedCommand.Label = function.Label;
+
+				// Assign the index range to the command
+				namedCommand.RangeMinimum = (byte)minValue;
+				namedCommand.RangeMaximum = (byte)maxValue;
 
 				// Create the command value from the tagged command
 				CommandValue commandValue = new CommandValue(namedCommand);

--- a/src/Vixen.Modules/Preview/VixenPreview/OpenGL/OpenGLPreviewForm.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/OpenGL/OpenGLPreviewForm.cs
@@ -46,7 +46,6 @@ namespace VixenModules.Preview.VixenPreview.OpenGL
 		private Camera _camera;
 		private bool _needsUpdate = true;
 		private bool _isRendering;
-		private bool _renderingInProcess;
 		private bool _formLoading;
 		private string _displayName = "Vixen Preview";
 
@@ -601,6 +600,9 @@ namespace VixenModules.Preview.VixenPreview.OpenGL
 			// If the moving head render strategy has not been created then...
 			if (_movingHeadRenderStrategy == null)
 			{
+				// Reset all strobe timers
+				MovingHeadIntentHandler.ResetStrobeTimers();
+
 				// Create the moving head render strategy
 				_movingHeadRenderStrategy = new MovingHeadRenderStrategy();
 
@@ -688,26 +690,15 @@ namespace VixenModules.Preview.VixenPreview.OpenGL
 		/// </summary>
 		private void OnRenderFrameOnGUIThread()
 		{
-			// If rendering is NOT already in progress then...
-			if (!_renderingInProcess)
+			// Render the preview on the GUI thread
+			BeginInvoke(() =>
 			{
-				// Set the flag that rendering is in progress as we
-				// don't want to post more than one render call
-				_renderingInProcess = true;
-
-				// Render the preview on the GUI thread
-				BeginInvoke(() =>
-				{
-					OnRenderFrame();
-				});
-			}
+				OnRenderFrame();
+			});
 		}
 		
 		private void OnRenderFrame()
 		{
-			// Set flag indicating that rendering is in progress
-			_renderingInProcess = true;
-
 			//Logging.Debug("Entering RenderFrame");
 			if (_isRendering || _formLoading || WindowState == FormWindowState.Minimized) return;
 
@@ -771,9 +762,6 @@ namespace VixenModules.Preview.VixenPreview.OpenGL
 			_previewUpdate.Set(_sw.ElapsedMilliseconds);
 			UpdateFrameRate();
 			
-			// Set flag indicating that rendering is complete
-			_renderingInProcess = false;
-
 			//Logging.Debug("Exiting RenderFrame");
 		}
 

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/IOpenGLMovingHeadShape.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/IOpenGLMovingHeadShape.cs
@@ -12,7 +12,8 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// </summary>
 		/// <remarks>The reference height is used to determine the maximum beam length</remarks>
 		/// <param name="referenceHeight">Height of the drawing area / background image</param>
-		void Initialize(int referenceHeight);
+		/// <param name="redraw">Delegate that redraws the preview</param>
+		void Initialize(int referenceHeight, Action redraw);
 
 		/// <summary>
 		/// Gets the OpenGL moving head associated with the shape.

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/MovingHeadTimer.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/MovingHeadTimer.cs
@@ -1,0 +1,210 @@
+﻿using System.Timers;
+
+using VixenModules.Editor.FixtureGraphics;
+
+using Timer = System.Timers.Timer;
+
+namespace VixenModules.Preview.VixenPreview.Shapes
+{
+	/// <summary>
+	/// Maintains a moving head strobe timer.
+	/// </summary>
+	internal class MovingHeadTimer
+	{
+		#region Fields
+		
+		/// <summary>
+		/// Timer used to strobe the moving head beam.
+		/// </summary>
+		private Timer _timer;
+
+		/// <summary>
+		/// Collection of moving heads registered with this timer.
+		/// </summary>
+		private List<Tuple<IMovingHead, Action>> _movingHeads;
+
+		/// <summary>
+		/// Delegate to refresh the Vixen preview.
+		/// </summary>
+		private Action _redraw;
+
+		/// <summary>
+		/// Duration of the strobe flash in milliseconds.
+		/// </summary>
+		private int _strobeDuration;
+
+		/// <summary>
+		/// Lock to ensure thread safety with respect to the moving heads collection.
+		/// </summary>
+		private object _movingHeadsLock;
+
+		#endregion
+
+		#region Constructor
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="interval">Interval of the strobe timer in ms</param>
+		/// <param name="maxStrobeDuration">Maximum strobe duration in ms</param>
+		/// <param name="redraw">Delegate to redraw the Vixen preview</param>
+		public MovingHeadTimer(
+			int interval, 
+			int maxStrobeDuration, 
+			Action redraw)
+		{
+			// Store off the timer interval
+			Interval = interval;
+
+			// Store off the maximum strobe duration
+			MaximumStrobeDuration = maxStrobeDuration;
+
+			// Store off the delegate to refresh the Vixen preview
+			_redraw = redraw;
+
+			// Initialize the moving heads collection lock
+			_movingHeadsLock = new object();
+
+			// Initialize the moving heads collection
+			_movingHeads = new List<Tuple<IMovingHead, Action>>();
+
+			// Create the OS timer
+			_timer = new Timer(interval);
+
+			// Hook up the Elapsed event for the timer
+			_timer.Elapsed += OnStrobeTimerEvent;
+
+			// Configure the timer to continuously fire
+			_timer.AutoReset = true;
+
+			// Default the strobe duration to 25% of the interval
+			_strobeDuration = interval / 4;
+
+			// If the duration is greater than the max duration then...
+			if (_strobeDuration > MaximumStrobeDuration)
+			{
+				// Limit the duration to 50 ms
+				_strobeDuration = MaximumStrobeDuration;
+			}
+		}
+
+		#endregion
+
+		#region Public Properties
+
+		/// <summary>
+		/// Interval of the moving head strobe timer in milliseconds.
+		/// </summary>
+		public int Interval { get; set; }
+
+		/// <summary>
+		/// Maximum strobe duration in ms.
+		/// </summary>
+		public int MaximumStrobeDuration { get; set; }
+
+		#endregion
+
+		#region Public Methods
+
+		/// <summary>
+		/// Adds the specified moving head to the timer.
+		/// </summary>
+		/// <param name="movingHead">Moving head to associate with the strobe timer</param>
+		public void AddMovingHead(Tuple<IMovingHead, Action> movingHead)
+		{
+			// Lock the collection
+			lock (_movingHeadsLock)
+			{
+				// Add the moving head to the collection
+				_movingHeads.Add(movingHead);
+			}
+
+			// If the timer has NOT already been started then...
+			if (!_timer.Enabled)
+			{
+				// Start the timer
+				_timer.Start();
+			}
+		}
+
+		/// <summary>
+		/// Removes the specified moving head from the timer.
+		/// </summary>
+		/// <param name="movingHead">Moving head to remove from the timer</param>
+		public void RemoveMovingHead(Tuple<IMovingHead, Action> movingHead)
+		{
+			// Lock the collection
+			lock (_movingHeadsLock)
+			{
+				// Remove the moving head from the collection
+				_movingHeads.Remove(movingHead);
+			}
+
+			// If there are no moving heads associated with this timer then...
+			if (_movingHeads.Count == 0)
+			{
+				// Stop the OS timer
+				_timer.Stop();
+			}
+		}
+
+		#endregion
+
+		#region Private Methods
+
+		/// <summary>
+		/// Event handler when the strobe timer expires.
+		/// </summary>
+		/// <param name="source">Source of the event</param>
+		/// <param name="e">Event arguments</param>
+		private void OnStrobeTimerEvent(Object source, ElapsedEventArgs e)
+		{
+			// Declare a local collection of moving heads
+			List<Tuple<IMovingHead, Action>> heads;
+			
+			// Lock the moving head collection
+			lock (_movingHeadsLock)
+			{
+				// Make a copy of the moving heads collection to avoid
+				// threading issues while working with the collection
+				heads = _movingHeads.ToList();
+			}
+
+			// Loop over the moving heads
+			foreach (Tuple<IMovingHead, Action> movingHead in heads)
+			{
+				// Turn on the beam
+				movingHead.Item1.OnOff = true;
+			}
+
+			// Redraw the preview
+			_redraw();
+
+			// Sleep for the duration of the strobe flash
+			Thread.Sleep(_strobeDuration);
+
+			// Loop over the moving heads
+			foreach (Tuple<IMovingHead, Action> movingHead in heads)
+			{
+				// Turn off the beam
+				movingHead.Item1.OnOff = false;
+			}
+
+			// Redraw the preview
+			_redraw();
+
+			// Loop over the moving heads
+			foreach (Tuple<IMovingHead, Action> movingHead in heads)
+			{
+				// If the moving head strobe interval no longer matches this timer then...
+				if (movingHead.Item1.StrobeRate != Interval)
+				{
+					// Update the strobe rate timer associated with the moving head
+					movingHead.Item2();
+				}
+			}
+		}
+
+		#endregion
+	}
+}

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHead.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHead.cs
@@ -107,6 +107,11 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// </summary>
 		private const int DefaultStrobeRateMaximum = 25;
 
+		/// <summary>
+		/// Default the strobe flash duration to 50ms.
+		/// </summary>
+		private const int MaxStrobeDuration = 50;
+
 		#endregion
 
 		#region Fields
@@ -543,6 +548,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			_intentHandler.StrobeRateMinimum = StrobeRateMinimum;
 			_intentHandler.StrobeRateMaximum = StrobeRateMaximum;
 
+			// Give the intent handler the maximum strobe duration
+			_intentHandler.MaximumStrobeDuration = MaximumStrobeDuration;
+
 			// Configure how the fixture zooms
 			_intentHandler.ZoomNarrowToWide = ZoomNarrowToWide;	
 
@@ -950,10 +958,19 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// Strobe rate maximum in Hz.
 		/// </summary>
 		[DataMember(EmitDefaultValue = false),
-		Category("Settings"),
-		Description("The strobe rate maximum (in Hz)."),
-		DisplayName("Strobe Rate Maximum (Hz)")]
+		 Category("Settings"),
+		 Description("The strobe rate maximum (in Hz)."),
+		 DisplayName("Strobe Rate Maximum (Hz)")]
 		public int StrobeRateMaximum { get; set; }
+
+		/// <summary>
+		/// Strobe duration in ms.
+		/// </summary>
+		[DataMember(EmitDefaultValue = false),
+		 Category("Settings"),
+		 Description("The maximum strobe duration in ms."),
+		 DisplayName("Maximum Strobe Duration (ms)")]
+		public int MaximumStrobeDuration { get; set; }
 
 		/// <summary>
 		/// Pan start position in degrees.

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHead.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHead.cs
@@ -892,6 +892,9 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			{
 				// Save off the node ID associated with the shape
 				_nodeId = node.Id;
+
+				// Transfer movement constraints from the Intelligent Fixture property associated with the node
+				InitializeMovingHeadMovementConstraints(node);
 			}
 		}
 

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
@@ -50,12 +50,32 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 			// Initialize the pan/tilt movement constraints
 			InitializeMovingHeadMovementConstraints(selectedNode);
 
+			// Default the fixture strobe minimum and maximum
+			StrobeRateMinimum = DefaultStrobeRateMinimum;
+			StrobeRateMaximum = DefaultStrobeRateMaximum;
+
 			Reconfigure(selectedNode);
 		}
 				
 		[OnDeserialized]
 		private void OnDeserialized(StreamingContext context)
-		{			
+		{
+			// If the strobe rate minimum is zero this must be
+			// an existing fixture
+			if (StrobeRateMinimum == 0)
+			{
+				// Default the strobe rate minimum
+				StrobeRateMinimum = DefaultStrobeRateMinimum;
+			}
+
+			// If the strobe rate maximum is zero this must be
+			// an existing fixture
+			if (StrobeRateMaximum == 0) 
+			{
+				// Default the strobe rate maximum
+				StrobeRateMaximum = DefaultStrobeRateMaximum;
+			}
+
 			Layout();						
 		}
 	

--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewMovingHeadPartial.cs
@@ -76,6 +76,14 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 				StrobeRateMaximum = DefaultStrobeRateMaximum;
 			}
 
+			// If the maximum strobe duration is zero this must be an
+			// existing fixture
+			if (MaximumStrobeDuration == 0)
+			{
+				// Default the maximum strobe duration
+				MaximumStrobeDuration = MaxStrobeDuration;
+			}
+
 			Layout();						
 		}
 	

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -1393,6 +1393,7 @@ namespace VixenModules.Preview.VixenPreview
 							// Restore the selected display item
 							_selectedDisplayItem = selectedDisplayItem;
 
+							// Associate the node with the shape and transfer any constraints from the node to the shape
 							_selectedDisplayItem.Shape.Reconfigure(elementsForm.SelectedNode);
 
 							// Restore the selected display item
@@ -1528,7 +1529,7 @@ namespace VixenModules.Preview.VixenPreview
 						PreviewMovingHead movingHead = (PreviewMovingHead)clonedDisplayItem.Shape;
 
 						// Update the node associated with the shape
-						movingHead.Node = node;
+						clonedDisplayItem.Shape.Reconfigure(node);
 					}
 
 					// Add the cloned display item to the preview


### PR DESCRIPTION
VIX-3513  Intelligent fixture wizard doesn't copy pan/tilt start/end properties

This branch is based off of VIX-3519.  It is probably going to need to be rebased after VIX-3521 is merged.