### PR TITLE
VIX-3558 Catel, Orc libraries need updated to more current versions.

### DIFF
--- a/src/Vixen.Application/Setup/ElementTemplates/IntelligentFixtureTemplate.cs
+++ b/src/Vixen.Application/Setup/ElementTemplates/IntelligentFixtureTemplate.cs
@@ -937,7 +937,7 @@ namespace VixenApplication.Setup.ElementTemplates
 			IWizardService wizardService = (IWizardService)dependencyResolver.Resolve(typeof(IWizardService));
 
 			// Display the intelligent fixture wizard
-			bool? result = await wizardService.ShowWizardAsync(_wizard);
+			bool? result = (await wizardService.ShowWizardAsync(_wizard)).DialogResult;
 
 			// Return whether the wizard was completed or cancelled
 			return result;

--- a/src/Vixen.Application/Vixen.Application.csproj
+++ b/src/Vixen.Application/Vixen.Application.csproj
@@ -27,10 +27,10 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.Core" Version="5.12.22" />
+				<PackageReference Include="Catel.Core" Version="6.0.3" />
 				<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 				<PackageReference Include="NLog" Version="5.3.2" />
-				<PackageReference Include="Orchestra.Core" Version="6.8.1" />
+				<PackageReference Include="Orchestra.Core" Version="7.0.1" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Application/VixenApplication.cs
+++ b/src/Vixen.Application/VixenApplication.cs
@@ -25,6 +25,7 @@ using Timer = System.Windows.Forms.Timer;
 using WPFApplication = System.Windows.Application;
 using System.ComponentModel;
 using System.Drawing;
+using Common.WPFCommon.Services;
 
 namespace VixenApplication
 {
@@ -443,7 +444,8 @@ namespace VixenApplication
 		private void RegisterIOC()
 		{
 			var serviceLocator = ServiceLocator.Default;
-			serviceLocator.AutoRegisterTypesViaAttributes = true;
+			serviceLocator.RegisterType<IDownloadService, DownloadService>(); 
+			serviceLocator.RegisterType<IMessageBoxService, MessageBoxService>(); 
 		}
 
 		private void VixenApplication_Shown(object sender, EventArgs e)

--- a/src/Vixen.Common/DiscreteColorPicker/DiscreteColorPicker.csproj
+++ b/src/Vixen.Common/DiscreteColorPicker/DiscreteColorPicker.csproj
@@ -5,8 +5,8 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.Core" Version="5.12.22" />
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.Core" Version="6.0.3" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
 		</ItemGroup>
 

--- a/src/Vixen.Common/DiscreteColorPicker/ViewModels/ColorItems/ColorItem.cs
+++ b/src/Vixen.Common/DiscreteColorPicker/ViewModels/ColorItems/ColorItem.cs
@@ -23,7 +23,7 @@ namespace Common.DiscreteColorPicker.ViewModels
 		/// <summary>
 		/// Item Color property data.
 		/// </summary>
-		public static readonly PropertyData ItemColorPropertyData = RegisterProperty(nameof(ItemColor), typeof(Color));
+		public static readonly IPropertyData ItemColorPropertyData = RegisterProperty<Color>(nameof(ItemColor));
 
 		/// <summary>
 		/// True when the Item is selected in the ListBox.
@@ -37,7 +37,7 @@ namespace Common.DiscreteColorPicker.ViewModels
 		/// <summary>
 		/// IsSelected property data.
 		/// </summary>
-		public static readonly PropertyData IsSelectedPropertyData = RegisterProperty(nameof(IsSelected), typeof(bool));
+		public static readonly IPropertyData IsSelectedPropertyData = RegisterProperty<bool>(nameof(IsSelected));
 
 		#endregion
 	}

--- a/src/Vixen.Common/DiscreteColorPicker/ViewModels/ColorItems/MultiSelectColorItem.cs
+++ b/src/Vixen.Common/DiscreteColorPicker/ViewModels/ColorItems/MultiSelectColorItem.cs
@@ -22,7 +22,7 @@ namespace Common.DiscreteColorPicker.ViewModels
 		/// <summary>
 		/// Check box selected property data.
 		/// </summary>
-		public static readonly PropertyData CheckBoxSelectedPropertyData = RegisterProperty(nameof(CheckBoxSelected), typeof(bool));
+		public static readonly IPropertyData CheckBoxSelectedPropertyData = RegisterProperty<bool>(nameof(CheckBoxSelected));
 
 		#endregion
 	}

--- a/src/Vixen.Common/WPFCommon/Services/DownloadService.cs
+++ b/src/Vixen.Common/WPFCommon/Services/DownloadService.cs
@@ -4,7 +4,6 @@ using Catel.IoC;
 
 namespace Common.WPFCommon.Services
 {
-	[ServiceLocatorRegistration(typeof(IDownloadService))]
 	public class DownloadService:IDownloadService
 	{
 		private static NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();

--- a/src/Vixen.Common/WPFCommon/Services/MessageBoxService.cs
+++ b/src/Vixen.Common/WPFCommon/Services/MessageBoxService.cs
@@ -7,7 +7,6 @@ using Common.Controls;
 
 namespace Common.WPFCommon.Services
 {
-	[ServiceLocatorRegistration(typeof(IMessageBoxService))]
 	public class MessageBoxService : IMessageBoxService
 	{
 		public MessageBoxResponse GetUserInput(string question, string title, string defaultText, Form parent=null)

--- a/src/Vixen.Common/WPFCommon/WPFCommon.csproj
+++ b/src/Vixen.Common/WPFCommon/WPFCommon.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Catel.MVVM" Version="5.12.22" />
+    <PackageReference Include="Catel.Core" Version="6.0.3" />
+    <PackageReference Include="Catel.MVVM" Version="6.0.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
     <PackageReference Include="NLog" Version="5.3.2" />
   </ItemGroup>

--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
@@ -30,7 +30,8 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.Core" Version="6.0.3" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
 				<PackageReference Include="LiteDB" Version="5.0.20" />
 				<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />

--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditorModule.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditorModule.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Forms.Integration;
 using Catel.IoC;
+using Common.WPFCommon.Services;
 using Vixen.Module.App;
 using Vixen.Sys;
 using VixenModules.App.CustomPropEditor.Model;
@@ -16,7 +17,9 @@ namespace VixenModules.App.CustomPropEditor
 		public override void Loading()
 		{
 			var serviceLocator = ServiceLocator.Default;
-			serviceLocator.AutoRegisterTypesViaAttributes = true;
+			serviceLocator.RegisterType<IDownloadService, DownloadService>();
+			serviceLocator.RegisterType<IMessageBoxService, MessageBoxService>();
+			
 			AddApplicationMenu();
 			Configuration config = new Configuration((CustomPropEditorData)StaticModuleData);
 			ConfigurationService service = ConfigurationService.Instance();

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ConfigurationWindowViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ConfigurationWindowViewModel.cs
@@ -41,7 +41,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Config property data.
 		/// </summary>
-		public static readonly PropertyData ConfigProperty = RegisterProperty("Config", typeof(Configuration));
+		public static readonly IPropertyData ConfigProperty = RegisterProperty<Configuration>(nameof(Config));
 
 		#endregion
 
@@ -59,7 +59,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// LightColor property data.
 		/// </summary>
-		public static readonly PropertyData LightColorProperty = RegisterProperty("LightColor", typeof(Color));
+		public static readonly IPropertyData LightColorProperty = RegisterProperty<Color>(nameof(LightColor));
 
 		#endregion
 
@@ -77,7 +77,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedLightColor property data.
 		/// </summary>
-		public static readonly PropertyData SelectedLightColorProperty = RegisterProperty("SelectedLightColor", typeof(Color), null);
+		public static readonly IPropertyData SelectedLightColorProperty = RegisterProperty<Color>(nameof(SelectedLightColor));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/DrawingPanelViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/DrawingPanelViewModel.cs
@@ -90,7 +90,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Prop property data.
 		/// </summary>
-		public static readonly PropertyData PropProperty = RegisterProperty("Prop", typeof(Prop));
+		public static readonly IPropertyData PropProperty = RegisterProperty<Prop>(nameof(Prop));
 
 		#endregion
 
@@ -110,7 +110,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// LightNodes property data.
 		/// </summary>
-		public static readonly PropertyData LightNodesProperty = RegisterProperty("LightNodes", typeof(ObservableCollection<LightViewModel>));
+		public static readonly IPropertyData LightNodesProperty = RegisterProperty<ObservableCollection<LightViewModel>>(nameof(LightNodes));
 
 		#endregion
 
@@ -129,7 +129,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Width property data.
 		/// </summary>
-		public static readonly PropertyData WidthProperty = RegisterProperty("Width", typeof(double), null);
+		public static readonly IPropertyData WidthProperty = RegisterProperty<double>(nameof(Width));
 
 		#endregion
 
@@ -148,7 +148,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Height property data.
 		/// </summary>
-		public static readonly PropertyData HeightProperty = RegisterProperty("Height", typeof(double), null);
+		public static readonly IPropertyData HeightProperty = RegisterProperty<double>(nameof(Height));
 
 		#endregion
 
@@ -167,7 +167,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Image property data.
 		/// </summary>
-		public static readonly PropertyData ImageProperty = RegisterProperty("Image", typeof(BitmapSource), null);
+		public static readonly IPropertyData ImageProperty = RegisterProperty<BitmapSource>(nameof(Image));
 
 		#endregion
 
@@ -186,7 +186,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Opacity property data.
 		/// </summary>
-		public static readonly PropertyData OpacityProperty = RegisterProperty("Opacity", typeof(double), null);
+		public static readonly IPropertyData OpacityProperty = RegisterProperty<double>(nameof(Opacity));
 
 		#endregion
 
@@ -204,7 +204,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsDrawing property data.
 		/// </summary>
-		public static readonly PropertyData IsDrawingProperty = RegisterProperty("IsDrawing", typeof(bool));
+		public static readonly IPropertyData IsDrawingProperty = RegisterProperty<bool>(nameof(IsDrawing));
 
 		#endregion
 
@@ -223,7 +223,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Confguration property data.
 		/// </summary>
-		public static readonly PropertyData ConfgurationProperty = RegisterProperty("Configuration", typeof(Configuration));
+		public static readonly IPropertyData ConfgurationProperty = RegisterProperty<Configuration>(nameof(Configuration));
 
 		#endregion
 
@@ -242,7 +242,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// LightColor property data.
 		/// </summary>
-		public static readonly PropertyData LightColorProperty = RegisterProperty("LightColor", typeof(Color), null);
+		public static readonly IPropertyData LightColorProperty = RegisterProperty<Color>(nameof(LightColor));
 
 		#endregion
 
@@ -261,7 +261,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedLightColor property data.
 		/// </summary>
-		public static readonly PropertyData SelectedLightColorProperty = RegisterProperty("SelectedLightColor", typeof(Color), null);
+		public static readonly IPropertyData SelectedLightColorProperty = RegisterProperty<Color>(nameof(SelectedLightColor));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
@@ -42,7 +42,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ElementModel property data.
 		/// </summary>
-		public static readonly PropertyData ElementModelProperty = RegisterProperty("ElementModel", typeof(ElementModel));
+		public static readonly IPropertyData ElementModelProperty = RegisterProperty<ElementModel>(nameof(ElementModel));
 
 		#endregion
 
@@ -62,7 +62,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Children property data.
 		/// </summary>
-		public static readonly PropertyData ChildrenProperty = RegisterProperty("Children", typeof(ObservableCollection<ElementModel>), null);
+		public static readonly IPropertyData ChildrenProperty = RegisterProperty<ObservableCollection<ElementModel>>(nameof(Children));
 
 		#endregion
 
@@ -81,7 +81,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ChildrenViewModels property data.
 		/// </summary>
-		public static readonly PropertyData ChildrenViewModelsProperty = RegisterProperty("ChildrenViewModels", typeof(ElementViewModelCollection));
+		public static readonly IPropertyData ChildrenViewModelsProperty = RegisterProperty<ElementViewModelCollection>(nameof(ChildrenViewModels));
 
 		#endregion
 
@@ -109,7 +109,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsSelected property data.
 		/// </summary>
-		public static readonly PropertyData IsSelectedProperty = RegisterProperty("IsSelected", typeof(bool));
+		public static readonly IPropertyData IsSelectedProperty = RegisterProperty<bool>(nameof(IsSelected));
 
 		#endregion
 
@@ -136,7 +136,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsExpanded property data.
 		/// </summary>
-		public static readonly PropertyData IsExpandedProperty = RegisterProperty("IsExpanded", typeof(bool));
+		public static readonly IPropertyData IsExpandedProperty = RegisterProperty<bool>(nameof(IsExpanded));
 
 		#endregion
 
@@ -155,7 +155,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsEditing property data.
 		/// </summary>
-		public static readonly PropertyData IsEditingProperty = RegisterProperty("IsEditing", typeof(bool));
+		public static readonly IPropertyData IsEditingProperty = RegisterProperty<bool>(nameof(IsEditing));
 
 		#endregion
 
@@ -190,7 +190,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				object oldValue = ElementModel.Name;
 				ElementModel.Name = value;
 				IsDirty = true;
-				RaisePropertyChanged(nameof(Name), oldValue , value);
+				RaisePropertyChanged(nameof(Name));
 			}
 		}
 
@@ -212,7 +212,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				object oldValue = ElementModel.FaceDefinition.FaceComponent;
 				ElementModel.FaceDefinition.FaceComponent = value;
 				IsDirty = true;
-				RaisePropertyChanged(nameof(FaceComponent), oldValue, value);
+				RaisePropertyChanged(nameof(FaceComponent)); 
 			}
 		}
 
@@ -260,7 +260,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				object oldValue = ElementModel.StateDefinition.Name;
 				ElementModel.StateDefinition.Name = value;
 				IsDirty = true;
-				RaisePropertyChanged(nameof(StateName), oldValue, value);
+				RaisePropertyChanged(nameof(StateName)); 
 			}
 		}
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementOrderViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementOrderViewModel.cs
@@ -52,7 +52,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Prop property data.
 		/// </summary>
-		public static readonly PropertyData PropProperty = RegisterProperty("Prop", typeof(Prop));
+		public static readonly IPropertyData PropProperty = RegisterProperty<Prop>(nameof(Prop));
 
 		#endregion
 
@@ -70,7 +70,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// LeafNodes property data.
 		/// </summary>
-		public static readonly PropertyData LeafNodesProperty = RegisterProperty("LeafNodes", typeof(ObservableCollection<ElementModelViewModel>));
+		public static readonly IPropertyData LeafNodesProperty = RegisterProperty<ObservableCollection<ElementModelViewModel>>(nameof(LeafNodes));
 
 		#endregion
 
@@ -88,7 +88,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedItems property data.
 		/// </summary>
-		public static readonly PropertyData SelectedItemsProperty = RegisterProperty("SelectedItems", typeof(ObservableCollection<ElementModelViewModel>));
+		public static readonly IPropertyData SelectedItemsProperty = RegisterProperty<ObservableCollection<ElementModelViewModel>>(nameof(SelectedItems));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementTreeViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementTreeViewModel.cs
@@ -57,7 +57,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Prop property data.
 		/// </summary>
-		public static readonly PropertyData PropProperty = RegisterProperty("Prop", typeof(Prop));
+		public static readonly IPropertyData PropProperty = RegisterProperty<Prop>(nameof(Prop));
 
 		#endregion
 
@@ -76,7 +76,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// RootNodes property data.
 		/// </summary>
-		public static readonly PropertyData RootNodesProperty = RegisterProperty("RootNodes", typeof(ObservableCollection<ElementModel>), null);
+		public static readonly IPropertyData RootNodesProperty = RegisterProperty<ObservableCollection<ElementModel>>(nameof(RootNodes));
 
 		#endregion
 
@@ -94,7 +94,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// RootNodesViewModels property data.
 		/// </summary>
-		public static readonly PropertyData RootNodesViewModelsProperty = RegisterProperty("RootNodesViewModels", typeof(ObservableCollection<ElementModelViewModel>));
+		public static readonly IPropertyData RootNodesViewModelsProperty = RegisterProperty<ObservableCollection<ElementModelViewModel>>(nameof(RootNodesViewModels));
 
 		#endregion
 
@@ -112,8 +112,8 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedItems property data.
 		/// </summary>
-		public static readonly PropertyData SelectedItemsProperty =
-			RegisterProperty("SelectedItems", typeof(ObservableCollection<ElementModelViewModel>), null);
+		public static readonly IPropertyData SelectedItemsProperty =
+			RegisterProperty<ObservableCollection<ElementModelViewModel>>(nameof(SelectedItems));
 
 
 		private void SelectedItems_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -152,7 +152,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedItem property data.
 		/// </summary>
-		public static readonly PropertyData SelectedItemProperty = RegisterProperty("SelectedItem", typeof(ElementModelViewModel));
+		public static readonly IPropertyData SelectedItemProperty = RegisterProperty<ElementModelViewModel>(nameof(SelectedItem));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/LightViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/LightViewModel.cs
@@ -37,7 +37,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// LightNode property data.
 		/// </summary>
-		public static readonly PropertyData LightProperty = RegisterProperty("Light", typeof(Light));
+		public static readonly IPropertyData LightProperty = RegisterProperty<Light>(nameof(Light));
 
 		#endregion
 
@@ -56,7 +56,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Id property data.
 		/// </summary>
-		public static readonly PropertyData IdProperty = RegisterProperty("Id", typeof(Guid), null);
+		public static readonly IPropertyData IdProperty = RegisterProperty<Guid>(nameof(Id));
 
 		#endregion
 
@@ -75,7 +75,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// X property data.
 		/// </summary>
-		public static readonly PropertyData XProperty = RegisterProperty("X", typeof(double), null);
+		public static readonly IPropertyData XProperty = RegisterProperty<double>(nameof(X));
 
 		#endregion
 
@@ -94,7 +94,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Y property data.
 		/// </summary>
-		public static readonly PropertyData YProperty = RegisterProperty("Y", typeof(double), null);
+		public static readonly IPropertyData YProperty = RegisterProperty<double>(nameof(Y));
 
 		#endregion
 
@@ -113,7 +113,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Size property data.
 		/// </summary>
-		public static readonly PropertyData SizeProperty = RegisterProperty("Size", typeof(double), null);
+		public static readonly IPropertyData SizeProperty = RegisterProperty<double>(nameof(Size));
 
 		#endregion
 
@@ -132,7 +132,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Center property data.
 		/// </summary>
-		public static readonly PropertyData CenterProperty = RegisterProperty("Center", typeof(Point), null);
+		public static readonly IPropertyData CenterProperty = RegisterProperty<Point>(nameof(Center));
 
 		#endregion
 
@@ -155,7 +155,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsSelected property data.
 		/// </summary>
-		public static readonly PropertyData IsSelectedProperty = RegisterProperty("IsSelected", typeof(bool));
+		public static readonly IPropertyData IsSelectedProperty = RegisterProperty<bool>(nameof(IsSelected));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PhysicalMetadataViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PhysicalMetadataViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Controls.WpfPropertyGrid;
+using Catel.Data;
 using Catel.MVVM;
 using VixenModules.App.CustomPropEditor.Converters;
 using VixenModules.App.CustomPropEditor.Model;
@@ -30,7 +31,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// PropertyName property data.
 		/// </summary>
-		public static readonly PropertyData PhysicalMetadataProperty = RegisterProperty("PhysicalMetadata", typeof(PhysicalMetadata));
+		public static readonly IPropertyData PhysicalMetadataProperty = RegisterProperty<PhysicalMetadata>(nameof(PhysicalMetadata));
 
 		#endregion
 
@@ -51,7 +52,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Height property data.
 		/// </summary>
-		public static readonly PropertyData HeightProperty = RegisterProperty("Height", typeof(string), null);
+		public static readonly IPropertyData HeightProperty = RegisterProperty<string>(nameof(Height));
 
 		#endregion
 
@@ -72,7 +73,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Width property data.
 		/// </summary>
-		public static readonly PropertyData WidthProperty = RegisterProperty("Width", typeof(string), null);
+		public static readonly IPropertyData WidthProperty = RegisterProperty<string>(nameof(Width));
 
 		#endregion
 
@@ -93,7 +94,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Material property data.
 		/// </summary>
-		public static readonly PropertyData MaterialProperty = RegisterProperty("Material", typeof(string), null);
+		public static readonly IPropertyData MaterialProperty = RegisterProperty<string>(nameof(Material));
 
 		#endregion
 
@@ -114,7 +115,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Depth property data.
 		/// </summary>
-		public static readonly PropertyData DepthProperty = RegisterProperty("Depth", typeof(string), null);
+		public static readonly IPropertyData DepthProperty = RegisterProperty<string>(nameof(Depth));
 
 		#endregion
 
@@ -135,7 +136,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// NodeCount property data.
 		/// </summary>
-		public static readonly PropertyData NodeCountProperty = RegisterProperty("NodeCount", typeof(string));
+		public static readonly IPropertyData NodeCountProperty = RegisterProperty<string>(nameof(NodeCount));
 
 		#endregion
 
@@ -158,7 +159,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// BulbType property data.
 		/// </summary>
-		public static readonly PropertyData BulbTypeProperty = RegisterProperty("BulbType", typeof(string), null);
+		public static readonly IPropertyData BulbTypeProperty = RegisterProperty<string>(nameof(BulbType));
 
 		#endregion
 
@@ -182,7 +183,7 @@ This maps to color handling in the Display Setup.")]
 		/// <summary>
 		/// ColorMode property data.
 		/// </summary>
-		public static readonly PropertyData ColorModeProperty = RegisterProperty("ColorMode", typeof(ColorMode), null);
+		public static readonly IPropertyData ColorModeProperty = RegisterProperty<ColorMode>(nameof(ColorMode));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -20,6 +20,7 @@ using VixenModules.App.CustomPropEditor.Model.InternalVendorInventory;
 using VixenModules.App.CustomPropEditor.Services;
 using ModelType = VixenModules.App.CustomPropEditor.Model.InternalVendorInventory.ModelType;
 using PropertyData = Catel.Data.PropertyData;
+using Catel.Data;
 
 namespace VixenModules.App.CustomPropEditor.ViewModels
 {
@@ -59,7 +60,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Prop property data.
 		/// </summary>
-		public static readonly PropertyData PropProperty = RegisterProperty("Prop", typeof(Prop));
+		public static readonly IPropertyData PropProperty = RegisterProperty<Prop>(nameof(Prop));
 
 		#endregion
 
@@ -78,7 +79,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty("Name", typeof(string), null);
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -100,7 +101,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Category property data.
 		/// </summary>
-		public static readonly PropertyData CategoryProperty = RegisterProperty("Type", typeof(string), null);
+		public static readonly IPropertyData CategoryProperty = RegisterProperty<string>(nameof(Type));
 
 		#endregion
 
@@ -122,7 +123,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// CreatedBy property data.
 		/// </summary>
-		public static readonly PropertyData CreatedByProperty = RegisterProperty("CreatedBy", typeof(string), null);
+		public static readonly IPropertyData CreatedByProperty = RegisterProperty<string>(nameof(CreatedBy));
 
 		#endregion
 
@@ -144,7 +145,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// CreationDate property data.
 		/// </summary>
-		public static readonly PropertyData CreationDateProperty = RegisterProperty("CreationDate", typeof(DateTime), null);
+		public static readonly IPropertyData CreationDateProperty = RegisterProperty<DateTime>(nameof(CreationDate));
 
 		#endregion
 
@@ -167,7 +168,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ModifiedDate property data.
 		/// </summary>
-		public static readonly PropertyData ModifiedDateProperty = RegisterProperty("ModifiedDate", typeof(DateTime), null);
+		public static readonly IPropertyData ModifiedDateProperty = RegisterProperty<DateTime>(nameof(ModifiedDate));
 
 		#endregion
 
@@ -187,7 +188,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// VendorMetadata property data.
 		/// </summary>
-		public static readonly PropertyData VendorMetadataProperty = RegisterProperty("VendorMetadata", typeof(VendorMetadata), null);
+		public static readonly IPropertyData VendorMetadataProperty = RegisterProperty<VendorMetadata>(nameof(VendorMetadata));
 
 		#endregion
 
@@ -207,7 +208,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// PhysicalMetadata property data.
 		/// </summary>
-		public static readonly PropertyData PhysicalMetadataProperty = RegisterProperty("PhysicalMetadata", typeof(PhysicalMetadata), null);
+		public static readonly IPropertyData PhysicalMetadataProperty = RegisterProperty<PhysicalMetadata>(nameof(PhysicalMetadata));
 
 		#endregion
 
@@ -227,7 +228,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// InformationMetadata property data.
 		/// </summary>
-		public static readonly PropertyData InformationMetadataProperty = RegisterProperty("InformationMetadata", typeof(InformationMetadata), null);
+		public static readonly IPropertyData InformationMetadataProperty = RegisterProperty<InformationMetadata>(nameof(InformationMetadata));
 
 		#endregion
 
@@ -273,7 +274,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// DrawingPanelViewModel property data.
 		/// </summary>
-		public static readonly PropertyData DrawingPanelViewModelProperty = RegisterProperty("DrawingPanelViewModel", typeof(DrawingPanelViewModel));
+		public static readonly IPropertyData DrawingPanelViewModelProperty = RegisterProperty<DrawingPanelViewModel>(nameof(DrawingPanelViewModel));
 
 		#endregion
 
@@ -292,7 +293,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ElementTreeViewModel property data.
 		/// </summary>
-		public static readonly PropertyData ElementTreeViewModelProperty = RegisterProperty("ElementTreeViewModel", typeof(ElementTreeViewModel));
+		public static readonly IPropertyData ElementTreeViewModelProperty = RegisterProperty<ElementTreeViewModel>(nameof(ElementTreeViewModel));
 
 		#endregion
 
@@ -311,7 +312,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ElementOrderViewModel property data.
 		/// </summary>
-		public static readonly PropertyData ElementOrderViewModelProperty = RegisterProperty("ElementOrderViewModel", typeof(ElementOrderViewModel));
+		public static readonly IPropertyData ElementOrderViewModelProperty = RegisterProperty<ElementOrderViewModel>(nameof(ElementOrderViewModel));
 
 		#endregion
 
@@ -330,7 +331,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// FilePath property data.
 		/// </summary>
-		public static readonly PropertyData FilePathProperty = RegisterProperty("FilePath", typeof(string));
+		public static readonly IPropertyData FilePathProperty = RegisterProperty<string>(nameof(FilePath));
 
 		#endregion
 
@@ -349,8 +350,8 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedTabIndex property data.
 		/// </summary>
-		public static readonly PropertyData SelectedTabIndexProperty =
-			RegisterProperty("SelectedTabIndex", typeof(int), null, (sender, e) => ((PropEditorViewModel) sender).OnSelectedTabIndexChanged());
+		public static readonly IPropertyData SelectedTabIndexProperty =
+			RegisterProperty<int>(nameof(SelectedTabIndex), null, (sender, e) => ((PropEditorViewModel) sender).OnSelectedTabIndexChanged());
 
 		/// <summary>
 		/// Called when the SelectedTabIndex property has changed.
@@ -593,7 +594,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				string path = result.FileNames.First();
 				if (!string.IsNullOrEmpty(path))
 				{
-					var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+					var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 					pleaseWaitService.Show();
 					LoadPropFromPath(path);
 					pleaseWaitService.Hide();
@@ -778,7 +779,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				string path = result.FileName;
 				if (!string.IsNullOrEmpty(path))
 				{
-					var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+					var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 					pleaseWaitService.Show();
 					await ImportProp(path);
 					pleaseWaitService.Hide();
@@ -861,7 +862,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 			if (!vendorInventories.Any()) { return; }
 			var uiVisualizerService = dependencyResolver.Resolve<IUIVisualizerService>();
 			var vm = new VendorInventoryWindowViewModel(vendorInventories, dependencyResolver.Resolve<IProcessService>());
-			bool? result = await uiVisualizerService.ShowDialogAsync(vm);
+			bool? result = (await uiVisualizerService.ShowDialogAsync(vm)).DialogResult;
 
 			if (result.HasValue && result.Value)
 			{
@@ -1120,7 +1121,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 			var targetPath = Path.Combine(Path.GetTempPath() + Guid.NewGuid());
 			var dependencyResolver = this.GetDependencyResolver();
 			var ds = dependencyResolver.Resolve<IDownloadService>();
-			var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+			var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 			var mbs = dependencyResolver.Resolve<IMessageBoxService>();
 
 			var status = new Tuple<bool, ModelType>(false, ModelType.XModel);

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/VendorInventoryWindowViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/VendorInventoryWindowViewModel.cs
@@ -38,7 +38,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedInventory property data.
 		/// </summary>
-		public static readonly PropertyData SelectedInventoryProperty = RegisterProperty("SelectedInventory", typeof(ModelInventory));
+		public static readonly IPropertyData SelectedInventoryProperty = RegisterProperty<ModelInventory>(nameof(SelectedInventory));
 
 		#endregion
 
@@ -57,7 +57,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Inventory property data.
 		/// </summary>
-		public static readonly PropertyData InventoryProperty = RegisterProperty("VendorInventories", typeof(List<ModelInventory>));
+		public static readonly IPropertyData InventoryProperty = RegisterProperty<List<ModelInventory>>(nameof(VendorInventories));
 
 		#endregion
 
@@ -75,7 +75,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedProduct property data.
 		/// </summary>
-		public static readonly PropertyData SelectedProductProperty = RegisterProperty("SelectedProduct", typeof(Product));
+		public static readonly IPropertyData SelectedProductProperty = RegisterProperty<Product>(nameof(SelectedProduct));
 
 		#endregion
 
@@ -93,7 +93,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// SelectedModelLink property data.
 		/// </summary>
-		public static readonly PropertyData SelectedModelLinkProperty = RegisterProperty("SelectedModelLink", typeof(ModelLink));
+		public static readonly IPropertyData SelectedModelLinkProperty = RegisterProperty<ModelLink>(nameof(SelectedModelLink));
 
 		#endregion
 
@@ -111,7 +111,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ShowModelTab property data.
 		/// </summary>
-		public static readonly PropertyData IsModelValidProperty = RegisterProperty("IsModelValid", typeof(bool));
+		public static readonly IPropertyData IsModelValidProperty = RegisterProperty<bool>(nameof(IsModelValid));
 
 		#endregion
 
@@ -131,7 +131,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// IsProductVisible property data.
 		/// </summary>
-		public static readonly PropertyData IsProductVisibleProperty = RegisterProperty("IsProductVisible", typeof(bool));
+		public static readonly IPropertyData IsProductVisibleProperty = RegisterProperty<bool>(nameof(IsProductVisible));
 
 		#endregion
 
@@ -151,7 +151,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// ProductTabSelected property data.
 		/// </summary>
-		public static readonly PropertyData IsProductViewSelectedProperty = RegisterProperty("IsProductViewSelected", typeof(bool));
+		public static readonly IPropertyData IsProductViewSelectedProperty = RegisterProperty<bool>(nameof(IsProductViewSelected));
 
 		#endregion
 
@@ -196,7 +196,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// DialogResult property data.
 		/// </summary>
-		public static readonly PropertyData DialogResultProperty = RegisterProperty("DialogResult", typeof(bool));
+		public static readonly IPropertyData DialogResultProperty = RegisterProperty<bool>(nameof(DialogResult));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/VendorMetadataViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/VendorMetadataViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Controls.WpfPropertyGrid;
+using Catel.Data;
 using Catel.MVVM;
 using VixenModules.App.CustomPropEditor.Model;
 using PropertyData = Catel.Data.PropertyData;
@@ -29,7 +30,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 	    /// <summary>
 	    /// VendorMetadata property data.
 	    /// </summary>
-	    public static readonly PropertyData VendorMetadataProperty = RegisterProperty("VendorMetadata", typeof(VendorMetadata));
+	    public static readonly IPropertyData VendorMetadataProperty = RegisterProperty<VendorMetadata>(nameof(VendorMetadata));
 
 		#endregion
 
@@ -50,7 +51,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// Vendor property data.
 		/// </summary>
-		public static readonly PropertyData VendorProperty = RegisterProperty("Name", typeof(string), null);
+		public static readonly IPropertyData VendorProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -71,7 +72,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 	    /// <summary>
 	    /// Contact property data.
 	    /// </summary>
-	    public static readonly PropertyData ContactProperty = RegisterProperty("Contact", typeof(string), null);
+	    public static readonly IPropertyData ContactProperty = RegisterProperty<string>(nameof(Contact));
 
 	    #endregion
 
@@ -93,7 +94,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// VendorUrl property data.
 		/// </summary>
-		public static readonly PropertyData VendorUrlProperty = RegisterProperty("Website", typeof(string), null);
+		public static readonly IPropertyData VendorUrlProperty = RegisterProperty<string>(nameof(Website));
 
 		#endregion
 
@@ -115,7 +116,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// <summary>
 		/// VendorEmail property data.
 		/// </summary>
-		public static readonly PropertyData VendorEmailProperty = RegisterProperty("Email", typeof(string), null);
+		public static readonly IPropertyData VendorEmailProperty = RegisterProperty<string>(nameof(Email));
 
 		#endregion
 
@@ -133,10 +134,10 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		    set { SetValue(PhoneProperty, value); }
 	    }
 
-	    /// <summary>
-	    /// Phone property data.
-	    /// </summary>
-	    public static readonly PropertyData PhoneProperty = RegisterProperty("Phone", typeof(string), null);
+		/// <summary>
+		/// Phone property data.
+		/// </summary>
+		public static readonly IPropertyData PhoneProperty = RegisterProperty<string>(nameof(Phone));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/LipSyncApp/LipSyncApp.csproj
+++ b/src/Vixen.Modules/App/LipSyncApp/LipSyncApp.csproj
@@ -7,7 +7,7 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="NLog" Version="5.3.2" />
 		</ItemGroup>
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMap.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMap.cs
@@ -33,7 +33,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// Id property data.
 		/// </summary>
-		public static readonly PropertyData IdProperty = RegisterProperty("Id", typeof(Guid));
+		public static readonly IPropertyData IdProperty = RegisterProperty<Guid>(nameof(Id));
 
 		#endregion
 
@@ -51,7 +51,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty("Name", typeof(string));
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -73,7 +73,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// ElementMappings property data.
 		/// </summary>
-		public static readonly PropertyData ElementMappingsProperty = RegisterProperty("ElementMappings", typeof(FastObservableCollection<ElementMapping>));
+		public static readonly IPropertyData ElementMappingsProperty = RegisterProperty<FastObservableCollection<ElementMapping>>(nameof(ElementMappings));
 
 		#endregion
 
@@ -91,7 +91,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// SourceTree property data.
 		/// </summary>
-		public static readonly PropertyData SourceTreeProperty = RegisterProperty("SourceTree", typeof(ElementNodeProxy));
+		public static readonly IPropertyData SourceTreeProperty = RegisterProperty<ElementNodeProxy>(nameof(SourceTree));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMapping.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/Models/ElementMapping.cs
@@ -31,7 +31,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// SourceName property data.
 		/// </summary>
-		public static readonly PropertyData SourceNameProperty = RegisterProperty("SourceName", typeof(string));
+		public static readonly IPropertyData SourceNameProperty = RegisterProperty<string>(nameof(SourceName));
 
 		#endregion
 
@@ -49,7 +49,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// SourceId property data.
 		/// </summary>
-		public static readonly PropertyData SourceIdProperty = RegisterProperty("SourceId", typeof(Guid));
+		public static readonly IPropertyData SourceIdProperty = RegisterProperty<Guid>(nameof(SourceId));
 
 		#endregion
 
@@ -67,7 +67,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// TargetName property data.
 		/// </summary>
-		public static readonly PropertyData TargetNameProperty = RegisterProperty("TargetName", typeof(string));
+		public static readonly IPropertyData TargetNameProperty = RegisterProperty<string>(nameof(TargetName));
 
 		#endregion
 
@@ -85,7 +85,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.Models
 		/// <summary>
 		/// TargetId property data.
 		/// </summary>
-		public static readonly PropertyData TargetIdProperty = RegisterProperty("TargetId", typeof(Guid));
+		public static readonly IPropertyData TargetIdProperty = RegisterProperty<Guid>(nameof(TargetId));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementMapperViewModel.cs
@@ -79,7 +79,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// Title property data.
 		/// </summary>
-		public static readonly PropertyData TitleProperty = RegisterProperty("Title", typeof(string));
+		public static readonly IPropertyData TitleProperty = RegisterProperty<string>(nameof(Title)); 
 
 		#endregion
 		// TODO: Register models with the vmpropmodel codesnippet
@@ -170,7 +170,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 				}
 			}
 			
-			var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+			var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 			pleaseWaitService.Show();
 			if(await _elementMapService.SaveMapAsync(ElementMapFilePath))
 			{
@@ -202,7 +202,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// SourceTreeView property data.
 		/// </summary>
-		public static readonly PropertyData SourceTreeViewProperty = RegisterProperty("SourceTreeView", typeof(Visibility));
+		public static readonly IPropertyData SourceTreeViewProperty = RegisterProperty<Visibility>(nameof(SourceTreeView));
 
 		#endregion
 
@@ -220,7 +220,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// BasicView property data.
 		/// </summary>
-		public static readonly PropertyData BasicViewProperty = RegisterProperty("BasicView", typeof(Visibility));
+		public static readonly IPropertyData BasicViewProperty = RegisterProperty<Visibility>(nameof(BasicView));
 
 		#endregion
 
@@ -238,7 +238,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// Elements property data.
 		/// </summary>
-		public static readonly PropertyData ElementsProperty = RegisterProperty("Elements", typeof(List<ElementNode>));
+		public static readonly IPropertyData ElementsProperty = RegisterProperty<List<ElementNode>>(nameof(Elements));
 
 		#endregion
 
@@ -256,7 +256,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// SourceElementTree property data.
 		/// </summary>
-		public static readonly PropertyData SourceElementTreeProperty = RegisterProperty("SourceElementTree", typeof(FastObservableCollection<ElementNodeProxy>));
+		public static readonly IPropertyData SourceElementTreeProperty = RegisterProperty<FastObservableCollection<ElementNodeProxy>>(nameof(SourceElementTree));
 
 		#endregion
 
@@ -278,7 +278,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// SelectedMapping property data.
 		/// </summary>
-		public static readonly PropertyData SelectedMappingProperty = RegisterProperty("SelectedMapping", typeof(ElementMapping));
+		public static readonly IPropertyData SelectedMappingProperty = RegisterProperty<ElementMapping>(nameof(SelectedMapping));
 
 		#endregion
 
@@ -297,7 +297,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// ElementMap property data.
 		/// </summary>
-		public static readonly PropertyData ElementMapProperty = RegisterProperty("ElementMap", typeof(ElementMap));
+		public static readonly IPropertyData ElementMapProperty = RegisterProperty<ElementMap>(nameof(ElementMap));
 
 		#endregion
 
@@ -417,7 +417,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 			var ofResult = await openFileService.DetermineFileAsync(determineFileContext);
 			if (ofResult.Result)
 			{
-				var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+				var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 				//var modelPersistenceService = dependencyResolver.Resolve<IModelPersistenceService<ElementMap>>();
 
 				pleaseWaitService.Show();
@@ -552,7 +552,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 			}
 			var dependencyResolver = this.GetDependencyResolver();
 			var modelPersistenceService = dependencyResolver.Resolve<IModelPersistenceService<ElementMap>>();
-			var pleaseWaitService = dependencyResolver.Resolve<IPleaseWaitService>();
+			var pleaseWaitService = dependencyResolver.Resolve<IBusyIndicatorService>();
 
 			pleaseWaitService.Show();
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementNodeProxyViewModel.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/ElementNodeProxyViewModel.cs
@@ -70,7 +70,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// ElementMapping property data.
 		/// </summary>
-		public static readonly PropertyData ElementMappingProperty = RegisterProperty("ElementMapping", typeof(ElementMapping));
+		public static readonly IPropertyData ElementMappingProperty = RegisterProperty<ElementMapping>(nameof(ElementMapping));
 
 		#endregion
 
@@ -89,7 +89,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// ElementNodeProxy property data.
 		/// </summary>
-		public static readonly PropertyData ElementNodeProxyProperty = RegisterProperty("ElementNodeProxy", typeof(ElementNodeProxy), null);
+		public static readonly IPropertyData ElementNodeProxyProperty = RegisterProperty<ElementNodeProxy>(nameof(ElementNodeProxy));
 
 		#endregion
 
@@ -108,7 +108,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty("Name", typeof(string), null);
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -127,7 +127,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// Children property data.
 		/// </summary>
-		public static readonly PropertyData ChildrenProperty = RegisterProperty("Children", typeof(List<ElementNodeProxy>), null);
+		public static readonly IPropertyData ChildrenProperty = RegisterProperty<List<ElementNodeProxy>>(nameof(Children));
 
 		#endregion
 
@@ -146,7 +146,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// TargetName property data.
 		/// </summary>
-		public static readonly PropertyData TargetNameProperty = RegisterProperty("TargetName", typeof(string), null, (sender, e) => ((ElementNodeProxyViewModel)sender).OnTargetNameChanged());
+		public static readonly IPropertyData TargetNameProperty = RegisterProperty<string>(nameof(TargetName),  default(string), (sender, e) => ((ElementNodeProxyViewModel)sender).OnTargetNameChanged());
 
 		#endregion
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/SourceTreeViewModel.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/SequenceElementMapper/ViewModels/SourceTreeViewModel.cs
@@ -35,7 +35,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// SourceTreeNodes property data.
 		/// </summary>
-		public static readonly PropertyData SourceTreeNodesProperty = RegisterProperty("SourceTreeNodes", typeof(ObservableCollection<ElementNodeProxy>));
+		public static readonly IPropertyData SourceTreeNodesProperty = RegisterProperty<ObservableCollection<ElementNodeProxy>>(nameof(SourceTreeNodes));
 
 		#endregion
 
@@ -53,7 +53,7 @@ namespace VixenModules.App.TimedSequenceMapper.SequenceElementMapper.ViewModels
 		/// <summary>
 		/// SourceTreeSelectedItem property data.
 		/// </summary>
-		public static readonly PropertyData SourceTreeSelectedItemProperty = RegisterProperty("SourceTreeSelectedItem", typeof(ElementNodeProxy));
+		public static readonly IPropertyData SourceTreeSelectedItemProperty = RegisterProperty<ElementNodeProxy>(nameof(SourceTreeSelectedItem));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/TimedSequenceMapper/TimedSequenceMapper.csproj
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/TimedSequenceMapper.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Catel.MVVM" Version="5.12.22" />
+    <PackageReference Include="Catel.MVVM" Version="6.0.3" />
     <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.2" />

--- a/src/Vixen.Modules/App/TimedSequenceMapper/TimedSequencePackagerModule.cs
+++ b/src/Vixen.Modules/App/TimedSequenceMapper/TimedSequencePackagerModule.cs
@@ -1,5 +1,7 @@
 ﻿using System.Windows.Forms;
 using Catel.IoC;
+using Common.WPFCommon.Services;
+
 using Vixen.Module;
 using Vixen.Module.App;
 using Vixen.Sys;
@@ -23,7 +25,9 @@ namespace VixenModules.App.TimedSequenceMapper
 		public override void Loading()
 		{
 			var serviceLocator = ServiceLocator.Default;
-			serviceLocator.AutoRegisterTypesViaAttributes = true;
+			serviceLocator.RegisterType<IDownloadService, DownloadService>();
+			serviceLocator.RegisterType<IMessageBoxService, MessageBoxService>();
+
 			AddApplicationMenu();
 		}
 

--- a/src/Vixen.Modules/App/TimingTrackBrowser/TimingTrackBrowser.csproj
+++ b/src/Vixen.Modules/App/TimingTrackBrowser/TimingTrackBrowser.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Catel.MVVM" Version="5.12.22" />
+    <PackageReference Include="Catel.MVVM" Version="6.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.2" />
   </ItemGroup>

--- a/src/Vixen.Modules/App/TimingTrackBrowser/ViewModels/VendorInventoryWindowViewModel.cs
+++ b/src/Vixen.Modules/App/TimingTrackBrowser/ViewModels/VendorInventoryWindowViewModel.cs
@@ -78,7 +78,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// SelectedInventory property data.
 		/// </summary>
-		public static readonly PropertyData SelectedInventoryProperty = RegisterProperty("SelectedInventory", typeof(SongInventory));
+		public static readonly IPropertyData SelectedInventoryProperty = RegisterProperty<SongInventory>(nameof(SelectedInventory));
 
 		#endregion
 
@@ -97,7 +97,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// Inventory property data.
 		/// </summary>
-		public static readonly PropertyData InventoryProperty = RegisterProperty("SongInventories", typeof(ObservableCollection<SongInventory>));
+		public static readonly IPropertyData InventoryProperty = RegisterProperty<ObservableCollection<SongInventory>>(nameof(SongInventories));
 
 		#endregion
 
@@ -115,7 +115,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// SelectedProduct property data.
 		/// </summary>
-		public static readonly PropertyData SelectedSongProperty = RegisterProperty("SelectedSong", typeof(Song));
+		public static readonly IPropertyData SelectedSongProperty = RegisterProperty<Song>(nameof(SelectedSong));
 
 		#endregion
 
@@ -133,7 +133,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// ShowModelTab property data.
 		/// </summary>
-		public static readonly PropertyData IsSongValidProperty = RegisterProperty("IsSongValid", typeof(bool));
+		public static readonly IPropertyData IsSongValidProperty = RegisterProperty<bool>(nameof(IsSongValid));
 
 		#endregion
 
@@ -153,7 +153,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// IsProductVisible property data.
 		/// </summary>
-		public static readonly PropertyData IsSongVisibleProperty = RegisterProperty("IsSongVisible", typeof(bool));
+		public static readonly IPropertyData IsSongVisibleProperty = RegisterProperty<bool>(nameof(IsSongVisible));
 
 		#endregion
 
@@ -173,7 +173,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// ProductTabSelected property data.
 		/// </summary>
-		public static readonly PropertyData IsSongViewSelectedProperty = RegisterProperty("IsSongViewSelected", typeof(bool));
+		public static readonly IPropertyData IsSongViewSelectedProperty = RegisterProperty<bool>(nameof(IsSongViewSelected));
 
 		#endregion
 
@@ -217,7 +217,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// DialogResult property data.
 		/// </summary>
-		public static readonly PropertyData DialogResultProperty = RegisterProperty("DialogResult", typeof(bool));
+		public static readonly IPropertyData DialogResultProperty = RegisterProperty<bool>(nameof(DialogResult));
 
 		#endregion
 

--- a/src/Vixen.Modules/App/TimingTrackBrowser/ViewModels/VendorMetadataViewModel.cs
+++ b/src/Vixen.Modules/App/TimingTrackBrowser/ViewModels/VendorMetadataViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Controls.WpfPropertyGrid;
+using Catel.Data;
 using Catel.MVVM;
 using VixenModules.App.TimingTrackBrowser.Model;
 using PropertyData = Catel.Data.PropertyData;
@@ -29,7 +30,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 	    /// <summary>
 	    /// VendorMetadata property data.
 	    /// </summary>
-	    public static readonly PropertyData VendorMetadataProperty = RegisterProperty("VendorMetadata", typeof(VendorMetadata));
+	    public static readonly IPropertyData VendorMetadataProperty = RegisterProperty<VendorMetadata>(nameof(VendorMetadata));
 
 		#endregion
 
@@ -50,7 +51,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// Vendor property data.
 		/// </summary>
-		public static readonly PropertyData VendorProperty = RegisterProperty("Name", typeof(string), null);
+		public static readonly IPropertyData VendorProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -71,7 +72,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 	    /// <summary>
 	    /// Contact property data.
 	    /// </summary>
-	    public static readonly PropertyData ContactProperty = RegisterProperty("Contact", typeof(string), null);
+	    public static readonly IPropertyData ContactProperty = RegisterProperty<string>(nameof(Contact));
 
 	    #endregion
 
@@ -93,7 +94,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// VendorUrl property data.
 		/// </summary>
-		public static readonly PropertyData VendorUrlProperty = RegisterProperty("Website", typeof(string), null);
+		public static readonly IPropertyData VendorUrlProperty = RegisterProperty<string>(nameof(Website));
 
 		#endregion
 
@@ -115,7 +116,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 		/// <summary>
 		/// VendorEmail property data.
 		/// </summary>
-		public static readonly PropertyData VendorEmailProperty = RegisterProperty("Email", typeof(string), null);
+		public static readonly IPropertyData VendorEmailProperty = RegisterProperty<string>(nameof(Email));
 
 		#endregion
 
@@ -136,7 +137,7 @@ namespace VixenModules.App.TimingTrackBrowser.ViewModels
 	    /// <summary>
 	    /// Phone property data.
 	    /// </summary>
-	    public static readonly PropertyData PhoneProperty = RegisterProperty("Phone", typeof(string), null);
+	    public static readonly IPropertyData PhoneProperty = RegisterProperty<string>(nameof(Phone));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixtureGraphics/FixtureGraphics.csproj
+++ b/src/Vixen.Modules/Editor/FixtureGraphics/FixtureGraphics.csproj
@@ -6,8 +6,8 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.Core" Version="5.12.22" />
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.Core" Version="6.0.3" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="OpenTK" Version="4.7.7" />
 		</ItemGroup>
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/FixturePropertyEditor.csproj
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/FixturePropertyEditor.csproj
@@ -6,8 +6,8 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.Core" Version="5.12.22" />
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.Core" Version="6.0.3" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ChannelItemViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ChannelItemViewModel.cs
@@ -85,7 +85,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function names property data.
 		/// </summary>
-		public static readonly PropertyData FunctionsProperty = RegisterProperty(nameof(Functions), typeof(ObservableCollection<string>), null);
+		public static readonly IPropertyData FunctionsProperty = RegisterProperty<ObservableCollection<string>>(nameof(Functions));
 
 		/// <summary>
 		/// Gets or sets the allowable channel numbers.
@@ -99,7 +99,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Channel numbers property data.
 		/// </summary>
-		public static readonly PropertyData ChannelNumbersProperty = RegisterProperty(nameof(ChannelNumbers), typeof(ObservableCollection<string>), null);
+		public static readonly IPropertyData ChannelNumbersProperty = RegisterProperty<ObservableCollection<string>>(nameof(ChannelNumbers));
 
 
 		/// <summary>
@@ -114,7 +114,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Channel number property data.
 		/// </summary>
-		public static readonly PropertyData ChannelNumberProperty = RegisterProperty(nameof(ChannelNumber), typeof(string), null);
+		public static readonly IPropertyData ChannelNumberProperty = RegisterProperty<string>(nameof(ChannelNumber));
 
 		/// <summary>
 		/// Function associated with the channel.
@@ -165,7 +165,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function property data.
 		/// </summary>
-		public static readonly PropertyData FunctionProperty = RegisterProperty(nameof(Function), typeof(string), null);
+		public static readonly IPropertyData FunctionProperty = RegisterProperty<string>(nameof(Function));
 
 		/// <summary>
 		/// Icon associated with the button to edit the function associated with the channel.
@@ -182,7 +182,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function property data.
 		/// </summary>
-		public static readonly PropertyData EditFunctionsImageSourceProperty = RegisterProperty(nameof(EditFunctionsImageSource), typeof(string), null);
+		public static readonly IPropertyData EditFunctionsImageSourceProperty = RegisterProperty<string>(nameof(EditFunctionsImageSource));
 
 		#endregion
 		

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ColorWheelItemViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ColorWheelItemViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Catel.Data;
+﻿using System.Drawing;
+using Catel.Data;
 using Catel.MVVM;
 using Common.Controls.ColorManagement.ColorModels;
 using Common.Controls.ColorManagement.ColorPicker;
@@ -62,7 +63,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Start value property data.
 		/// </summary>
-		public static readonly PropertyData StartValueProperty = RegisterProperty(nameof(StartValue), typeof(string), null);
+		public static readonly IPropertyData StartValueProperty = RegisterProperty<string>(nameof(StartValue));
 
 		/// <summary>
 		/// End DMX value of the color item.
@@ -82,7 +83,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// End value property data.
 		/// </summary>
-		public static readonly PropertyData EndValueProperty = RegisterProperty(nameof(EndValue), typeof(string), null);
+		public static readonly IPropertyData EndValueProperty = RegisterProperty<string>(nameof(EndValue));
 
 		/// <summary>
 		/// Indicates if the color wheel entry uses a curve beteween the start and stop values.
@@ -96,7 +97,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Use Curve value property data.
 		/// </summary>
-		public static readonly PropertyData UseCurveProperty = RegisterProperty(nameof(UseCurve), typeof(bool), null);
+		public static readonly IPropertyData UseCurveProperty = RegisterProperty<bool>(nameof(UseCurve));
 
 
 		/// <summary>
@@ -111,7 +112,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Color 1 property data.
 		/// </summary>
-		public static readonly PropertyData Color1Property = RegisterProperty(nameof(Color1), typeof(System.Drawing.Color), null);
+		public static readonly IPropertyData Color1Property = RegisterProperty<Color>(nameof(Color1));
 
 		/// <summary>
 		/// Second color associated with the color wheel item.
@@ -125,7 +126,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Color 2 property data.
 		/// </summary>
-		public static readonly PropertyData Color2Property = RegisterProperty(nameof(Color2), typeof(System.Drawing.Color), null);
+		public static readonly IPropertyData Color2Property = RegisterProperty<System.Drawing.Color>(nameof(Color2));
 		
 		/// <summary>
 		/// Color item represents a half step and contains two colors.
@@ -161,7 +162,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Half step property data.
 		/// </summary>
-		public static readonly PropertyData HalfStepProperty = RegisterProperty(nameof(HalfStep), typeof(bool), null);
+		public static readonly IPropertyData HalfStepProperty = RegisterProperty<bool>(nameof(HalfStep));
 
 		/// <summary>
 		/// Button text on the color panel.
@@ -175,7 +176,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Button text property data.
 		/// </summary>
-		public static readonly PropertyData ButtonTextProperty = RegisterProperty(nameof(ButtonText), typeof(string), null);
+		public static readonly IPropertyData ButtonTextProperty = RegisterProperty<string>(nameof(ButtonText));
 
 		/// <summary>
 		/// Indicates if the color wheel entry should be excluded from the color property of the element.
@@ -189,7 +190,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// ExcludeColor value property data.
 		/// </summary>
-		public static readonly PropertyData ExcludeColorPropertyProperty = RegisterProperty(nameof(ExcludeColorProperty), typeof(bool), null);
+		public static readonly IPropertyData ExcludeColorPropertyProperty = RegisterProperty<bool>(nameof(ExcludeColorProperty));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorViewModel.cs
@@ -78,7 +78,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function names property data.
 		/// </summary>
-		public static readonly PropertyData FunctionsProperty = RegisterProperty(nameof(Functions), typeof(ObservableCollection<string>), null);
+		public static readonly IPropertyData FunctionsProperty = RegisterProperty<ObservableCollection<string>>(nameof(Functions));
 
 		/// <summary>
 		/// Name of the fixture.
@@ -102,7 +102,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty(nameof(Name), typeof(string), null);
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		/// <summary>
 		/// Manufacturer of the fixture.
@@ -122,7 +122,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Manufacturer property data.
 		/// </summary>
-		public static readonly PropertyData ManufacturerProperty = RegisterProperty(nameof(Manufacturer), typeof(string), null);
+		public static readonly IPropertyData ManufacturerProperty = RegisterProperty<string>(nameof(Manufacturer));
 
 		/// <summary>
 		/// Name of the user that created the fixture profile.
@@ -142,7 +142,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Created By property data.
 		/// </summary>
-		public static readonly PropertyData CreatedByProperty = RegisterProperty(nameof(CreatedBy), typeof(string), null);
+		public static readonly IPropertyData CreatedByProperty = RegisterProperty<string>(nameof(CreatedBy));
 
 		/// <summary>
 		/// Revision information about the fixture profile.
@@ -162,7 +162,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Revision property data.
 		/// </summary>
-		public static readonly PropertyData RevisionProperty = RegisterProperty(nameof(Revision), typeof(string), null);
+		public static readonly IPropertyData RevisionProperty = RegisterProperty<string>(nameof(Revision));
 
 		/// <summary>
 		/// Determines if the profile properties are displayed.
@@ -182,7 +182,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// ShowProfileProperties property data.
 		/// </summary>
-		public static readonly PropertyData ShowProfilePropertiesProperty = RegisterProperty(nameof(ShowProfileProperties), typeof(bool), null);
+		public static readonly IPropertyData ShowProfilePropertiesProperty = RegisterProperty<bool>(nameof(ShowProfileProperties));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorWindowViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorWindowViewModel.cs
@@ -40,7 +40,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
         /// <summary>
         /// Fixture specification property data.
         /// </summary>
-        public static readonly PropertyData FixtureSpecificationProperty = RegisterProperty(nameof(FixtureSpecification), typeof(Tuple<FixtureSpecification, Action, bool>), null);
+        public static readonly IPropertyData FixtureSpecificationProperty = RegisterProperty<Tuple<FixtureSpecification, Action, bool>>(nameof(FixtureSpecification));
 
         #endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyWindowViewModelBase.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyWindowViewModelBase.cs
@@ -49,7 +49,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
         /// <summary>
         /// Ok tooltip property data.
         /// </summary>
-        public static readonly PropertyData OKTooltipProperty = RegisterProperty(nameof(OKTooltip), typeof(string), null);
+        public static readonly IPropertyData OKTooltipProperty = RegisterProperty<string>(nameof(OKTooltip));
 
         /// <summary>
         /// Determines if the Error triangle is displayed.
@@ -69,7 +69,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
         /// <summary>
         /// Show Error property data.
         /// </summary>
-        public static readonly PropertyData ShowErrorProperty = RegisterProperty(nameof(ShowError), typeof(Visibility), null);
+        public static readonly IPropertyData ShowErrorProperty = RegisterProperty<Visibility>(nameof(ShowError));
 
         #endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionItemViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionItemViewModel.cs
@@ -183,7 +183,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function Identities property data.
 		/// </summary>
-		public static readonly PropertyData FunctionIdentitiesProperty = RegisterProperty(nameof(FunctionIdentities), typeof(IList<FunctionIdentity>), null);
+		public static readonly IPropertyData FunctionIdentitiesProperty = RegisterProperty<IList<FunctionIdentity>>(nameof(FunctionIdentities));
 
 		/// <summary>
 		/// Type of function (Ranged, Indexed, Color Wheel etc).
@@ -234,7 +234,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function type property data.
 		/// </summary>
-		public static readonly PropertyData FunctionTypeEnumProperty = RegisterProperty(nameof(FunctionTypeEnum), typeof(FixtureFunctionTypeVM), null);
+		public static readonly IPropertyData FunctionTypeEnumProperty = RegisterProperty<FixtureFunctionTypeVM>(nameof(FunctionTypeEnum));
 
 		/// <summary>
 		/// Function identity.
@@ -264,7 +264,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Function property data.
 		/// </summary>
-		public static readonly PropertyData FunctionIdentityProperty = RegisterProperty(nameof(FunctionIdentity), typeof(FunctionIdentity), null);
+		public static readonly IPropertyData FunctionIdentityProperty = RegisterProperty<FunctionIdentity>(nameof(FunctionIdentity));
 		
 		/// <summary>
 		/// Preview legend associated with the function.
@@ -281,7 +281,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Legend property data.
 		/// </summary>
-		public static readonly PropertyData LegendProperty = RegisterProperty(nameof(Legend), typeof(string), null);
+		public static readonly IPropertyData LegendProperty = RegisterProperty<string>(nameof(Legend));
 
 		/// <summary>
 		/// Maximum rotation associated with the function.  Only applies to Pan and tilt functions.
@@ -298,7 +298,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Maximum rotation property data.
 		/// </summary>
-		public static readonly PropertyData MaximumRotationProperty = RegisterProperty(nameof(MaximumRotation), typeof(string), null);
+		public static readonly IPropertyData MaximumRotationProperty = RegisterProperty<string>(nameof(MaximumRotation));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionTypeViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionTypeViewModel.cs
@@ -89,7 +89,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Color Wheel Visible property data.
 		/// </summary>
-		public static readonly PropertyData ColorWheelVisibleProperty = RegisterProperty(nameof(ColorWheelVisible), typeof(bool), null);
+		public static readonly IPropertyData ColorWheelVisibleProperty = RegisterProperty<bool>(nameof(ColorWheelVisible));
 
 		/// <summary>
 		/// Controls whether the Indexed or Enumerated values user control is visible.
@@ -109,7 +109,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Indexed visible property data.
 		/// </summary>
-		public static readonly PropertyData IndexedVisibleProperty = RegisterProperty(nameof(IndexedVisible), typeof(bool), null);
+		public static readonly IPropertyData IndexedVisibleProperty = RegisterProperty<bool>(nameof(IndexedVisible));
 
 		/// <summary>
 		/// Controls whether the Pan/Tilt user control is visible.
@@ -129,7 +129,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Pan tilt visible property data.
 		/// </summary>
-		public static readonly PropertyData PanAndTiltVisibleProperty = RegisterProperty(nameof(PanTiltVisible), typeof(bool), null);
+		public static IPropertyData PanAndTiltVisibleProperty = RegisterProperty<bool>(nameof(PanTiltVisible));
 
 		/// <summary>
 		/// Controls whether the zoom user control is visible.
@@ -149,7 +149,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Zoom visible property data.
 		/// </summary>
-		public static readonly PropertyData ZoomVisibleProperty = RegisterProperty(nameof(ZoomVisible), typeof(bool), null);
+		public static readonly IPropertyData ZoomVisibleProperty = RegisterProperty<bool>(nameof(ZoomVisible));
 
 		/// <summary>
 		/// Maintains the previously selected function from the list of fixture functions.
@@ -182,7 +182,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Selected function property data.
 		/// </summary>
-		public static readonly PropertyData PrevoiuslySelectedItemProperty = RegisterProperty(nameof(PreviouslySelectedItem), typeof(FunctionItemViewModel), null);
+		public static readonly IPropertyData PrevoiuslySelectedItemProperty = RegisterProperty<FunctionItemViewModel>(nameof(PreviouslySelectedItem));
 
 		/// <summary>
 		/// Title for the detailed function group box.  The title on this group box changes as the user selects different functions.
@@ -202,7 +202,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Group box title property data.
 		/// </summary>
-		public static readonly PropertyData GroupBoxTitleProperty = RegisterProperty(nameof(GroupBoxTitle), typeof(string), null);
+		public static readonly IPropertyData GroupBoxTitleProperty = RegisterProperty<string>(nameof(GroupBoxTitle));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionTypeWindowViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FunctionTypeWindowViewModel.cs
@@ -40,7 +40,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
         /// <summary>
         /// Functions property data.
         /// </summary>
-        public static readonly PropertyData FunctionsProperty = RegisterProperty(nameof(Functions), typeof(Tuple<List<FixtureFunction>, string, Action>), null);
+        public static readonly IPropertyData FunctionsProperty = RegisterProperty<Tuple<List<FixtureFunction>, string, Action>>(nameof(Functions));
 
         #endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/IndexedItemViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/IndexedItemViewModel.cs
@@ -55,7 +55,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Start value property data.
 		/// </summary>
-		public static readonly PropertyData StartValueProperty = RegisterProperty(nameof(StartValue), typeof(string), null);
+		public static readonly IPropertyData StartValueProperty = RegisterProperty<string>(nameof(StartValue));
 
 		/// <summary>
 		/// End value of the index.
@@ -75,7 +75,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// End value property data.
 		/// </summary>
-		public static readonly PropertyData EndValueProperty = RegisterProperty(nameof(EndValue), typeof(string), null);
+		public static readonly IPropertyData EndValueProperty = RegisterProperty<string>(nameof(EndValue));
 
 		/// <summary>
 		/// Indicator if the index is a ranage and should be represented by a curve.
@@ -95,7 +95,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Use curve property data.
 		/// </summary>
-		public static readonly PropertyData UseCurveProperty = RegisterProperty(nameof(UseCurve), typeof(bool), null);
+		public static readonly IPropertyData UseCurveProperty = RegisterProperty<bool>(nameof(UseCurve));
 
 		/// <summary>
 		/// Type of the index for use by the preview.
@@ -115,7 +115,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Index type property data.
 		/// </summary>
-		public static readonly PropertyData IndexTypeProperty = RegisterProperty(nameof(IndexType), typeof(FixtureIndexType), null);
+		public static readonly IPropertyData IndexTypeProperty = RegisterProperty<FixtureIndexType>(nameof(IndexType));
 
 		/// <summary>
 		/// Image associated with the index.
@@ -135,7 +135,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Image property data.
 		/// </summary>
-		public static readonly PropertyData ImageProperty = RegisterProperty(nameof(Image), typeof(string), null);
+		public static readonly IPropertyData ImageProperty = RegisterProperty<string>(nameof(Image));
 
 		/// <summary>
 		/// Collection of available images.
@@ -152,7 +152,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Available Image property data.
 		/// </summary>
-		public static readonly PropertyData AvailableImagesProperty = RegisterProperty(nameof(AvailableImages), typeof(IList<string>), null);
+		public static readonly IPropertyData AvailableImagesProperty = RegisterProperty<IList<string>>(nameof(AvailableImages));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/IndexedViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/IndexedViewModel.cs
@@ -55,7 +55,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Display image property data.
 		/// </summary>
-		public static readonly PropertyData DisplayImageProperty = RegisterProperty(nameof(DisplayImage), typeof(bool), null);
+		public static readonly IPropertyData DisplayImageProperty = RegisterProperty<bool>(nameof(DisplayImage));
 
 		/// <summary>
 		/// Determines whether the tag column is displayed.
@@ -72,7 +72,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Display tag property data.
 		/// </summary>
-		public static readonly PropertyData DisplayTagProperty = RegisterProperty(nameof(DisplayTag), typeof(bool), null);
+		public static readonly IPropertyData DisplayTagProperty = RegisterProperty<bool>(nameof(DisplayTag));
 
 		/// <summary>
 		/// Gets or sets the Associated Function name.
@@ -90,7 +90,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Associated Function Name property data.
 		/// </summary>
-		public static readonly PropertyData AssociatedFunctionNameProperty = RegisterProperty(nameof(AssociatedFunctionName), typeof(string), null);
+		public static readonly IPropertyData AssociatedFunctionNameProperty = RegisterProperty<string>(nameof(AssociatedFunctionName));
 
 		/// <summary>
 		/// Collection of function names defined on the Intelligent Fixture.
@@ -107,7 +107,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Fixture functions property data.
 		/// </summary>
-		public static readonly PropertyData FunctionsProperty = RegisterProperty(nameof(Functions), typeof(List<string>), null);
+		public static readonly IPropertyData FunctionsProperty = RegisterProperty<List<string>>(nameof(Functions));
 
 		/// <summary>
 		/// Determines whether the Associated Functions ComboBox is displayed.
@@ -124,7 +124,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Display Associated Functions property data.
 		/// </summary>
-		public static readonly PropertyData DisplayAssociationedFunctionsProperty = RegisterProperty(nameof(DisplayAssociatedFunctions), typeof(bool), null);
+		public static readonly IPropertyData DisplayAssociationedFunctionsProperty = RegisterProperty<bool>(nameof(DisplayAssociatedFunctions));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ItemViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ItemViewModel.cs
@@ -56,7 +56,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty(nameof(Name), typeof(string), null);
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 				
@@ -97,7 +97,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <param name="value">Value of the field</param>
 		protected void ValidateDMXNumber(
 			List<IFieldValidationResult> validationResults,
-			PropertyData propertyData,
+			IPropertyData propertyData,
 			string fieldName,
 			string value)
 		{

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ItemsViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ItemsViewModel.cs
@@ -244,7 +244,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Selected item property data.
 		/// </summary>
-		public static readonly PropertyData SelectedItemProperty = RegisterProperty(nameof(SelectedItem), typeof(TItemType), null);
+		public static readonly IPropertyData SelectedItemProperty = RegisterProperty<TItemType>(nameof(SelectedItem));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/PanTiltViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/PanTiltViewModel.cs
@@ -103,7 +103,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Maximum rotation property data.
 		/// </summary>
-		public static readonly PropertyData StartPositionProperty = RegisterProperty(nameof(StartPosition), typeof(string), null);
+		public static readonly IPropertyData StartPositionProperty = RegisterProperty<string>(nameof(StartPosition));
 
 		/// <summary>
 		/// Maximum rotation of the function (pan or tilt) in degrees.
@@ -123,9 +123,8 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Maximum rotation property data.
 		/// </summary>
-		public static readonly PropertyData StopPositionProperty = RegisterProperty(nameof(StopPosition), typeof(string), null);
+		public static readonly IPropertyData StopPositionProperty = RegisterProperty<string>(nameof(StopPosition));
 
-		
 		/// <summary>
 		/// Indicates if the Pan function (true)  being editor vs the Tilt function (false).
 		/// </summary>
@@ -144,7 +143,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// IsPan property data.
 		/// </summary>
-		public static readonly PropertyData IsPanProperty = RegisterProperty(nameof(IsPan), typeof(bool), null);
+		public static readonly IPropertyData IsPanProperty = RegisterProperty<bool>(nameof(IsPan));
 
 		#endregion
 
@@ -169,7 +168,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <param name="value">Value to validate</param>
 		private void ValidatesAngle(
 			List<IFieldValidationResult> validationResults,
-			PropertyData propertyData,
+			IPropertyData propertyData,
 			string fieldName,
 			string value)
 		{

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ZoomViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/ZoomViewModel.cs
@@ -59,7 +59,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Narrow to Wide zoom property data.
 		/// </summary>
-		public static readonly PropertyData NarrowToWideProperty = RegisterProperty(nameof(NarrowToWide), typeof(bool), null);
+		public static readonly IPropertyData NarrowToWideProperty = RegisterProperty<bool>(nameof(NarrowToWide));
 
 		/// <summary>
 		/// True when the fixture zooms from wide to narrow.
@@ -79,7 +79,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Wide to Narrow zoom property data.
 		/// </summary>
-		public static readonly PropertyData WideToNarrowProperty = RegisterProperty(nameof(WideToNarrow), typeof(bool), null);
+		public static readonly IPropertyData WideToNarrowProperty = RegisterProperty<bool>(nameof(WideToNarrow));
 		
 		#endregion		
 	}

--- a/src/Vixen.Modules/Editor/FixtureWizard/FixtureWizard.csproj
+++ b/src/Vixen.Modules/Editor/FixtureWizard/FixtureWizard.csproj
@@ -13,16 +13,16 @@
 				<PackageReference Include="Catel.Fody" Version="4.9.0">
 						<PrivateAssets>all</PrivateAssets>
 				</PackageReference>
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="Fody" Version="6.6.4">
 				</PackageReference>
 				<PackageReference Include="LoadAssembliesOnStartup.Fody" Version="4.6.0" PrivateAssets="all" />				
 				<PackageReference Include="ModuleInit.Fody" Version="2.1.1" PrivateAssets="all" />
 				<PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="all" />
-				<PackageReference Include="Orc.Controls" Version="4.8.0" />
-				<PackageReference Include="Orc.SystemInfo" Version="4.3.1" />
-				<PackageReference Include="Orc.Wizard" Version="4.8.3" />
-				<PackageReference Include="Orchestra.Core" Version="6.8.1" />
+				<PackageReference Include="Orc.Controls" Version="5.0.5" />
+				<PackageReference Include="Orc.SystemInfo" Version="5.0.0" />
+				<PackageReference Include="Orc.Wizard" Version="5.0.0" />
+				<PackageReference Include="Orchestra.Core" Version="7.0.1" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/EditProfileFunctionsWizardPageViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/EditProfileFunctionsWizardPageViewModel.cs
@@ -56,7 +56,8 @@
         /// <summary>
         /// Functions property data.
         /// </summary>
-        public static readonly PropertyData FunctionsProperty = RegisterProperty(nameof(Functions), typeof(Tuple<List<FixtureFunction>, string, Action>), null);
+        public static readonly IPropertyData FunctionsProperty =
+	        RegisterProperty<Tuple<List<FixtureFunction>, string, Action>>(nameof(Functions));
 
         #endregion
 

--- a/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/EditProfileWizardPageViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/EditProfileWizardPageViewModel.cs
@@ -56,7 +56,8 @@
         /// <summary>
         /// Fixture specification property data.
         /// </summary>
-        public static readonly PropertyData FixtureSpecificationProperty = RegisterProperty(nameof(FixtureSpecification), typeof(Tuple<FixtureSpecification, Action, bool>), null);
+        public static readonly IPropertyData FixtureSpecificationProperty =
+	        RegisterProperty<Tuple<FixtureSpecification, Action, bool>>(nameof(FixtureSpecification));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/GroupingWizardPageViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/GroupingWizardPageViewModel.cs
@@ -171,7 +171,7 @@
         /// <summary>
         /// Preview tree property data.
         /// </summary>
-        public static readonly PropertyData PreviewTreeProperty = RegisterProperty(nameof(PreviewTree), typeof(ObservableCollection<FixtureWizardTreeItem>));
+        public static readonly IPropertyData PreviewTreeProperty = RegisterProperty<ObservableCollection<FixtureWizardTreeItem>>(nameof(PreviewTree));
 
         /// <summary>
         /// Number of fixtures to create.
@@ -192,7 +192,7 @@
         /// <summary>
         /// Number of fixtures property data.
         /// </summary>
-        public static readonly PropertyData NumberOfFixturesProperty = RegisterProperty(nameof(NumberOfFixtures), typeof(int));
+        public static readonly IPropertyData NumberOfFixturesProperty = RegisterProperty<int>(nameof(NumberOfFixtures));
 
         /// <summary>
         /// Element prefix of the fixtures.
@@ -220,7 +220,7 @@
         /// <summary>
         /// Element prefix property data.
         /// </summary>
-        public static readonly PropertyData ElementPrefixProperty = RegisterProperty(nameof(ElementPrefix), typeof(string));
+        public static readonly IPropertyData ElementPrefixProperty = RegisterProperty<string>(nameof(ElementPrefix));
 
         /// <summary>
         /// Indicates is a group is created to contain the fixtures.
@@ -253,7 +253,7 @@
         /// <summary>
         /// Create group property data.
         /// </summary>
-        public static readonly PropertyData CreateGroupProperty = RegisterProperty(nameof(CreateGroup), typeof(bool));
+        public static readonly IPropertyData CreateGroupProperty = RegisterProperty<bool>(nameof(CreateGroup));
 
         /// <summary>
         /// Name of the fixture group.  This name is used as the root of the preview tree.
@@ -275,7 +275,7 @@
         /// <summary>
         /// Group name property data.
         /// </summary>
-        public static readonly PropertyData GroupNameProperty = RegisterProperty(nameof(GroupName), typeof(string));
+        public static readonly IPropertyData GroupNameProperty = RegisterProperty<string>(nameof(GroupName));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/SelectProfileWizardPageViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixtureWizard/Wizard/ViewModels/SelectProfileWizardPageViewModel.cs
@@ -109,7 +109,7 @@
         /// <summary>
         /// Selected fixture property data.
         /// </summary>
-        public static readonly PropertyData SelectedFixtureProperty = RegisterProperty(nameof(SelectedFixture), typeof(string));
+        public static readonly IPropertyData SelectedFixtureProperty = RegisterProperty<string>(nameof(SelectedFixture));
 
         /// <summary>
         /// Fixture profile being modified by the Wizard.
@@ -140,7 +140,7 @@
         /// <summary>
         /// Fixture property data.
         /// </summary>
-        public static readonly PropertyData FixtureProperty = RegisterProperty(nameof(Fixture), typeof(FixtureSpecification));
+        public static readonly IPropertyData FixtureProperty = RegisterProperty<FixtureSpecification>(nameof(Fixture));
 
         /// <summary>
         /// Indicates an existing fixture profile is selected.
@@ -176,7 +176,7 @@
         /// <summary>
         /// Select existig profile property data.
         /// </summary>
-        public static readonly PropertyData SelectExistingProfileProperty = RegisterProperty(nameof(SelectExistingProfile), typeof(bool));
+        public static readonly IPropertyData SelectExistingProfileProperty = RegisterProperty<bool>(nameof(SelectExistingProfile));
 
         /// <summary>
         /// Flag indicating if the wizard is creating a new fixture profile.
@@ -201,7 +201,7 @@
             }
         }
        
-        public static readonly PropertyData CreateNewProfileProperty = RegisterProperty(nameof(CreateNewProfile), typeof(bool));
+        public static readonly IPropertyData CreateNewProfileProperty = RegisterProperty<bool>(nameof(CreateNewProfile));
 
         /// <summary>
         /// Name of the fixture profile.
@@ -222,7 +222,7 @@
         /// <summary>
         /// Profile name property data.
         /// </summary>
-        public static readonly PropertyData ProfileNameProperty = RegisterProperty(nameof(ProfileName), typeof(string));
+        public static readonly IPropertyData ProfileNameProperty = RegisterProperty<string>(nameof(ProfileName));
 
         /// <summary>
         /// Name of the company that makes the fixture.
@@ -243,7 +243,7 @@
         /// <summary>
         /// Manufacturer property data.
         /// </summary>
-        public static readonly PropertyData ManufacturerProperty = RegisterProperty(nameof(Manufacturer), typeof(string));
+        public static readonly IPropertyData ManufacturerProperty = RegisterProperty<string>(nameof(Manufacturer));
 
         /// <summary>
         /// Name of the user that created the profile.
@@ -264,7 +264,7 @@
         /// <summary>
         /// CreatedBy property data.
         /// </summary>
-        public static readonly PropertyData CreatedByProperty = RegisterProperty(nameof(CreatedBy), typeof(string));
+        public static readonly IPropertyData CreatedByProperty = RegisterProperty<string>(nameof(CreatedBy));
 
         /// <summary>
         /// Revision number of the fixture profile.
@@ -285,7 +285,7 @@
         /// <summary>
         /// CreatedBy property data.
         /// </summary>
-        public static readonly PropertyData RevisionProperty = RegisterProperty(nameof(Revision), typeof(string));
+        public static readonly IPropertyData RevisionProperty = RegisterProperty<string>(nameof(Revision));
 
 
         /// <summary>
@@ -307,7 +307,7 @@
         /// <summary>
         /// SelectExistingProfile property data.
         /// </summary>
-        public static readonly PropertyData SelectExistingProfileEnabledProperty = RegisterProperty(nameof(SelectExistingProfileEnabled), typeof(bool));
+        public static readonly IPropertyData SelectExistingProfileEnabledProperty = RegisterProperty<bool>(nameof(SelectExistingProfileEnabled));
 
         #endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/PolygonEditor.csproj
+++ b/src/Vixen.Modules/Editor/PolygonEditor/PolygonEditor.csproj
@@ -48,7 +48,7 @@
 		</ItemGroup>
 
 		<ItemGroup>
-		  <PackageReference Include="Catel.MVVM" Version="5.12.22" />
+		  <PackageReference Include="Catel.MVVM" Version="6.0.3" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/EllipseViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/EllipseViewModel.cs
@@ -133,7 +133,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 			}
 		}
 
-		public static readonly PropertyData EllipseModelProperty = RegisterProperty(nameof(Ellipse), typeof(App.Polygon.Ellipse), null);
+		public static readonly IPropertyData EllipseModelProperty = RegisterProperty<Ellipse>(nameof(Ellipse));
 
 		#endregion
 
@@ -152,7 +152,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Width property data.
 		/// </summary>
-		public static readonly PropertyData WidthProperty = RegisterProperty(nameof(Width), typeof(double), null);
+		public static readonly IPropertyData WidthProperty = RegisterProperty<double>(nameof(Width));
 
 		/// <summary>
 		/// Gets or sets the height of the ellipse.
@@ -167,7 +167,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Height property data.
 		/// </summary>
-		public static readonly PropertyData HeightProperty = RegisterProperty(nameof(Height), typeof(double), null);
+		public static readonly IPropertyData HeightProperty = RegisterProperty<double>(nameof(Height));
 
 		/// <summary>
 		/// Gets or sets the left point of the ellipse rectangle.
@@ -182,7 +182,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Left property data.
 		/// </summary>
-		public static readonly PropertyData LeftProperty = RegisterProperty(nameof(Left), typeof(double), null);
+		public static readonly IPropertyData LeftProperty = RegisterProperty<double>(nameof(Left));
 
 		/// <summary>
 		/// Gets or sets the top point of the ellipse rectangle.
@@ -197,7 +197,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Top property data.
 		/// </summary>
-		public static readonly PropertyData TopProperty = RegisterProperty(nameof(Top), typeof(double), null);
+		public static readonly IPropertyData TopProperty = RegisterProperty<double>(nameof(Top));
 
 		/// <summary>
 		/// Gets or sets the angle of the ellipse.
@@ -212,7 +212,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Top property data.
 		/// </summary>
-		public static readonly PropertyData AngleProperty = RegisterProperty(nameof(Angle), typeof(double), null);
+		public static readonly IPropertyData AngleProperty = RegisterProperty<double>(nameof(Angle));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/LineSegmentViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/LineSegmentViewModel.cs
@@ -58,7 +58,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CenterPointColor property data.
 		/// </summary>
-		public static readonly PropertyData CenterPointColorProperty = RegisterProperty(nameof(Color), typeof(Color), null);
+		public static readonly IPropertyData CenterPointColorProperty = RegisterProperty<Color>(nameof(Color));
 
 		#endregion
 	}

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/LineViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/LineViewModel.cs
@@ -72,7 +72,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PointCollection property data.
 		/// </summary>
-		public static readonly PropertyData StartPointProperty = RegisterProperty(nameof(StartPoint), typeof(PolygonPointViewModel));
+		public static readonly IPropertyData StartPointProperty = RegisterProperty<PolygonPointViewModel>(nameof(StartPoint));
 
 		public PolygonPointViewModel EndPoint
 		{
@@ -83,7 +83,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PointCollection property data.
 		/// </summary>
-		public static readonly PropertyData EndPointProperty = RegisterProperty(nameof(EndPoint), typeof(PolygonPointViewModel));
+		public static readonly IPropertyData EndPointProperty = RegisterProperty<PolygonPointViewModel>(nameof(EndPoint));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PointBasedViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PointBasedViewModel.cs
@@ -41,7 +41,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SegmentsVisible property data.
 		/// </summary>
-		public static readonly PropertyData SegmentsVisibleProperty = RegisterProperty(nameof(SegmentsVisible), typeof(bool), null);
+		public static readonly IPropertyData SegmentsVisibleProperty = RegisterProperty<bool>(nameof(SegmentsVisible));
 
 		/// <summary>
 		/// Maintains a collection of line segments.  The line segments help define the polygon until the polygon has been closed.
@@ -55,8 +55,8 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SegmentsVisible property data.
 		/// </summary>
-		public static readonly PropertyData SegmentsProperty =
-			RegisterProperty(nameof(Segments), typeof(ObservableCollection<LineSegmentViewModel>), null);
+		public static readonly IPropertyData SegmentsProperty =
+			RegisterProperty<ObservableCollection<LineSegmentViewModel>>(nameof(Segments));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonEditorViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonEditorViewModel.cs
@@ -133,7 +133,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedPointsReadOnly property data.
 		/// </summary>
-		public static readonly PropertyData SelectedPointsReadOnlyProperty = RegisterProperty(nameof(SelectedPointsReadOnly), typeof(bool));
+		public static readonly IPropertyData SelectedPointsReadOnlyProperty = RegisterProperty<bool>(nameof(SelectedPointsReadOnly));
 
 		/// <summary>
 		/// Cursor applicable to the time bar.
@@ -147,7 +147,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// TimeBar property data.
 		/// </summary>
-		public static readonly PropertyData TimeBarCursorProperty = RegisterProperty(nameof(TimeBarCusor), typeof(Cursor));
+		public static readonly IPropertyData TimeBarCursorProperty = RegisterProperty<Cursor>(nameof(TimeBarCusor));
 
 		/// <summary>
 		/// Cursor for the polygon/line drawing canvas.
@@ -161,7 +161,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// TimeBar property data.
 		/// </summary>
-		public static readonly PropertyData CanvasCursorProperty = RegisterProperty(nameof(CanvasCursor), typeof(Cursor));
+		public static readonly IPropertyData CanvasCursorProperty = RegisterProperty<Cursor>(nameof(CanvasCursor));
 
 		/// <summary>
 		/// Desired width of control.
@@ -175,7 +175,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// ControlWidth property data.
 		/// </summary>
-		public static readonly PropertyData ControlWidthProperty = RegisterProperty(nameof(ControlWidth), typeof(int));
+		public static readonly IPropertyData ControlWidthProperty = RegisterProperty<int>(nameof(ControlWidth));
 
 		/// <summary>
 		/// Desired height of control.
@@ -189,7 +189,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// WindowHeight property data.
 		/// </summary>
-		public static readonly PropertyData ControlHeightProperty = RegisterProperty(nameof(ControlHeight), typeof(int));
+		public static readonly IPropertyData ControlHeightProperty = RegisterProperty<int>(nameof(ControlHeight));
 
 		/// <summary>
 		/// Desired width of window.
@@ -203,7 +203,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// WindowWidth property data.
 		/// </summary>
-		public static readonly PropertyData WindowWidthProperty = RegisterProperty(nameof(WindowWidth), typeof(int));
+		public static readonly IPropertyData WindowWidthProperty = RegisterProperty<int>(nameof(WindowWidth));
 
 		/// <summary>
 		/// Desired height of window.
@@ -217,7 +217,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// WindowHeight property data.
 		/// </summary>
-		public static readonly PropertyData WindowHeightProperty = RegisterProperty(nameof(WindowHeight), typeof(int));
+		public static readonly IPropertyData WindowHeightProperty = RegisterProperty<int>(nameof(WindowHeight));
 
 		/// <summary>
 		/// Desired width of canvas.
@@ -231,7 +231,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CanvasWidth property data.
 		/// </summary>
-		public static readonly PropertyData CanvasWidthProperty = RegisterProperty(nameof(CanvasWidth), typeof(int));
+		public static readonly IPropertyData CanvasWidthProperty = RegisterProperty<int>(nameof(CanvasWidth));
 
 		/// <summary>
 		/// Desired height of canvas.
@@ -245,7 +245,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CanvaswHeight property data.
 		/// </summary>
-		public static readonly PropertyData CanvasHeightProperty = RegisterProperty(nameof(CanvasHeight), typeof(int));
+		public static readonly IPropertyData CanvasHeightProperty = RegisterProperty<int>(nameof(CanvasHeight));
 
 		/// <summary>
 		/// Display element width excluding any margin.
@@ -259,7 +259,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DisplayElementWidth property data.
 		/// </summary>
-		public static readonly PropertyData DisplayElementWidthProperty = RegisterProperty(nameof(DisplayElementWidth), typeof(double));
+		public static readonly IPropertyData DisplayElementWidthProperty = RegisterProperty<double>(nameof(DisplayElementWidth));
 
 		/// <summary>
 		/// Display element height excluding any margin.
@@ -273,7 +273,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DisplayElementHeight property data.
 		/// </summary>
-		public static readonly PropertyData DisplayElementHeightProperty = RegisterProperty(nameof(DisplayElementHeight), typeof(double));
+		public static readonly IPropertyData DisplayElementHeightProperty = RegisterProperty<double>(nameof(DisplayElementHeight));
 
 		/// <summary>
 		/// Display element X axis origin.  This is an offset into the virtual display element.
@@ -287,7 +287,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Display element X axis origin.  
 		/// </summary>
-		public static readonly PropertyData DisplayElementXOriginProperty = RegisterProperty(nameof(DisplayElementXOrigin), typeof(double));
+		public static readonly IPropertyData DisplayElementXOriginProperty = RegisterProperty<double>(nameof(DisplayElementXOrigin));
 
 		/// <summary>
 		/// Display element Y axis origin.  This is an offset into the virtual display element.
@@ -301,7 +301,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DisplayElementYOrigin property data.
 		/// </summary>
-		public static readonly PropertyData DisplayElementYOriginProperty = RegisterProperty(nameof(DisplayElementYOrigin), typeof(double));
+		public static readonly IPropertyData DisplayElementYOriginProperty = RegisterProperty<double>(nameof(DisplayElementYOrigin));
 
 		/// <summary>
 		/// Controls whether the display element outline should be displayed.
@@ -315,7 +315,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// ShowDisplayElement property data.
 		/// </summary>
-		public static readonly PropertyData ShowDisplayElementProperty = RegisterProperty(nameof(ShowDisplayElement), typeof(bool));
+		public static readonly IPropertyData ShowDisplayElementProperty = RegisterProperty<bool>(nameof(ShowDisplayElement));
 
 		/// <summary>
 		/// Gets or sets the view model's selected polygon.
@@ -333,7 +333,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedPolygon property data.
 		/// </summary>
-		public static readonly PropertyData SelectedPolygonProperty = RegisterProperty(nameof(SelectedPolygon), typeof(PolygonViewModel));
+		public static readonly IPropertyData SelectedPolygonProperty = RegisterProperty<PolygonViewModel>(nameof(SelectedPolygon));
 
 		/// <summary>
 		/// Gets or sets the view model's selected line.
@@ -351,7 +351,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedLine property data.
 		/// </summary>
-		public static readonly PropertyData SelectedLineProperty = RegisterProperty(nameof(SelectedLine), typeof(LineViewModel));
+		public static readonly IPropertyData SelectedLineProperty = RegisterProperty<LineViewModel>(nameof(SelectedLine));
 
 		/// <summary>
 		/// Gets or sets the view model's selected ellipse.
@@ -369,7 +369,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedLine property data.
 		/// </summary>
-		public static readonly PropertyData SelectedEllipseProperty = RegisterProperty(nameof(SelectedEllipse), typeof(EllipseViewModel));
+		public static readonly IPropertyData SelectedEllipseProperty = RegisterProperty<EllipseViewModel>(nameof(SelectedEllipse));
 
 		/// <summary>
 		/// Currently selected shape.
@@ -389,7 +389,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedLine property data.
 		/// </summary>
-		public static readonly PropertyData SelectedShapeProperty = RegisterProperty(nameof(SelectedShape), typeof(ShapeViewModel));
+		public static readonly IPropertyData SelectedShapeProperty = RegisterProperty<ShapeViewModel>(nameof(SelectedShape));
 
 		/// <summary>
 		/// Gets or sets the previous point during a point move operation.
@@ -403,7 +403,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// PreviousPointMoving property data.
 		/// </summary>
-		public static readonly PropertyData PreviousPointMovingProperty = RegisterProperty(nameof(PreviousPointMoving), typeof(PolygonPointViewModel));
+		public static readonly IPropertyData PreviousPointMovingProperty = RegisterProperty<PolygonPointViewModel>(nameof(PreviousPointMoving));
 
 		/// <summary>
 		/// Gets or sets the point being moved.
@@ -417,7 +417,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// PointMoving property data.
 		/// </summary>
-		public static readonly PropertyData PointMovingProperty = RegisterProperty(nameof(PointMoving), typeof(PolygonPointViewModel));
+		public static readonly IPropertyData PointMovingProperty = RegisterProperty<PolygonPointViewModel>(nameof(PointMoving));
 
 		/// <summary>
 		/// Gets or sets the next point during a move operation.
@@ -431,7 +431,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// NextPointMoving property data.
 		/// </summary>
-		public static readonly PropertyData NextPointMovingProperty = RegisterProperty(nameof(NextPointMoving), typeof(PolygonPointViewModel));
+		public static readonly IPropertyData NextPointMovingProperty = RegisterProperty<PolygonPointViewModel>(nameof(NextPointMoving));
 
 		/// <summary>
 		/// True when the moving ghost point is visible.
@@ -445,7 +445,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// MovingPointVisibilityPrevious property data.
 		/// </summary>
-		public static readonly PropertyData MovingPointVisibilityPreviousProperty = RegisterProperty(nameof(MovingPointVisibilityPrevious), typeof(bool));
+		public static readonly IPropertyData MovingPointVisibilityPreviousProperty = RegisterProperty<bool>(nameof(MovingPointVisibilityPrevious));
 
 		/// <summary>
 		/// True when the moving ghost point is visible.
@@ -459,7 +459,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// MovingPointVisibilityNext property data.
 		/// </summary>
-		public static readonly PropertyData MovingPointVisibilityNextProperty = RegisterProperty(nameof(MovingPointVisibilityNext), typeof(bool));
+		public static readonly IPropertyData MovingPointVisibilityNextProperty = RegisterProperty<bool>(nameof(MovingPointVisibilityNext));
 
 		/// <summary>
 		/// Collection of polygon snapshots.
@@ -473,7 +473,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PolygonSnapshots property data.
 		/// </summary>
-		public static readonly PropertyData PolygonSnapshotsProperty = RegisterProperty(nameof(PolygonSnapshots), typeof(ObservableCollection<PolygonSnapshotViewModel>));
+		public static readonly IPropertyData PolygonSnapshotsProperty = RegisterProperty<ObservableCollection<PolygonSnapshotViewModel>>(nameof(PolygonSnapshots));
 		
 		/// <summary>
 		/// Draw polygon mode flag.
@@ -518,7 +518,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DrawPolygon property data.
 		/// </summary>
-		public static readonly PropertyData DrawPolygonProperty = RegisterProperty(nameof(DrawPolygon), typeof(bool));
+		public static readonly IPropertyData DrawPolygonProperty = RegisterProperty<bool>(nameof(DrawPolygon));
 
 		/// <summary>
 		/// Draw Ellipse mode flag.
@@ -551,7 +551,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DrawEllipse property data.
 		/// </summary>
-		public static readonly PropertyData DrawEllipseProperty = RegisterProperty(nameof(DrawEllipse), typeof(bool));
+		public static readonly IPropertyData DrawEllipseProperty = RegisterProperty<bool>(nameof(DrawEllipse));
 
 		/// <summary>
 		/// Draw line mode flag.
@@ -591,7 +591,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// DrawLine property data.
 		/// </summary>
-		public static readonly PropertyData DrawLineProperty = RegisterProperty(nameof(DrawLine), typeof(bool));
+		public static readonly IPropertyData DrawLineProperty = RegisterProperty<bool>(nameof(DrawLine));
 		
 		/// <summary>
 		/// Add polygon point mode flag.
@@ -616,7 +616,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// AddPoint property data.
 		/// </summary>
-		public static readonly PropertyData AddPointProperty = RegisterProperty(nameof(AddPoint), typeof(bool));
+		public static readonly IPropertyData AddPointProperty = RegisterProperty<bool>(nameof(AddPoint));
 
 		/// <summary>
 		/// Selection mode flag.
@@ -644,7 +644,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// IsSelecting property data.
 		/// </summary>
-		public static readonly PropertyData IsSelectingProperty = RegisterProperty(nameof(IsSelecting), typeof(bool));
+		public static readonly IPropertyData IsSelectingProperty = RegisterProperty<bool>(nameof(IsSelecting));
 
 		/// <summary>
 		/// 
@@ -664,7 +664,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// TimeBarVisible property data.
 		/// </summary>
-		public static readonly PropertyData TimeBarVisibleProperty = RegisterProperty(nameof(TimeBarVisible), typeof(bool));
+		public static readonly IPropertyData TimeBarVisibleProperty = RegisterProperty<bool>(nameof(TimeBarVisible));
 
 		/// <summary>
 		/// Width of time bar.
@@ -682,7 +682,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// TimeBarActualWidth property data.
 		/// </summary>
-		public static readonly PropertyData TimeBarActualWidthProperty = RegisterProperty(nameof(TimeBarActualWidth), typeof(double));
+		public static readonly IPropertyData TimeBarActualWidthProperty = RegisterProperty<double>(nameof(TimeBarActualWidth));
 
 		/// <summary>
 		/// Width of the canvas.
@@ -704,7 +704,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CanvasActualWidth property data.
 		/// </summary>
-		public static readonly PropertyData CanvasActualWidthProperty = RegisterProperty(nameof(CanvasActualWidth), typeof(double));
+		public static readonly IPropertyData CanvasActualWidthProperty = RegisterProperty<double>(nameof(CanvasActualWidth));
 
 		/// <summary>
 		/// Height of the canvas.
@@ -726,7 +726,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CanvasActualHeight property data.
 		/// </summary>
-		public static readonly PropertyData CanvasActualHeightProperty = RegisterProperty(nameof(CanvasActualHeight), typeof(double));
+		public static readonly IPropertyData CanvasActualHeightProperty = RegisterProperty<double>(nameof(CanvasActualHeight));
 
 		/// <summary>
 		/// Gets or sets whether the polygon/line labels should be shown.
@@ -740,7 +740,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// ShowLabels property data.
 		/// </summary>
-		public static readonly PropertyData ShowLabelsProperty = RegisterProperty(nameof(ShowLabels), typeof(bool));
+		public static readonly IPropertyData ShowLabelsProperty = RegisterProperty<bool>(nameof(ShowLabels));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonPointViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonPointViewModel.cs
@@ -46,7 +46,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Polygon Point model property data.
 		/// </summary>
-		public static readonly PropertyData PolygonPointProperty = RegisterProperty("PolygonPoint", typeof(PolygonPoint));
+		public static readonly IPropertyData PolygonPointProperty = RegisterProperty<PolygonPoint>(nameof(PolygonPoint));
 
 		#endregion
 
@@ -75,7 +75,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// X property data.
 		/// </summary>
-		public static readonly PropertyData XProperty = RegisterProperty(nameof(X), typeof(double), null);
+		public static readonly IPropertyData XProperty = RegisterProperty<double>(nameof(X));
 		
 		/// <summary>
 		/// Gets or sets the Y position of the point.
@@ -100,7 +100,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Y property data.
 		/// </summary>
-		public static readonly PropertyData YProperty = RegisterProperty(nameof(Y), typeof(double), null);
+		public static readonly IPropertyData YProperty = RegisterProperty<double>(nameof(Y));
 		
 		/// <summary>
 		/// Gets or sets the label of the point.
@@ -117,7 +117,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Label property data.
 		/// </summary>
-		public static readonly PropertyData LabelProperty = RegisterProperty(nameof(Label), typeof(string), null);
+		public static readonly IPropertyData LabelProperty = RegisterProperty<string>(nameof(Label));
 
 		/// <summary>
 		/// True when the point has been selected.
@@ -147,7 +147,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Selected property data.
 		/// </summary>
-		public static readonly PropertyData SelectedProperty = RegisterProperty(nameof(Selected), typeof(bool), null);
+		public static readonly IPropertyData SelectedProperty = RegisterProperty<bool>(nameof(Selected));
 
 		/// <summary>
 		/// Color of the center point hash.
@@ -161,7 +161,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CenterPointColor property data.
 		/// </summary>
-		public static readonly PropertyData ColorProperty = RegisterProperty(nameof(Color), typeof(Color), null);
+		public static readonly IPropertyData ColorProperty = RegisterProperty<Color>(nameof(Color));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonSnapShotViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/PolygonSnapShotViewModel.cs
@@ -63,7 +63,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PointCollection property data.
 		/// </summary>
-		public static readonly PropertyData TimeProperty = RegisterProperty(nameof(Time), typeof(double));
+		public static readonly IPropertyData TimeProperty = RegisterProperty<double>(nameof(Time));
 
 		/// <summary>
 		/// Collection of polygon points.
@@ -77,7 +77,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PointCollection property data.
 		/// </summary>
-		public static readonly PropertyData PointCollectionProperty = RegisterProperty(nameof(PointCollection), typeof(ObservableCollection<PolygonPointViewModel>));
+		public static readonly IPropertyData PointCollectionProperty = RegisterProperty<ObservableCollection<PolygonPointViewModel>>(nameof(PointCollection));
 
 		/// <summary>
 		/// Color of the center point hash.
@@ -91,7 +91,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Color property data.
 		/// </summary>
-		public static readonly PropertyData ColorProperty = RegisterProperty(nameof(Color), typeof(Color), null);
+		public static readonly IPropertyData ColorProperty = RegisterProperty<Color>(nameof(Color));
 
 		/// <summary>
 		/// Whether the polygon snapshot is selected.
@@ -121,7 +121,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Selected property data.
 		/// </summary>
-		public static readonly PropertyData SelectedProperty = RegisterProperty(nameof(Selected), typeof(bool), null);
+		public static readonly IPropertyData SelectedProperty = RegisterProperty<bool>(nameof(Selected));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/ShapeViewModel.cs
+++ b/src/Vixen.Modules/Editor/PolygonEditor/ViewModels/ShapeViewModel.cs
@@ -56,7 +56,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Shape model property data.
 		/// </summary>
-		public static readonly PropertyData ShapeProperty = RegisterProperty(nameof(Shape), typeof(App.Polygon.Shape));
+		public static readonly IPropertyData ShapeProperty = RegisterProperty<App.Polygon.Shape>(nameof(Shape));
 
 		/// <summary>
 		/// Label of the shape.
@@ -71,7 +71,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Label property data.
 		/// </summary>
-		public static readonly PropertyData LabelProperty = RegisterProperty(nameof(Label), typeof(string), null);
+		public static readonly IPropertyData LabelProperty = RegisterProperty<string>(nameof(Label));
 
 		/// <summary>
 		/// Controls whether the shape's label is visible.
@@ -85,7 +85,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// LabelVisible property data.
 		/// </summary>
-		public static readonly PropertyData LabelVisibleProperty = RegisterProperty(nameof(LabelVisible), typeof(bool), null);
+		public static readonly IPropertyData LabelVisibleProperty = RegisterProperty<bool>(nameof(LabelVisible));
 
 		/// <summary>
 		/// Color of the center point hash.
@@ -99,7 +99,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CenterPointColor property data.
 		/// </summary>
-		public static readonly PropertyData CenterPointColorProperty = RegisterProperty(nameof(CenterPointColor), typeof(Color), null);
+		public static readonly IPropertyData CenterPointColorProperty = RegisterProperty<Color>(nameof(CenterPointColor));
 
 		/// <summary>
 		/// Position of the center point hash mark of the shape.
@@ -113,7 +113,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// CenterPoint property data.
 		/// </summary>
-		public static readonly PropertyData CenterPointProperty = RegisterProperty(nameof(CenterPoint), typeof(PolygonPointViewModel), null);
+		public static readonly IPropertyData CenterPointProperty = RegisterProperty<PolygonPointViewModel>(nameof(CenterPoint));
 
 		/// <summary>
 		/// True when the underlying shape is visible.		
@@ -127,7 +127,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// Visibility property data.
 		/// </summary>
-		public static readonly PropertyData VisibilityProperty = RegisterProperty(nameof(Visibility), typeof(bool), null);
+		public static readonly IPropertyData VisibilityProperty = RegisterProperty<bool>(nameof(Visibility));
 
 		/// <summary>
 		/// Selected vertex of the polygon.
@@ -141,7 +141,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>
 		/// SelectedVertex property data.
 		/// </summary>
-		public static readonly PropertyData SelectedVertextProperty = RegisterProperty(nameof(SelectedVertex), typeof(PolygonPointViewModel), null);
+		public static readonly IPropertyData SelectedVertextProperty = RegisterProperty<PolygonPointViewModel>(nameof(SelectedVertex));
 
 		/// <summary>
 		/// Collection of polygon points.
@@ -155,7 +155,7 @@ namespace VixenModules.Editor.PolygonEditor.ViewModels
 		/// <summary>		
 		/// PointCollection property data.
 		/// </summary>
-		public static readonly PropertyData PointCollectionProperty = RegisterProperty(nameof(PointCollection), typeof(ObservableCollection<PolygonPointViewModel>));
+		public static readonly IPropertyData PointCollectionProperty = RegisterProperty<ObservableCollection<PolygonPointViewModel>>(nameof(PointCollection));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/CheckBoxStateBase.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/CheckBoxStateBase.cs
@@ -18,7 +18,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// Text property data.
 		/// </summary>
-		public static readonly PropertyData TextProperty = RegisterProperty("Text", typeof(string));
+		public static readonly IPropertyData TextProperty = RegisterProperty<string>(nameof(Text));
 
 
 		#endregion
@@ -37,7 +37,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// Value property data.
 		/// </summary>
-		public static readonly PropertyData ValueProperty = RegisterProperty("Value", typeof(bool));
+		public static readonly IPropertyData ValueProperty = RegisterProperty<bool>(nameof(Value));
 		
 		#endregion
 	}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
@@ -75,7 +75,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// MarkCollection property data.
 		/// </summary>
-		public static readonly PropertyData MarkCollectionProperty = RegisterProperty("MarkCollection", typeof(MarkCollection));
+		public static readonly IPropertyData MarkCollectionProperty = RegisterProperty<MarkCollection>(nameof(MarkCollection));
 
 		#endregion
 
@@ -94,7 +94,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// Name property data.
 		/// </summary>
-		public static readonly PropertyData NameProperty = RegisterProperty("Name", typeof(string), null);
+		public static readonly IPropertyData NameProperty = RegisterProperty<string>(nameof(Name));
 
 		#endregion
 
@@ -113,7 +113,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// IsEnabled property data.
 		/// </summary>
-		public static readonly PropertyData ShowGridLinesProperty = RegisterProperty("ShowGridLines", typeof(bool), null);
+		public static readonly IPropertyData ShowGridLinesProperty = RegisterProperty<bool>(nameof(ShowGridLines));
 
 		#endregion
 
@@ -132,7 +132,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// ShowMarkBar property data.
 		/// </summary>
-		public static readonly PropertyData ShowMarkBarProperty = RegisterProperty("ShowMarkBar", typeof(bool), null);
+		public static readonly IPropertyData ShowMarkBarProperty = RegisterProperty<bool>(nameof(ShowMarkBar));
 
 		#endregion
 
@@ -151,7 +151,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// IsDefault property data.
 		/// </summary>
-		public static readonly PropertyData IsDefaultProperty = RegisterProperty("IsDefault", typeof(bool), null);
+		public static readonly IPropertyData IsDefaultProperty = RegisterProperty<bool>(nameof(IsDefault));
 
 		#endregion
 
@@ -170,7 +170,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// SnapLevel property data.
 		/// </summary>
-		public static readonly PropertyData LevelProperty = RegisterProperty("Level", typeof(int), null);
+		public static readonly IPropertyData LevelProperty = RegisterProperty<int>(nameof(Level));
 
 		#endregion
 
@@ -189,7 +189,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// CollectionType property data.
 		/// </summary>
-		public static readonly PropertyData CollectionTypeProperty = RegisterProperty("CollectionType", typeof(MarkCollectionType), null);
+		public static readonly IPropertyData CollectionTypeProperty = RegisterProperty<MarkCollectionType>(nameof(CollectionType));
 
 		#endregion
 		
@@ -252,7 +252,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// IsEditing property data.
 		/// </summary>
-		public static readonly PropertyData IsEditingProperty = RegisterProperty("IsEditing", typeof(bool));
+		public static readonly IPropertyData IsEditingProperty = RegisterProperty<bool>(nameof(IsEditing));
 
 		#endregion
 
@@ -322,7 +322,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// Decorator property data.
 		/// </summary>
-		public static readonly PropertyData DecoratorProperty = RegisterProperty("Decorator", typeof(IMarkDecorator), null);
+		public static readonly IPropertyData DecoratorProperty = RegisterProperty<IMarkDecorator>(nameof(Decorator));
 
 		#endregion
 
@@ -420,7 +420,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// CheckBoxStates property data.
 		/// </summary>
-		public static readonly PropertyData CheckBoxStatesProperty = RegisterProperty("CollectionTypeCheckBoxStates", typeof(ObservableCollection<CollectionTypeCheckBoxState>));
+		public static readonly IPropertyData CheckBoxStatesProperty = RegisterProperty<ObservableCollection<CollectionTypeCheckBoxState>>(nameof(CollectionTypeCheckBoxStates));
 
 		#endregion
 
@@ -438,7 +438,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// LinkedToCheckBoxState property data.
 		/// </summary>
-		public static readonly PropertyData LinkedToCheckBoxStatesProperty = RegisterProperty("LinkedToCheckBoxStates", typeof(ObservableCollection<LinkedToCheckBoxState>));
+		public static readonly IPropertyData LinkedToCheckBoxStatesProperty = RegisterProperty<ObservableCollection<LinkedToCheckBoxState>>(nameof(LinkedToCheckBoxStates));
 
 		#endregion
 
@@ -456,7 +456,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// LevelCheckBoxStates property data.
 		/// </summary>
-		public static readonly PropertyData LevelCheckBoxStatesProperty = RegisterProperty("LevelCheckBoxStates", typeof(ObservableCollection<LevelCheckBoxState>));
+		public static readonly IPropertyData LevelCheckBoxStatesProperty = RegisterProperty<ObservableCollection<LevelCheckBoxState>>(nameof(LevelCheckBoxStates));
 
 		#endregion
 
@@ -474,7 +474,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// IsPhonemeType property data.
 		/// </summary>
-		public static readonly PropertyData IsLinkableTypeProperty = RegisterProperty("IsLinkableType", typeof(bool));
+		public static readonly IPropertyData IsLinkableTypeProperty = RegisterProperty<bool>(nameof(IsLinkableType));
 
 		#endregion
 		

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs
@@ -41,7 +41,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		/// <summary>
 		/// MarkCollections property data.
 		/// </summary>
-		public static readonly PropertyData MarkCollectionsProperty = RegisterProperty("MarkCollections", typeof(ObservableCollection<IMarkCollection>));
+		public static readonly IPropertyData MarkCollectionsProperty = RegisterProperty<ObservableCollection<IMarkCollection>>(nameof(MarkCollections));
 
 		#endregion
 

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditor.csproj
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditor.csproj
@@ -7,8 +7,8 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-		  <PackageReference Include="Catel.MVVM" Version="5.12.22" />
-		  <PackageReference Include="Catel.Serialization.Json" Version="5.12.22" />
+		  <PackageReference Include="Catel.MVVM" Version="6.0.3" />
+		  <PackageReference Include="Catel.Serialization.Json" Version="6.0.3" />
 		  <PackageReference Include="DockPanelSuite" Version="3.1.0" />
 		  <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.0" />
 		  <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />

--- a/src/Vixen.Modules/Effect/Fixture/FixtureEffect/FixtureEffect.csproj
+++ b/src/Vixen.Modules/Effect/Fixture/FixtureEffect/FixtureEffect.csproj
@@ -15,7 +15,7 @@
 		</ItemGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
@@ -7,7 +7,7 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
+				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="DockPanelSuite" Version="3.1.0" />
 				<PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.0" />
 				<PackageReference Include="NLog" Version="5.3.2" />


### PR DESCRIPTION
VIX-3558 Catel, Orc libraries need updated to more current versions

Catel changed how properties are registered so there are a lot of source code changes.  They also seemed to have removed support for registering services via a class attribute.  I have a question out to them but I think I found workarounds.  [Issues Upgrading from Catel 5.12 to 6.0.3 - Stack Overflow](https://stackoverflow.com/questions/78626683/issues-upgrading-from-catel-5-12-to-6-0-3)