### PR TITLE
VIX-3561 Revert "VIX-3530 Upgrade LiteDB library"

### DIFF
--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
@@ -32,7 +32,7 @@
 		<ItemGroup>
 				<PackageReference Include="Catel.MVVM" Version="5.12.22" />
 				<PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
-				<PackageReference Include="LiteDB" Version="5.0.20" />
+				<PackageReference Include="LiteDB" Version="4.1.4" />
 				<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
 				<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 				<PackageReference Include="NLog" Version="5.3.2" />

--- a/src/Vixen.Modules/App/CustomPropEditor/Services/PropModelPersistenceService.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Services/PropModelPersistenceService.cs
@@ -36,7 +36,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 
 		public static bool SaveModel(Prop prop, string path)
 		{
-			using (var db = new LiteDatabase($"Filename={path};Upgrade=true"))
+			using (var db = new LiteDatabase(path))
 			{
 				var col = db.GetCollection<Prop>("props");
 				if (col.Count() > 0)
@@ -54,12 +54,14 @@ namespace VixenModules.App.CustomPropEditor.Services
 
 		public static bool UpdateModel(Prop prop, string path)
 		{
-			using (var db = new LiteDatabase($"Filename={path};Upgrade=true"))
+			using (var db = new LiteDatabase(path))
 			{
 				var col = db.GetCollection<Prop>("props");
 				col.Update(prop);
 				CleanUpLegacyImages(db);
 				db.FileStorage.Upload($"$/image/{ImageFileName}", ImageFileName, StreamFromBitmapSource(prop.Image));
+
+				db.Shrink();
 			}
 
 			return true;
@@ -68,7 +70,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 		public static Prop GetModel(string path)
 		{
 			Prop p;
-			using (var db = new LiteDatabase($"Filename={path};Upgrade=true"))
+			using (var db = new LiteDatabase(path))
 			{
 				var col = db.GetCollection<Prop>("props");
 
@@ -96,7 +98,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 			Task<Prop> t = Task<Prop>.Factory.StartNew(() =>
 			{
 				Prop p;
-				using (var db = new LiteDatabase($"Filename={path};Upgrade=true"))
+				using (var db = new LiteDatabase(path))
 				{
 					var col = db.GetCollection<Prop>("props");
 


### PR DESCRIPTION
* The new version has a 16mb document size limit that the old version did not and this causes a problem with large props. Will need to look for an alternate solution.

This reverts commit 2a946ab87bf66e1660ea3b590dea3549e7d55964.