### PR TITLE
VIX-3575 Allow default light size preference

### DIFF
--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditorData.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditorData.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.Runtime.Serialization;
 using Vixen.Module;
+using VixenModules.App.CustomPropEditor.Model;
 
 namespace VixenModules.App.CustomPropEditor
 {
@@ -31,6 +32,9 @@ namespace VixenModules.App.CustomPropEditor
 		[DataMember]
 		public Color SelectedLightColor { get; set; } = Color.HotPink;
 
+		[DataMember]
+		public uint DefaultLightSize { get; set; } = ElementModel.DefaultLightSize;
+
 		[OnDeserialized]
 		public void OnDeserialized(StreamingContext c)
 		{
@@ -42,6 +46,11 @@ namespace VixenModules.App.CustomPropEditor
 			if (SelectedLightColor == Color.Empty)
 			{
 				SelectedLightColor = Color.HotPink;
+			}
+
+			if (DefaultLightSize == 0)
+			{
+				DefaultLightSize = ElementModel.DefaultLightSize;
 			}
 		}
 	}

--- a/src/Vixen.Modules/App/CustomPropEditor/Model/Configuration.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Model/Configuration.cs
@@ -32,5 +32,16 @@ namespace VixenModules.App.CustomPropEditor.Model
 			}
 		}
 
+		public uint DefaultLightSize
+		{
+			get => _data.DefaultLightSize; 
+			set 
+			{
+				if(value < 1) value = ElementModel.DefaultLightSize;
+				_data.DefaultLightSize = value;
+				OnPropertyChanged(nameof(DefaultLightSize));
+			}
+		}
+
 	}
 }

--- a/src/Vixen.Modules/App/CustomPropEditor/Model/ElementModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Model/ElementModel.cs
@@ -10,7 +10,7 @@ namespace VixenModules.App.CustomPropEditor.Model
 	[Serializable]
 	public class ElementModel : BindableBase, IEqualityComparer<ElementModel>, IEquatable<ElementModel>
 	{
-		private const int DefaultLightSize = 3;
+		public const int DefaultLightSize = 3;
 		private ObservableCollection<Light> _lights;
 		private ObservableCollection<ElementModel> _children;
 		private ObservableCollection<Guid> _parents;

--- a/src/Vixen.Modules/App/CustomPropEditor/Services/PropModelServices.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Services/PropModelServices.cs
@@ -261,7 +261,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 
 		}
 
-		public ElementModel AddLight(ElementModel target, Point p)
+		public ElementModel AddLight(ElementModel target, Point p, uint size)
 		{
 			if (target != null && !target.IsGroupNode && target.Parents.Any())
 			{
@@ -269,7 +269,7 @@ namespace VixenModules.App.CustomPropEditor.Services
 				return target;
 			}
 
-			return AddLightNode(target, p);
+			return AddLightNode(target, p, null, (int)size);
 		}
 
 		private ElementModel FindOrCreateTargetGroupForLight()

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ConfigurationWindowViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ConfigurationWindowViewModel.cs
@@ -15,14 +15,15 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		{
 			
 			Config = ConfigurationService.Instance().Config;
-			UpdateColors();
+			UpdateConfigValues();
 			Title = "Preferences";
 		}
 
-		private void UpdateColors()
+		private void UpdateConfigValues()
 		{
 			LightColor = Config.LightColor;
 			SelectedLightColor = Config.SelectedLightColor;
+			DefaultLightSize = Config.DefaultLightSize;
 		}
 
 
@@ -45,7 +46,25 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
-		#region LightColor property
+		#region DefaultLightSize property
+
+		/// <summary>
+		/// Gets or sets the DefaultLightSize value.
+		/// </summary>
+		public uint DefaultLightSize
+		{
+			get => GetValue<uint>(DefaultLightSizeProperty);
+			set => SetValue(DefaultLightSizeProperty, value);
+		}
+
+		/// <summary>
+		/// DefaultLightSize property data.
+		/// </summary>
+		public static readonly IPropertyData DefaultLightSizeProperty = RegisterProperty<uint>(nameof(DefaultLightSize));
+
+		#endregion
+
+		#region DefaultLightSize property
 
 		/// <summary>
 		/// Gets or sets the LightColor value.
@@ -142,7 +161,9 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		private void RestoreDefaults()
 		{
-			RestoreColorDefaults();
+			LightColor = Color.White;
+			SelectedLightColor = Color.HotPink;
+			DefaultLightSize = ElementModel.DefaultLightSize;
 		}
 
 		#endregion
@@ -192,13 +213,6 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
-		private void RestoreColorDefaults()
-		{
-			LightColor = Color.White;
-			SelectedLightColor = Color.HotPink;
-		}
-
-
 		#region Overrides of ViewModelBase
 
 		/// <inheritdoc />
@@ -206,6 +220,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		{
 			Config.LightColor = LightColor;
 			Config.SelectedLightColor = SelectedLightColor;
+			Config.DefaultLightSize = DefaultLightSize;
 		
 			return Task.FromResult(true);
 		}

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -973,7 +973,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		{
 			var target = ElementTreeViewModel.SelectedItem;
 
-			var model = PropModelServices.Instance().AddLight(target?.ElementModel, p);
+			var model = PropModelServices.Instance().AddLight(target?.ElementModel, p, DrawingPanelViewModel.Configuration.DefaultLightSize);
 
 			if (model == null) return;
 

--- a/src/Vixen.Modules/App/CustomPropEditor/Views/ConfigurationWindow.xaml
+++ b/src/Vixen.Modules/App/CustomPropEditor/Views/ConfigurationWindow.xaml
@@ -23,12 +23,13 @@
 								<Grid.RowDefinitions>
 										<RowDefinition Height="Auto" />
 										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto"/>
 								</Grid.RowDefinitions>
 								<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="Auto"></ColumnDefinition>
 										<ColumnDefinition Width="Auto"></ColumnDefinition>
 								</Grid.ColumnDefinitions>
-								<TextBlock Grid.Row="0" Grid.Column="0" Text="Light Color" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Light Color"  VerticalAlignment="Center" Margin="5,5"/>
 
 								<Rectangle Grid.Row="0" Grid.Column="1" x:Name="LightColorButton" 
 			           MinWidth="50" Height="25" Fill="{Binding LightColor ,Converter={StaticResource ColorToSolidBrushConverter}}" 
@@ -38,7 +39,7 @@
 										</Rectangle.InputBindings>
 								</Rectangle>
 
-								<TextBlock Grid.Row="1" Grid.Column="0" Text="Selected Color" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Selected Color"  VerticalAlignment="Center" Margin="5,5"/>
 								<Rectangle Grid.Row="1" Grid.Column="1" x:Name="SelectedColorButton" 
 	                   MinWidth="50" Height="25" Fill="{Binding SelectedLightColor,Converter={StaticResource ColorToSolidBrushConverter}}" 
 	                    Margin="6,2,2,2">
@@ -46,7 +47,9 @@
 												<MouseBinding Gesture="LeftDoubleClick" Command="{Binding EditSelectedLightColorCommand}"></MouseBinding>
 										</Rectangle.InputBindings>
 								</Rectangle>
-						</Grid>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Default Light Size"  VerticalAlignment="Center" Margin="5,5"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding DefaultLightSize}" Margin="6,2,2,2"/>
+            </Grid>
 						<WrapPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom">
 								<Button HorizontalAlignment="Right" Width="75" Margin="6" Command="{Binding RestoreDefaultsCommand}">Defaults</Button>
 								<Button HorizontalAlignment="Right" Width="75" Margin="6" IsDefault="True" Command="{Binding OkCommand}">Ok</Button>


### PR DESCRIPTION
* Add option to the Options -> Preferences to set the default light size for newly created lights.
* Persist the setting to the configuration data section so it appears each new session. This is per profile.
* Add logic to use the configuration setting when adding a light.