### PR TITLE
VIX-3577 Add export model function to the custom prop editor

### DIFF
--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
@@ -46,6 +46,7 @@
 				<ProjectReference Include="..\..\..\Vixen.Common\WpfPropertyGrid.Themes\WpfPropertyGrid.Themes.csproj" />
 				<ProjectReference Include="..\..\..\Vixen.Common\WpfPropertyGrid\WpfPropertyGrid.csproj" />
 				<ProjectReference Include="..\..\..\Vixen.Core\Vixen.Core.csproj" />
+				<ProjectReference Include="..\Modeling\Modeling.csproj" />
 		</ItemGroup>
 
 		<ItemGroup>

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/PropEditorViewModel.cs
@@ -21,6 +21,7 @@ using VixenModules.App.CustomPropEditor.Services;
 using ModelType = VixenModules.App.CustomPropEditor.Model.InternalVendorInventory.ModelType;
 using PropertyData = Catel.Data.PropertyData;
 using Catel.Data;
+using VixenModules.App.Modeling;
 
 namespace VixenModules.App.CustomPropEditor.ViewModels
 {
@@ -917,6 +918,42 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		}
 
 		#endregion
+
+		#region CreateWireDiagramCommand
+
+		private Command _createWireDiagramCommand;
+
+		/// <summary>
+		/// Gets the CreateWireDiagram command.
+		/// </summary>
+		[Browsable(false)]
+		public Command CreateWireDiagramCommand
+		{
+			get { return _createWireDiagramCommand ??= new Command(CreateWireDiagram); }
+		}
+
+		/// <summary>
+		/// Method to invoke when the CreateWireDiagram command is executed.
+		/// </summary>
+		private void CreateWireDiagram()
+		{
+			var nodes = new List<Tuple<System.Drawing.Point, int>>();
+			var leafNodes = ElementModelLookUpService.Instance.GetAllModels().Where(x => x.IsLightNode)
+				.DistinctBy(x => x.ElementModel.Id).OrderBy(x => x.ElementModel.Order);
+			//var leafNodes = PropModelServices.Instance().Prop.RootNode.GetLeafEnumerator().Distinct();
+			foreach (var elementModel in leafNodes)
+			{
+				foreach (var light in elementModel.ElementModel.Lights)
+				{
+					nodes.Add(new Tuple<System.Drawing.Point, int>(new System.Drawing.Point((int)light.X, (int)light.Y), elementModel.ElementModel.Order ));
+				}
+			}
+
+			ElementModeling.OrderedPointsToSvg(nodes);
+		}
+
+		#endregion
+
 
 		#region NewProp command
 

--- a/src/Vixen.Modules/App/CustomPropEditor/Views/CustomPropEditorWindow.xaml
+++ b/src/Vixen.Modules/App/CustomPropEditor/Views/CustomPropEditorWindow.xaml
@@ -100,6 +100,7 @@
 						</MenuItem>
 						<MenuItem Header="Tools">
 								<MenuItem Header="Vendor Browser" Command="{Binding OpenVendorBrowserCommand}"/>
+								<MenuItem Header="Export Wire Diagram" Command="{Binding CreateWireDiagramCommand}"/>
 						</MenuItem>
 						<MenuItem Header="Options">
 								<MenuItem Header="Preferences" Command="{Binding ColorOptionsCommand}"/>


### PR DESCRIPTION
* Update the modeling project to support sending data to export in a form other than actual elements. These do not exist in the prop editor.
* Add menu item under tools to invooke the export function.
* Add constants for the over size dimensions.