### PR TITLE
VIX-3588 Fix crash when removing outputs

### DIFF
--- a/src/Vixen.Application/Setup/SetupPatchingSimple.cs
+++ b/src/Vixen.Application/Setup/SetupPatchingSimple.cs
@@ -357,7 +357,7 @@ namespace VixenApplication.Setup
 
 				foreach (int outputIndex in controllersAndOutput.Value)
 				{
-					if (outputIndex > controller.Outputs.Length)
+					if (outputIndex >= controller.Outputs.Length)
 					{
 						Logging.Warn("passed an output index greater than the controller output length: " + controller.Name + ", " + outputIndex);
 						continue;

--- a/src/Vixen.Common/Controls/ControllerTree.cs
+++ b/src/Vixen.Common/Controls/ControllerTree.cs
@@ -646,7 +646,7 @@ namespace Common.Controls
 						VixenSystem.OutputControllers.Resume(controllerOutputs.Key);
 					}
 				}
-
+				treeview.ClearSelectedNodes();
 				OnControllersChanged();
 				PopulateControllerTree();
 				if (TopLevelControl != null)


### PR DESCRIPTION
* The selection was not being cleared after the outputs where removed and downstream code was crashing with index out of bounds.
* Fix improper check on the index bounds that was not accounting for 0 based indexing. This was causing the crash becasue of bad input.