### PR TITLE
VIX-3592 Ensure the state definition name is available and editable i…

### DIFF
--- a/src/Vixen.Modules/App/CustomPropEditor/Import/XLights/XModelImport.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Import/XLights/XModelImport.cs
@@ -362,7 +362,7 @@ namespace VixenModules.App.CustomPropEditor.Import.XLights
 				{
 					var stateItemGroup = PropModelServices.Instance().CreateNode($"{cm.Name} {{1}} - {stateInfo.Name} - S{stateItem.Index} - {stateItem.Name}", stateGroup);
 
-					stateItemGroup.StateDefinition = new StateDefinition{DefaultColor = stateItem.Color, Name = stateItem.Name, Index = stateItem.Index};
+					stateItemGroup.StateDefinition = new StateDefinition{StateDefinitionName = stateInfo.Name, DefaultColor = stateItem.Color, Name = stateItem.Name, Index = stateItem.Index};
 					
 					var subModelRangeGroup = stateItemGroup;
 

--- a/src/Vixen.Modules/App/CustomPropEditor/Model/StateDefinition.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/Model/StateDefinition.cs
@@ -9,13 +9,36 @@ namespace VixenModules.App.CustomPropEditor.Model
 		private Color _defaultColor;
 		private int _index;
 		private string _name;
+		private string _stateDefinitionName;
 
+		/// <summary>
+		/// State Definition defines a particular state of a group of nodes. They are grouped together by the StateDefinitionName property.
+		/// Each state can have a color and index assigned to it. Thus, a prop can have several parts grouped together and each part can have its own color and index.
+		/// </summary>
 		public StateDefinition()
 		{
-			Name = "Change Me!";
+			StateDefinitionName = "State Name 1";
+			Name = "Item 1";
 			DefaultColor = Color.White;
 		}
 
+		/// <summary>
+		/// The overall StateDefinitionName Key that this definition is grouped with. 
+		/// </summary>
+		public string StateDefinitionName
+		{
+			get => _stateDefinitionName;
+			set
+			{
+				if (value == _stateDefinitionName) return;
+				_stateDefinitionName = value;
+				OnPropertyChanged(nameof(StateDefinitionName));
+			}
+		}
+
+		/// <summary>
+		/// The individual state definition item
+		/// </summary>
 		public string Name
 		{
 			get => _name;
@@ -27,6 +50,9 @@ namespace VixenModules.App.CustomPropEditor.Model
 			}
 		}
 
+		/// <summary>
+		/// The defined color of this state item
+		/// </summary>
 		public Color DefaultColor
 		{
 			get => _defaultColor;
@@ -38,6 +64,9 @@ namespace VixenModules.App.CustomPropEditor.Model
 			}
 		}
 
+		/// <summary>
+		/// This is basically the row number when imported from an xModel. This is not used at this time.
+		/// </summary>
 		public int Index
 		{
 			get => _index;

--- a/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
+++ b/src/Vixen.Modules/App/CustomPropEditor/ViewModels/ElementModelViewModel.cs
@@ -254,15 +254,62 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
-		#region StateName property
+		#region StateDefinitionName property
 
 		/// <summary>
-		/// Gets or sets the StateDefinition Name value.
+		/// Gets or sets the StateDefinitionName value.
 		/// </summary>
 		[PropertyOrder(3)]
 		[DisplayName("State Name")]
-		[Description("Name of the State for this element.")]
-		public String StateName
+		[Description("State name for grouping state items together. This should be the same for any state items that are intended to work together.")]
+		public String StateDefinitionName
+		{
+			get => ElementModel.StateDefinition != null ? ElementModel.StateDefinition.StateDefinitionName : String.Empty;
+			set
+			{
+				if (ElementModel.StateDefinition != null)
+				{
+					if (!string.IsNullOrEmpty(value))
+					{
+						ElementModel.StateDefinition.StateDefinitionName = value;
+						IsDirty = true;
+						RaisePropertyChanged(nameof(StateDefinitionName));
+					}
+					else
+					{
+						ElementModel.StateDefinition = null;
+						IsDirty = true;
+						RaisePropertyChanged(nameof(StateItemColor));
+						RaisePropertyChanged(nameof(StateItemName));
+						RaisePropertyChanged(nameof(StateDefinitionName));
+					}
+				}
+				else
+				{
+					ElementModel.StateDefinition = new StateDefinition()
+					{
+						Name = value
+					};
+					IsDirty = true;
+					RaisePropertyChanged(nameof(StateItemColor));
+					RaisePropertyChanged(nameof(StateItemName));
+					RaisePropertyChanged(nameof(StateDefinitionName));
+				}
+
+			}
+		}
+
+		#endregion
+
+		#region StateDefinitionName property
+
+		/// <summary>
+		/// Gets or sets the State Item name value.
+		/// </summary>
+		[PropertyOrder(4)]
+		[DisplayName("State Item")]
+		[Description("Name of the item state for this element/group. All associated state items should have the same State name.")]
+		public String StateItemName
 		{
 			get => ElementModel.StateDefinition != null ? ElementModel.StateDefinition.Name:String.Empty;
 			set
@@ -273,15 +320,15 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 					{
 						ElementModel.StateDefinition.Name = value;
 						IsDirty = true;
-						RaisePropertyChanged(nameof(StateName));
+						RaisePropertyChanged(nameof(StateItemName));
 					}
 					else
 					{
 						ElementModel.StateDefinition = null;
 						IsDirty = true;
-						RaisePropertyChanged(nameof(StateColor));
-						RaisePropertyChanged(nameof(StateIndex));
-						RaisePropertyChanged(nameof(StateName));
+						RaisePropertyChanged(nameof(StateItemColor));
+						RaisePropertyChanged(nameof(StateItemName));
+						RaisePropertyChanged(nameof(StateDefinitionName));
 					}
 				}
 				else
@@ -291,9 +338,9 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 						Name = value
 					};
 					IsDirty = true;
-					RaisePropertyChanged(nameof(StateColor));
-					RaisePropertyChanged(nameof(StateIndex));
-					RaisePropertyChanged(nameof(StateName));
+					RaisePropertyChanged(nameof(StateItemColor));
+					RaisePropertyChanged(nameof(StateItemName));
+					RaisePropertyChanged(nameof(StateDefinitionName));
 				}
 				
 			}
@@ -301,15 +348,15 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
-		#region StateColor property
+		#region StateItemColor property
 
 		/// <summary>
 		/// Gets or sets the StateDefinition Color value.
 		/// </summary>
-		[PropertyOrder(4)]
-		[DisplayName("State Color")]
-		[Description("Color in Hex (#FFFFFF) associated with the State of this element.")]
-		public String StateColor
+		[PropertyOrder(5)]
+		[DisplayName("State Item Color")]
+		[Description("Color in Hex (#FFFFFF) for this state item.")]
+		public String StateItemColor
 		{
 			get => ElementModel.StateDefinition != null ?
 				ElementModel.StateDefinition.DefaultColor.ToHex() :
@@ -321,7 +368,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 				{
 					ElementModel.StateDefinition.DefaultColor = color;
 					IsDirty = true;
-					RaisePropertyChanged(nameof(StateColor));
+					RaisePropertyChanged(nameof(StateItemColor));
 				}
 				else
 				{
@@ -330,9 +377,9 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 						DefaultColor = color
 					};
 					IsDirty = true;
-					RaisePropertyChanged(nameof(StateName));
-					RaisePropertyChanged(nameof(StateColor));
-					RaisePropertyChanged(nameof(StateIndex));
+					RaisePropertyChanged(nameof(StateItemName));
+					RaisePropertyChanged(nameof(StateItemColor));
+					RaisePropertyChanged(nameof(StateDefinitionName));
 				}
 
 			}
@@ -340,37 +387,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 
 		#endregion
 
-		#region StateIndex property
-
-		/// <summary>
-		/// Gets or sets the StateDefinition Index value.
-		/// </summary>
-		[PropertyOrder(5)]
-		[DisplayName("State Index")]
-		[Description("Index associated with the State of this element.")]
-		public string StateIndex
-		{
-			get => ElementModel.StateDefinition != null ?
-				ElementModel.StateDefinition.Index.ToString() :
-				String.Empty;
-			set
-			{
-				if (value.IsNumeric())
-				{
-					if (ElementModel.StateDefinition != null)
-					{
-						ElementModel.StateDefinition.Index = Convert.ToInt32(value);
-						IsDirty = true;
-						RaisePropertyChanged(nameof(StateIndex));
-					}
-				}
-				
-			}
-		}
-
-		#endregion
-
-
+		
 		#region ChildCount property
 
 		/// <summary>
@@ -378,7 +395,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		[DisplayName("Children")]
 		[Description("Number of child elements associated with this element.")]
-		[PropertyOrder(6)]
+		[PropertyOrder(7)]
 		public int ChildCount => ElementModel.Children.Count();
 
 		#endregion
@@ -390,7 +407,7 @@ namespace VixenModules.App.CustomPropEditor.ViewModels
 		/// </summary>
 		[DisplayName("Lights")]
 		[Description("Number of light elements under this element.")]
-		[PropertyOrder(7)]
+		[PropertyOrder(8)]
 		public int LightCount => ElementModel.GetLeafEnumerator().Count(x => x.IsLightNode);
 
 		#endregion


### PR DESCRIPTION
…n the prop editor

* The overall name of the state definition was missing from the fields in the prop editor.
* Adjust some of the naming and tooltips to ensure better understanding of what the properties do.