### PR TITLE
VIX-3598 Fix crash in setup of new DDP Controller

### DIFF
--- a/src/Vixen.Modules/Controller/DDP/DDPData.cs
+++ b/src/Vixen.Modules/Controller/DDP/DDPData.cs
@@ -12,7 +12,7 @@ namespace VixenModules.Output.DDP
 
 		public DDPData()
 		{
-			Address = "127, 0, 0, 1";
+			Address = IPAddress.Loopback.ToString();
 		}
 
 		public override IModuleDataModel Clone()

--- a/src/Vixen.Modules/Controller/DDP/DDPSetup.cs
+++ b/src/Vixen.Modules/Controller/DDP/DDPSetup.cs
@@ -13,8 +13,15 @@ namespace VixenModules.Output.DDP
 			InitializeComponent();
 			ForeColor = ThemeColorTable.ForeColor;
 			BackColor = ThemeColorTable.BackgroundColor;
-			ThemeUpdateControls.UpdateControls(this);			
-			Address = IPAddress.Parse(data.Address);
+			ThemeUpdateControls.UpdateControls(this);
+			if (IPAddress.TryParse(data.Address, out var result))
+			{
+				Address = result;
+			}
+			else
+			{
+				Address = IPAddress.Loopback;
+			}
 		}
 
 		public IPAddress Address
@@ -25,12 +32,12 @@ namespace VixenModules.Output.DDP
 				if (IPAddress.TryParse(textBoxIPAddress.Text, out result)) {
 					return result;
 				}
-				return null;
+				return IPAddress.Loopback;
 			}
 			set
 			{
 				if (value == null)
-					textBoxIPAddress.Text = string.Empty;
+					textBoxIPAddress.Text = IPAddress.Loopback.ToString();
 				else
 					textBoxIPAddress.Text = value.ToString();
 			}


### PR DESCRIPTION
* Initial IP Address string is formated with commas instead of periods between the numbers and the parse fails. Set the default to use the IPAddress.Loopback field string value in order to get a correct value.
* Fix the logic in the constructor to use TryParse on the string value saved in the data object to ensure it is protected in case of a improper value. If it is not parsable, default to Loopback.
* Change the set/get for IPAddress to use Loopback if they have a null value. With the other changes, this really should not occur, but ensures at least a valid value in all cases.