### PR TITLE
VIX-3593 Fix issue with clone preventing proper duplication of preview

### DIFF
--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewCustom.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewCustom.cs
@@ -280,15 +280,16 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		{
 			var newCustom = (PreviewCustom) MemberwiseClone();
 
-			newCustom.Strings = new List<PreviewLightBaseShape>(Strings.Count);
+			var newStrings = new List<PreviewLightBaseShape>(Strings.Count);
 
 			newCustom._topLeft = _topLeft.Copy();
 
 			foreach (var previewBaseShape in Strings)
 			{
-				newCustom.Strings.Add((PreviewLightBaseShape)previewBaseShape.Clone());
+				newStrings.Add((PreviewLightBaseShape)previewBaseShape.Clone());
 			}
 
+			newCustom.Strings = newStrings;
 
 			return newCustom;
 		}


### PR DESCRIPTION
* The clone method in PreviewCustom was incorrectly adding strings to the underlying collection that has overriden function that does not work when you directly add to the cloolection. Build the new string collection and then update the property with that collection to elicit functional behavior. This PreviewCustom is deprected so this is the minumal fix to get it working for legacy users.