### PR TITLE
VIX-3602 Fix crash in Find Effects Form

### DIFF
--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FindEffectForm.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FindEffectForm.cs
@@ -50,8 +50,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 					row.ElementAdded -= RowElementAddedRemoved;
 				}
 
-				TimelineControl.ElementsFinishedMoving += TimelineControlOnElementsFinishedMoving;
+				TimelineControl.ElementsFinishedMoving -= TimelineControlOnElementsFinishedMoving;
 			}
+
+			Resize -= FindEffectForm_Resize;
 
 		}
 


### PR DESCRIPTION
* Events where not being properly cleaned up when the form was closed, thus code was executing in a bad state on disposed objects. One event was being added again instead of removed, and another was not there at all.