### PR TITLE
VIX-3611 Long Video effect drifts out of sync

### DIFF
--- a/src/Vixen.Common/ffmpeg/ffmpeg.cs
+++ b/src/Vixen.Common/ffmpeg/ffmpeg.cs
@@ -38,7 +38,7 @@ namespace Vixen.Common.ffmpeg
 		}
 
 		//Native Video Effect
-		public static void MakeScaledThumbNails(string movieFile, string outputPath, double startPosition, double duration, int width, int height, bool maintainAspect, int rotateVideo, string cropVideo, int fps=20)
+		public static void MakeScaledThumbNails(string movieFile, string outputPath, double startPosition, double duration, int width, int height, bool maintainAspect, int rotateVideo, string cropVideo, double fps=20)
 		{
 			int maintainAspectValue = maintainAspect ? -1 : height;
 			//make arguments string

--- a/src/Vixen.Modules/Effect/Video/Video.cs
+++ b/src/Vixen.Modules/Effect/Video/Video.cs
@@ -619,7 +619,7 @@ namespace VixenModules.Effect.Video
 					if (_renderHeight % 2 != 0) _renderHeight++;
 					if (_renderWidth % 2 != 0) _renderWidth++;
 					Ffmpeg.MakeScaledThumbNails(videoFilename, _tempFilePath, StartTimeSeconds, ((TimeSpan.TotalSeconds * ((double)PlayBackSpeed / 100 + 1))),
-						_renderWidth, _renderHeight, MaintainAspect, RotateVideo, cropVideo, 1000 / FrameTime);
+						_renderWidth, _renderHeight, MaintainAspect, RotateVideo, cropVideo, 1000.0 / FrameTime);
 					_moviePicturesFileList = Directory.GetFiles(_tempFilePath).OrderBy(f => f).ToList();
 
 					_videoFileDetected = true;


### PR DESCRIPTION
Long Video effect drifts out of sync when (1000 / Update Interval) is not an integer