### PR TITLE
VIX-2615 Added functionality, similar to Marks, where Alt+mouse will conversely change the duration of adjacent Effects

### DIFF
--- a/src/Vixen.Common/Controls/TimeLineControl/Element.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Element.cs
@@ -21,7 +21,7 @@ namespace Common.Controls.Timeline
 		private Size _cachedImageSize= new Size(0,0);
 		private TimeSpan _elementVisibleStartTime;
 		private TimeSpan _elementVisibleEndTime;
-		
+		private bool _inAdjoiningUpdate = false;
 		public Element()
 		{
 			
@@ -37,6 +37,7 @@ namespace Common.Controls.Timeline
 			_duration = other._duration;
 			_selected = other._selected;
 			_targetNodes = other._targetNodes;
+			_inAdjoiningUpdate = other._inAdjoiningUpdate;
 		}
 
 		#region Begin/End update
@@ -48,9 +49,13 @@ namespace Common.Controls.Timeline
 		public void BeginUpdate()
 		{
 			SuspendEvents = true;
-			_origStartTime = StartTime;
-			_origDuration = Duration;
-			_origTargetNodes = _targetNodes;
+			if (_inAdjoiningUpdate == false)
+			{
+				_origStartTime = StartTime;
+				_origDuration = Duration;
+				_origTargetNodes = _targetNodes;
+				_inAdjoiningUpdate = true;
+			}
 		}
 
 		public void EndUpdate()
@@ -63,6 +68,7 @@ namespace Common.Controls.Timeline
 			{
 				EffectNode.Effect.TargetNodes = _targetNodes;
 			}
+			_inAdjoiningUpdate = false;
 		}
 
 		/// <summary>
@@ -80,6 +86,8 @@ namespace Common.Controls.Timeline
 			}
 				
 		}
+
+		public bool InAdjoiningChange() { return _inAdjoiningUpdate; }
 
 		public void  UpdateNotifyContentChanged()
 		{

--- a/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
@@ -44,7 +44,7 @@ namespace Common.Controls.Timeline
 		public ISequenceContext Context = null;
 		public bool SequenceLoading { get; set; }
 		public Element _workingElement; //This is the element that was left clicked, is set to null on mouse up
-		public string alignmentHelperWarning = @"Too many effects selected on the same row for this action.\nMax selected effects per row for this action is 4";
+		public string alignmentHelperWarning = "Too many effects selected on the same row for this action.\nMax selected effects per row for this action is 4";
 		public bool aCadStyleSelectionBox { get; set; }
 
 		private List<Row> _visibleRows = new List<Row>();
@@ -2721,6 +2721,53 @@ namespace Common.Controls.Timeline
 			VisibleTimeStart = visibleTimeStart;
 		}
 
+		/// <summary>
+		/// Append a set of Elements parameters to Original buffer for an Undo operation
+		/// </summary>
+		/// <param name="modifyingElements">List of Elements</param>
+		/// <exception cref="OriginalElements">Thrown if ElementMoveInfo not called prior</exception>
+		public void AppendElementMoveInfo(IEnumerable<Element> modifyingElements)
+		{
+			if (OriginalElements == null)
+				throw new Exception("Appending moving elements without initializing moving.");
+
+			// Save the original parameters of each element
+			foreach (var elem in modifyingElements)
+			{
+				OriginalElements.Add(elem, new ElementTimeInfo(elem));
+			}
+		}
+
+		/// <summary>
+		/// Append a set of Elements parameters to Original buffer for an Undo operation
+		/// </summary>
+		/// <param name="modifyingElements">List of Elements</param>
+		/// <exception cref="OriginalElements">Thrown if ElementMoveInfo not called prior</exception>
+		public void AppendElementMoveInfo(Element modifyingElement)
+		{
+			if (OriginalElements == null)
+				throw new Exception("Appending a moving element without initializing moving.");
+
+			// Save the original parameters of an element
+			OriginalElements.Add(modifyingElement, new ElementTimeInfo(modifyingElement));
+		}
+
+		/// <summary>
+		/// Get the original time information for a specific element
+		/// </summary>
+		/// <param name="searchElement">List of Elements</param>
+		/// <exception cref="OriginalElements">Thrown if ElementMoveInfo not called prior</exception>
+		/// <returns>Time information</returns>
+		public ElementTimeInfo GetElementMoveInfo(Element searchElement)
+		{
+			if (OriginalElements == null)
+				throw new Exception("Getting move information without initializing moving.");
+
+			ElementTimeInfo modifyingElement;
+			OriginalElements.TryGetValue(searchElement, out modifyingElement);
+
+			return modifyingElement;
+		}
 
 		///<summary>The point on the grid where the mouse first went down.</summary>
 		public Point InitialGridLocation { get; private set; }

--- a/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -960,7 +960,7 @@ namespace Common.Controls.Timeline
 					if (shortest - dt < pixelsToTime(MinElemWidthPx))
 						dt = shortest - pixelsToTime(MinElemWidthPx);
 
-					if (AltPressed)
+					if (AltPressed && adjoiningElements.Count() == 0)
 					{
 						// Get the Elements that are preceding the Selected Element
 						List<Element> priorElements = Rows.First().GetPriorsOfElement(SelectedElements.First());
@@ -1008,7 +1008,8 @@ namespace Common.Controls.Timeline
 					if (shortest + dt < pixelsToTime(MinElemWidthPx))
 						dt = -(shortest - pixelsToTime(MinElemWidthPx));
 
-					if (AltPressed)
+					// If the Alt key is pressed and we have not already created as Adjoining List
+					if (AltPressed && adjoiningElements.Count() == 0)
 					{
 						// Get the Elements that are following the Selected Element
 						List<Element> followElements = Rows.First().GetFollowersOfElement(SelectedElements.First());
@@ -1062,7 +1063,7 @@ namespace Common.Controls.Timeline
 				}
 			}
 
-			// Apply dt to the Start Times of all adjoining elements, if any
+`			// Apply dt to all adjoining elements, if any
 			if (AltPressed && adjoiningElements is not null)
 			{
 				foreach (var element in adjoiningElements)
@@ -1073,27 +1074,32 @@ namespace Common.Controls.Timeline
 							// Move the starting time(s)
 							element.EndTime = SelectedElements.First().StartTime;
 
-							// If the resultant duration is less than the minimum, reset to the minimum
+							// If the resultant duration is less than the minimum,then stop all further resizing
 							if (timeToPixels(element.Duration) <= MinElemWidthPx)
+							{ 
 								element.EndTime = element.StartTime + PixelsToTime(MinElemWidthPx);
+								SelectedElements.First().StartTime = element.EndTime;
+								SelectedElements.First().EndTime = m_elemMoveInfo.OriginalElements[SelectedElements.First()].EndTime;
+							}
 
 							//Control when the time changed event happens.
 							element.UpdateNotifyTimeChanged();
 							break;
 
 						case ResizeZone.Back:
-							// Move the ending time(s)
+							// Move the time(s)
 							TimeSpan saveEndTime = element.EndTime;
 							element.StartTime = SelectedElements.First().EndTime;
 							
 							// Keep the end time unchanged
 							element.EndTime = saveEndTime;
 
-							// If the resultant duration is less than the minimum, reset to the minimum
+							// If the resultant duration is less than the minimum,then stop all further resizing
 							if (timeToPixels(element.Duration) <= MinElemWidthPx)
 							{
 								element.StartTime = saveEndTime - PixelsToTime(MinElemWidthPx);
 								element.Duration = PixelsToTime(MinElemWidthPx);
+								SelectedElements.First().EndTime = element.StartTime;
 							}
 
 							//Control when the time changed event happens.

--- a/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -7,6 +7,7 @@ namespace Common.Controls.Timeline
 	public partial class Grid
 	{
 		List<Element> capturedElements = new List<Element>();
+		List<Element> adjoiningElements = null;
 		public bool EnableDrawMode = false;
 		public Guid SelectedEffect { get; set; }
 		public bool _beginEffectDraw;
@@ -168,6 +169,14 @@ namespace Common.Controls.Timeline
 						}
 						else if (!CtrlPressed)
 						{
+							if (AltPressed && SelectedElements.Count() > 1)
+							{
+								MessageBoxForm.msgIcon = SystemIcons.Warning;
+								var messageBox = new MessageBoxForm("Too many effects selected.\nMaximum selected effects for this action is 1",
+									"Warning", false, false);
+								messageBox.ShowDialog();
+								return;
+							}
 							beginHResize(gridLocation); // begin a resize.
 						}
 					}
@@ -486,11 +495,48 @@ namespace Common.Controls.Timeline
 				elem.BeginUpdate();
 		}
 
+		/// <summary>
+		/// Saves the pre-move information and begins update on all selected elements.<br/>
+		/// Called when any operation moves element times.
+		/// </summary>
+		/// <param name="elements">List of Elements that are moving</param>
+		/// <exception cref="m_elemMoveInfo">Thrown if elementsBeginMove not called prior</exception>
+		private void appendElementsBeginMove(List<Element> elements)
+		{
+			if (m_elemMoveInfo == null)
+				throw new Exception("Calling appendMove prior to a beginMove.");
+
+			if (elements is null)
+				return;
+
+
+			foreach (var elem in elements)
+			{
+				if (!elem.InAdjoiningChange())
+				{
+					m_elemMoveInfo.AppendElementMoveInfo(elem);
+					elem.BeginUpdate();
+				}
+			}
+			return;
+		}
+
 		private void elementsFinishedMoving(ElementMoveType type)
 		{
 			foreach (var elem in SelectedElements) {
 				elem.EndUpdate();
 				RenderElement(elem);
+			}
+
+			// If there were any adjoining elements, then finish processing those
+			if (adjoiningElements is not null)
+			{
+				foreach (var elem in adjoiningElements)
+				{
+					elem.EndUpdate();
+					RenderElement(elem);
+				}
+				adjoiningElements = null;
 			}
 
 			MultiElementEventArgs evargs = new MultiElementEventArgs {Elements = SelectedElements};
@@ -814,7 +860,7 @@ namespace Common.Controls.Timeline
 			dt = FindSnapTimeForElements(SelectedElements, dt, ResizeZone.None);
 
 			foreach (var elem in SelectedElements) {
-				// Get this elemenent's original times (before resize started)
+				// Get this element's original times (before resize started)
 				ElementTimeInfo orig = m_elemMoveInfo.OriginalElements[elem];
 				elem.StartTime = orig.StartTime + dt;
 				//Control when the time changed event happens.
@@ -853,52 +899,151 @@ namespace Common.Controls.Timeline
 			CurrentRowIndexUnderMouse = Rows.IndexOf(rowAt(gridLocation));
 			calculateSnapPoints();
 			elementsBeginMove(gridLocation);
+			adjoiningElements = new List<Element>();
 		}
 
+		/// <summary>
+		/// Adds to the process of beginHResize
+		/// </summary>
+		/// <param name="elements">List of elements that are about to change</param>
+		/// <remarks>Must call beginHResize prior to calling this method</remarks>
+		private void beginAppendHResize(List<Element> elements)
+		{
+			appendElementsBeginMove(elements);
+		}
+
+		/// <summary>
+		/// Resize the starting or ending times of elements
+		/// </summary>
+		/// <param name="gridLocation">Current mouse position</param>
+		/// <param name="delta">Size and direction of mouse movement</param>
+		/// <remarks>If the Ctrl key is active, then the adjoining elements are also resized</remarks>
 		private void MouseMove_HResizing(Point gridLocation, Point delta)
 		{
 			TimeSpan dt = pixelsToTime(gridLocation.X - m_elemMoveInfo.InitialGridLocation.X);
 
+			// Check to see if the time (resizing) moved
 			if (dt == TimeSpan.Zero)
 				return;
 
-			// Modifidy our dt, if necessary.
+			// Verify that only one primary Element is selected, if we are moving adjoining Elements
+			else if (AltPressed && SelectedElements.Count() > 1)
+				return;
 
-			// modify the dt time based on snap points (ie. marks, and borders of other elements)
+			// Modify the dt time based on snap points (ie. marks, and borders of other elements)
 			dt = FindSnapTimeForElements(SelectedElements, dt, m_mouseResizeZone);
 
-			// Ensure minimum size
-			TimeSpan shortest = m_elemMoveInfo.OriginalElements.Values.Min(x => x.Duration);
+			// Find the shortest duration of all those elements selected
+			TimeSpan shortest = TimeSpan.MaxValue;
+			foreach (var element in SelectedElements)
+			{
+				ElementTimeInfo ei = m_elemMoveInfo.GetElementMoveInfo(element);
+				if (ei.Duration < shortest)
+					shortest = ei.Duration;
+			}
 
 			// Check boundary conditions
 			switch (m_mouseResizeZone) {
 				case ResizeZone.Front:
 					// Clip earliest element StartTime at zero
-					TimeSpan earliest = m_elemMoveInfo.OriginalElements.Values.Min(x => x.StartTime);
+					TimeSpan earliest = TimeInfo.TotalTime;
+					foreach (var element in SelectedElements)
+					{
+						TimeSpan checkTime = m_elemMoveInfo.GetElementMoveInfo(element).StartTime;
+						if (checkTime < earliest)
+							earliest = checkTime;
+					}
 					if ((earliest + dt) < TimeSpan.Zero)
 						dt = -earliest;
 
-					// Ensure the shortest meets minimum width (in px)
-					if (timeToPixels(shortest - dt) < MinElemWidthPx)
+					// Ensure the proposed shortest duration meets minimum width (in px)
+					if (shortest - dt < pixelsToTime(MinElemWidthPx))
 						dt = shortest - pixelsToTime(MinElemWidthPx);
+
+					if (AltPressed)
+					{
+						// Get the Elements that are preceding the Selected Element
+						List<Element> priorElements = Rows.First().GetPriorsOfElement(SelectedElements.First());
+
+						// In those preceding Elements, find what the latest ending time is
+						TimeSpan latestTime = TimeSpan.Zero;
+						foreach (var element in priorElements)
+						{
+							if (element.EndTime > latestTime)
+							{
+								latestTime = element.EndTime;
+							}
+						}
+
+						// Reiterate through the list of preceding elements, creating a new list of all
+						// those Elements that have that latest ending time
+						foreach (var element in priorElements)
+						{
+							if (element.EndTime == latestTime)
+							{
+								if (!element.InAdjoiningChange())
+								{
+									adjoiningElements.Add(element);
+								}
+							}
+						}
+
+						// Save the current state information of these Target Elements
+						beginAppendHResize(adjoiningElements);
+					}
 					break;
 
 				case ResizeZone.Back:
-					// Clip latest element EndTime at TotalTime
-					TimeSpan latest = m_elemMoveInfo.OriginalElements.Values.Max(x => x.EndTime);
+					TimeSpan latest = TimeSpan.Zero;
+					foreach (var element in SelectedElements)
+					{
+						TimeSpan checkTime = m_elemMoveInfo.GetElementMoveInfo(element).EndTime;
+						if (checkTime > latest)
+							latest = checkTime;
+					}
 					if ((latest + dt) > TimeInfo.TotalTime)
 						dt = TimeInfo.TotalTime - latest;
 
-					// Ensure the shortest meets minimum width (in px)
-					if (timeToPixels(shortest + dt) < MinElemWidthPx)
-						dt = pixelsToTime(MinElemWidthPx) - shortest;
+					// Ensure the proposed shortest duration meets minimum width (in px)
+					if (shortest + dt < pixelsToTime(MinElemWidthPx))
+						dt = -(shortest - pixelsToTime(MinElemWidthPx));
+
+					if (AltPressed)
+					{
+						// Get the Elements that are following the Selected Element
+						List<Element> followElements = Rows.First().GetFollowersOfElement(SelectedElements.First());
+
+						// In those following Elements, find what the earliest starting time is
+						TimeSpan earliestTime = TimeSpan.MaxValue;
+						foreach (var element in followElements)
+						{
+							if (element.StartTime < earliestTime)
+							{
+								earliestTime = element.StartTime;
+							}
+						}
+
+						// Reiterate through the list of following elements, creating a new list of all
+						// those Elements that have that earliest starting time
+						adjoiningElements = new List<Element>();
+						foreach (var element in followElements)
+						{
+							if (element.StartTime == earliestTime)
+							{
+								adjoiningElements.Add(element);
+							}
+						}
+
+						// Save the current state information of these Target Elements
+						beginAppendHResize(adjoiningElements);
+					}
 					break;
 			}
 
 
 			// Apply dt to all selected elements.
 			foreach (var elem in SelectedElements) {
-				// Get this elemenent's original times (before resize started)
+				// Get this element's original times (before resize started)
 				ElementTimeInfo orig = m_elemMoveInfo.OriginalElements[elem];
 
 				switch (m_mouseResizeZone) {
@@ -917,6 +1062,50 @@ namespace Common.Controls.Timeline
 				}
 			}
 
+			// Apply dt to the Start Times of all adjoining elements, if any
+			if (AltPressed && adjoiningElements is not null)
+			{
+				foreach (var element in adjoiningElements)
+				{
+					switch (m_mouseResizeZone)
+					{
+						case ResizeZone.Front:
+							// Move the starting time(s)
+							element.EndTime = SelectedElements.First().StartTime;
+
+							// If the resultant duration is less than the minimum, reset to the minimum
+							if (timeToPixels(element.Duration) <= MinElemWidthPx)
+								element.EndTime = element.StartTime + PixelsToTime(MinElemWidthPx);
+
+							//Control when the time changed event happens.
+							element.UpdateNotifyTimeChanged();
+							break;
+
+						case ResizeZone.Back:
+							// Move the ending time(s)
+							TimeSpan saveEndTime = element.EndTime;
+							element.StartTime = SelectedElements.First().EndTime;
+							
+							// Keep the end time unchanged
+							element.EndTime = saveEndTime;
+
+							// If the resultant duration is less than the minimum, reset to the minimum
+							if (timeToPixels(element.Duration) <= MinElemWidthPx)
+							{
+								element.StartTime = saveEndTime - PixelsToTime(MinElemWidthPx);
+								element.Duration = PixelsToTime(MinElemWidthPx);
+							}
+
+							//Control when the time changed event happens.
+							element.UpdateNotifyTimeChanged();
+							break;
+					}
+
+					// Render the Adjoining elements as they change
+					RenderElement(element);
+				}
+			}
+
 			Invalidate();
 		}
 
@@ -925,6 +1114,7 @@ namespace Common.Controls.Timeline
 			elementsFinishedMoving(ElementMoveType.Resize);
 			endAllDrag();
 			CurrentDragSnapPoints.Clear();
+			adjoiningElements = null;
 		}
 
 		#endregion

--- a/src/Vixen.Common/Controls/TimeLineControl/Row.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Row.cs
@@ -509,7 +509,7 @@ namespace Common.Controls.Timeline
 			List<Element> elements = new List<Element>();
 			int startingIndex = IndexOfElement(elementMaster, SearchBy.EndTime);
 			TimeSpan startTime = elementMaster.StartTime;
-			for (int i = startingIndex - 1, maxCtr = maximum-1; i >= 0 && maxCtr >= 0; i--, maxCtr--)
+			for (int i = startingIndex, maxCtr = maximum-1; i >= 0 && maxCtr >= 0; i--, maxCtr--)
 			{
 				Element element = GetElementAtIndex(i);
 				if (element.EndTime <= startTime)

--- a/src/Vixen.Common/Controls/TimeLineControl/Row.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Row.cs
@@ -499,6 +499,54 @@ namespace Common.Controls.Timeline
 		}
 
 		/// <summary>
+		/// Gets the elements that precede the selected element
+		/// </summary>
+		/// <param name="elementMaster">Element to start search</param>
+		/// <param name="maximum">Maximum number of elements to return. Defaults to 20</param>
+		/// <returns>List of all elements discovered</returns>
+		public List<Element> GetPriorsOfElement(Element elementMaster, int maximum = 20)
+		{
+			List<Element> elements = new List<Element>();
+			int startingIndex = IndexOfElement(elementMaster, SearchBy.EndTime);
+			TimeSpan startTime = elementMaster.StartTime;
+			for (int i = startingIndex - 1, maxCtr = maximum-1; i >= 0 && maxCtr >= 0; i--, maxCtr--)
+			{
+				Element element = GetElementAtIndex(i);
+				if (element.EndTime <= startTime)
+				{
+					elements.Add(element);
+				}
+			}
+
+			return elements;
+		}
+
+		/// <summary>
+		/// Gets the elements that follow the selected element
+		/// </summary>
+		/// <param name="elementMaster">Element to start search</param>
+		/// <param name="maximum">Maximum number of elements to return. Defaults to 20</param>
+		/// <returns>List of all elements discovered</returns>
+		public List<Element> GetFollowersOfElement(Element elementMaster, int maximum = 20)
+		{
+			List<Element> elements = new List<Element>();
+			int startingIndex = IndexOfElement(elementMaster);
+			TimeSpan endTime = elementMaster.EndTime;
+
+			// Start at elementMaster and look forward to very last element or "maximum" number of elements
+			for (int i = startingIndex + 1, maxCtr = maximum - 1 ; (maxCtr >= 0) && (i < m_elements.Count); i++, maxCtr--)
+			{
+				Element element = GetElementAtIndex(i);
+				if (element.StartTime >= endTime)
+				{
+					elements.Add(element);
+				}
+			}
+
+			return elements;
+		}
+
+		/// <summary>
 		/// For adding elements in bulk. Sorting is delayed until all elements are added.
 		/// </summary>
 		/// <param name="elements"></param>
@@ -567,9 +615,30 @@ namespace Common.Controls.Timeline
 			return m_elements.Contains(element);
 		}
 
-		public int IndexOfElement(Element element)
+		public enum SearchBy { StartTime, EndTime};
+		/// <summary>
+		/// Searches for the Element and returns the zero-based index of the occurrence with Row
+		/// </summary>
+		/// <param name="element">Element to search</param>
+		/// <param name="searchBy">
+		/// Search if the search is by the start time or end time<br />
+		/// - StartTime<br />
+		/// - EndTime
+		/// </param>
+		/// <returns>The zero-based index of the occurrence of the Element</returns>
+		public int IndexOfElement(Element element, SearchBy searchBy = SearchBy.StartTime)
 		{
-			return m_elements.IndexOf(element);
+			int index = m_elements.IndexOf(element);
+
+			if (searchBy == SearchBy.EndTime)
+			{
+				for (index++; index < m_elements.Count; index++)
+					if (m_elements[index].EndTime > element.EndTime)
+						break;
+				index--;
+			}
+
+			return index;
 		}
 
 		public Element GetElementAtIndex(int index)
@@ -623,7 +692,7 @@ namespace Common.Controls.Timeline
 		{
 			return m_elements.GetEnumerator();
 		}
-
+		
 		#endregion
 
 		#region Implementation of IDisposable


### PR DESCRIPTION
Added additional functionality, similar to Marks, where the Alt key will enhanced mouse dragging functionality to "connect" two adjecent Effects allowing the duration increase of one and the simultaneous duration decrease of the other.