### PR TITLE
VIX-3625 Video Effect Cache Improvements

### DIFF
--- a/src/Vixen.Application/OptionsDialog.Designer.cs
+++ b/src/Vixen.Application/OptionsDialog.Designer.cs
@@ -28,170 +28,182 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.btnOK = new System.Windows.Forms.Button();
-			this.btnCancel = new System.Windows.Forms.Button();
-			this.label1 = new System.Windows.Forms.Label();
-			this.label2 = new System.Windows.Forms.Label();
-			this.ctlUpdateInteral = new System.Windows.Forms.NumericUpDown();
-			this.label3 = new System.Windows.Forms.Label();
-			this.wasapiLatency = new System.Windows.Forms.NumericUpDown();
-			this.label4 = new System.Windows.Forms.Label();
-			this.grpAudio = new System.Windows.Forms.GroupBox();
-			((System.ComponentModel.ISupportInitialize)(this.ctlUpdateInteral)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.wasapiLatency)).BeginInit();
-			this.grpAudio.SuspendLayout();
-			this.SuspendLayout();
+			btnOK = new Button();
+			btnCancel = new Button();
+			label1 = new Label();
+			label2 = new Label();
+			ctlUpdateInteral = new NumericUpDown();
+			label3 = new Label();
+			wasapiLatency = new NumericUpDown();
+			grpAudio = new GroupBox();
+			grpVideoEffectCache = new GroupBox();
+			label4 = new Label();
+			cmbBoxVideoEffectCacheFileType = new ComboBox();
+			chkBoxClearEffectCacheOnExit = new CheckBox();
+			((System.ComponentModel.ISupportInitialize)ctlUpdateInteral).BeginInit();
+			((System.ComponentModel.ISupportInitialize)wasapiLatency).BeginInit();
+			grpAudio.SuspendLayout();
+			grpVideoEffectCache.SuspendLayout();
+			SuspendLayout();
 			// 
 			// btnOK
 			// 
-			this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.btnOK.Location = new System.Drawing.Point(196, 207);
-			this.btnOK.Name = "btnOK";
-			this.btnOK.Size = new System.Drawing.Size(87, 27);
-			this.btnOK.TabIndex = 1;
-			this.btnOK.Text = "OK";
-			this.btnOK.UseVisualStyleBackColor = true;
-			this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-			this.btnOK.MouseLeave += new System.EventHandler(this.buttonBackground_MouseLeave);
-			this.btnOK.MouseHover += new System.EventHandler(this.buttonBackground_MouseHover);
+			btnOK.DialogResult = DialogResult.OK;
+			btnOK.Location = new Point(196, 255);
+			btnOK.Name = "btnOK";
+			btnOK.Size = new Size(87, 27);
+			btnOK.TabIndex = 6;
+			btnOK.Text = "OK";
+			btnOK.UseVisualStyleBackColor = true;
+			btnOK.Click += btnOK_Click;
+			btnOK.MouseLeave += buttonBackground_MouseLeave;
+			btnOK.MouseHover += buttonBackground_MouseHover;
 			// 
 			// btnCancel
 			// 
-			this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.btnCancel.Location = new System.Drawing.Point(290, 207);
-			this.btnCancel.Name = "btnCancel";
-			this.btnCancel.Size = new System.Drawing.Size(87, 27);
-			this.btnCancel.TabIndex = 2;
-			this.btnCancel.Text = "Cancel";
-			this.btnCancel.UseVisualStyleBackColor = true;
-			this.btnCancel.MouseLeave += new System.EventHandler(this.buttonBackground_MouseLeave);
-			this.btnCancel.MouseHover += new System.EventHandler(this.buttonBackground_MouseHover);
+			btnCancel.DialogResult = DialogResult.Cancel;
+			btnCancel.Location = new Point(290, 255);
+			btnCancel.Name = "btnCancel";
+			btnCancel.Size = new Size(87, 27);
+			btnCancel.TabIndex = 7;
+			btnCancel.Text = "Cancel";
+			btnCancel.UseVisualStyleBackColor = true;
+			btnCancel.MouseLeave += buttonBackground_MouseLeave;
+			btnCancel.MouseHover += buttonBackground_MouseHover;
 			// 
 			// label1
 			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(14, 10);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(346, 15);
-			this.label1.TabIndex = 2;
-			this.label1.Text = "This form lets you set various options that control V3\'s operation";
+			label1.AutoSize = true;
+			label1.Location = new Point(14, 10);
+			label1.Name = "label1";
+			label1.Size = new Size(346, 15);
+			label1.TabIndex = 2;
+			label1.Text = "This form lets you set various options that control V3's operation";
 			// 
 			// label2
 			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(14, 47);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(90, 15);
-			this.label2.TabIndex = 3;
-			this.label2.Text = "Update Interval:";
+			label2.AutoSize = true;
+			label2.Location = new Point(14, 47);
+			label2.Name = "label2";
+			label2.Size = new Size(90, 15);
+			label2.TabIndex = 3;
+			label2.Text = "Update Interval:";
 			// 
 			// ctlUpdateInteral
 			// 
-			this.ctlUpdateInteral.Increment = new decimal(new int[] {
-            23,
-            0,
-            0,
-            0});
-			this.ctlUpdateInteral.Location = new System.Drawing.Point(116, 44);
-			this.ctlUpdateInteral.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            0});
-			this.ctlUpdateInteral.Name = "ctlUpdateInteral";
-			this.ctlUpdateInteral.Size = new System.Drawing.Size(59, 23);
-			this.ctlUpdateInteral.TabIndex = 0;
-			this.ctlUpdateInteral.Value = new decimal(new int[] {
-            23,
-            0,
-            0,
-            0});
+			ctlUpdateInteral.Increment = new decimal(new int[] { 23, 0, 0, 0 });
+			ctlUpdateInteral.Location = new Point(116, 44);
+			ctlUpdateInteral.Maximum = new decimal(new int[] { 500, 0, 0, 0 });
+			ctlUpdateInteral.Name = "ctlUpdateInteral";
+			ctlUpdateInteral.Size = new Size(59, 23);
+			ctlUpdateInteral.TabIndex = 0;
+			ctlUpdateInteral.Value = new decimal(new int[] { 23, 0, 0, 0 });
 			// 
 			// label3
 			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(6, 31);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(51, 15);
-			this.label3.TabIndex = 4;
-			this.label3.Text = "Latency:";
+			label3.AutoSize = true;
+			label3.Location = new Point(6, 31);
+			label3.Name = "label3";
+			label3.Size = new Size(51, 15);
+			label3.TabIndex = 4;
+			label3.Text = "Latency:";
 			// 
 			// wasapiLatency
 			// 
-			this.wasapiLatency.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-			this.wasapiLatency.Location = new System.Drawing.Point(99, 29);
-			this.wasapiLatency.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            0});
-			this.wasapiLatency.Minimum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-			this.wasapiLatency.Name = "wasapiLatency";
-			this.wasapiLatency.Size = new System.Drawing.Size(59, 23);
-			this.wasapiLatency.TabIndex = 5;
-			this.wasapiLatency.Value = new decimal(new int[] {
-            25,
-            0,
-            0,
-            0});
-			// 
-			// label4
-			// 
-			this.label4.AutoSize = true;
-			this.label4.Location = new System.Drawing.Point(6, 62);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(0, 15);
-			this.label4.TabIndex = 6;
+			wasapiLatency.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+			wasapiLatency.Location = new Point(99, 29);
+			wasapiLatency.Maximum = new decimal(new int[] { 500, 0, 0, 0 });
+			wasapiLatency.Minimum = new decimal(new int[] { 5, 0, 0, 0 });
+			wasapiLatency.Name = "wasapiLatency";
+			wasapiLatency.Size = new Size(59, 23);
+			wasapiLatency.TabIndex = 3;
+			wasapiLatency.Value = new decimal(new int[] { 25, 0, 0, 0 });
 			// 
 			// grpAudio
 			// 
-			this.grpAudio.Controls.Add(this.label3);
-			this.grpAudio.Controls.Add(this.label4);
-			this.grpAudio.Controls.Add(this.wasapiLatency);
-			this.grpAudio.Location = new System.Drawing.Point(17, 86);
-			this.grpAudio.Name = "grpAudio";
-			this.grpAudio.Size = new System.Drawing.Size(343, 76);
-			this.grpAudio.TabIndex = 7;
-			this.grpAudio.TabStop = false;
-			this.grpAudio.Text = "Audio";
+			grpAudio.Controls.Add(label3);
+			grpAudio.Controls.Add(wasapiLatency);
+			grpAudio.Location = new Point(17, 80);
+			grpAudio.Name = "grpAudio";
+			grpAudio.Size = new Size(343, 76);
+			grpAudio.TabIndex = 2;
+			grpAudio.TabStop = false;
+			grpAudio.Text = "Audio";
+			// 
+			// grpVideoEffectCache
+			// 
+			grpVideoEffectCache.Controls.Add(label4);
+			grpVideoEffectCache.Controls.Add(cmbBoxVideoEffectCacheFileType);
+			grpVideoEffectCache.Location = new Point(17, 166);
+			grpVideoEffectCache.Name = "grpVideoEffectCache";
+			grpVideoEffectCache.Size = new Size(343, 76);
+			grpVideoEffectCache.TabIndex = 4;
+			grpVideoEffectCache.TabStop = false;
+			grpVideoEffectCache.Text = "Video Effect Cache";
+			// 
+			// label4
+			// 
+			label4.AutoSize = true;
+			label4.Location = new Point(6, 31);
+			label4.Name = "label4";
+			label4.Size = new Size(91, 15);
+			label4.TabIndex = 2;
+			label4.Text = "Cache File Type:";
+			// 
+			// cmbBoxVideoEffectCacheFileType
+			// 
+			cmbBoxVideoEffectCacheFileType.FormattingEnabled = true;
+			cmbBoxVideoEffectCacheFileType.Items.AddRange(new object[] { "bmp", "png" });
+			cmbBoxVideoEffectCacheFileType.Location = new Point(99, 28);
+			cmbBoxVideoEffectCacheFileType.Name = "cmbBoxVideoEffectCacheFileType";
+			cmbBoxVideoEffectCacheFileType.Size = new Size(59, 23);
+			cmbBoxVideoEffectCacheFileType.TabIndex = 5;
+			cmbBoxVideoEffectCacheFileType.Text = "bmp";
+			// 
+			// chkBoxClearEffectCacheOnExit
+			// 
+			chkBoxClearEffectCacheOnExit.AutoSize = true;
+			chkBoxClearEffectCacheOnExit.Checked = true;
+			chkBoxClearEffectCacheOnExit.CheckState = CheckState.Checked;
+			chkBoxClearEffectCacheOnExit.Location = new Point(216, 46);
+			chkBoxClearEffectCacheOnExit.Name = "chkBoxClearEffectCacheOnExit";
+			chkBoxClearEffectCacheOnExit.Size = new Size(161, 19);
+			chkBoxClearEffectCacheOnExit.TabIndex = 1;
+			chkBoxClearEffectCacheOnExit.Text = "Clear Effect Cache on Exit";
+			chkBoxClearEffectCacheOnExit.UseVisualStyleBackColor = true;
 			// 
 			// OptionsDialog
 			// 
-			this.AcceptButton = this.btnOK;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.btnCancel;
-			this.ClientSize = new System.Drawing.Size(392, 246);
-			this.Controls.Add(this.grpAudio);
-			this.Controls.Add(this.ctlUpdateInteral);
-			this.Controls.Add(this.label2);
-			this.Controls.Add(this.label1);
-			this.Controls.Add(this.btnCancel);
-			this.Controls.Add(this.btnOK);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(408, 39);
-			this.Name = "OptionsDialog";
-			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Options";
-			this.Load += new System.EventHandler(this.OptionsDialog_Load);
-			((System.ComponentModel.ISupportInitialize)(this.ctlUpdateInteral)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.wasapiLatency)).EndInit();
-			this.grpAudio.ResumeLayout(false);
-			this.grpAudio.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
-
+			AcceptButton = btnOK;
+			AutoScaleDimensions = new SizeF(7F, 15F);
+			AutoScaleMode = AutoScaleMode.Font;
+			CancelButton = btnCancel;
+			ClientSize = new Size(392, 293);
+			Controls.Add(grpVideoEffectCache);
+			Controls.Add(grpAudio);
+			Controls.Add(chkBoxClearEffectCacheOnExit);
+			Controls.Add(ctlUpdateInteral);
+			Controls.Add(label2);
+			Controls.Add(label1);
+			Controls.Add(btnCancel);
+			Controls.Add(btnOK);
+			FormBorderStyle = FormBorderStyle.FixedDialog;
+			MaximizeBox = false;
+			MinimizeBox = false;
+			MinimumSize = new Size(408, 39);
+			Name = "OptionsDialog";
+			SizeGripStyle = SizeGripStyle.Hide;
+			StartPosition = FormStartPosition.CenterParent;
+			Text = "Options";
+			Load += OptionsDialog_Load;
+			((System.ComponentModel.ISupportInitialize)ctlUpdateInteral).EndInit();
+			((System.ComponentModel.ISupportInitialize)wasapiLatency).EndInit();
+			grpAudio.ResumeLayout(false);
+			grpAudio.PerformLayout();
+			grpVideoEffectCache.ResumeLayout(false);
+			grpVideoEffectCache.PerformLayout();
+			ResumeLayout(false);
+			PerformLayout();
 		}
 
 		#endregion
@@ -203,7 +215,10 @@
 		private System.Windows.Forms.NumericUpDown ctlUpdateInteral;
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.NumericUpDown wasapiLatency;
-		private System.Windows.Forms.Label label4;
 		private System.Windows.Forms.GroupBox grpAudio;
+		private GroupBox grpVideoEffectCache;
+		private CheckBox chkBoxClearEffectCacheOnExit;
+		private Label label4;
+		private ComboBox cmbBoxVideoEffectCacheFileType;
 	}
 }

--- a/src/Vixen.Application/OptionsDialog.cs
+++ b/src/Vixen.Application/OptionsDialog.cs
@@ -18,12 +18,25 @@ namespace VixenApplication
 		{
 			ctlUpdateInteral.Value = Vixen.Sys.VixenSystem.DefaultUpdateInterval;
 			wasapiLatency.Value = AudioOutputManager.Instance().Latency;
+			chkBoxClearEffectCacheOnExit.Checked = Vixen.Sys.VixenSystem.ClearEffectCacheOnExit;
+			cmbBoxVideoEffectCacheFileType.Text = Vixen.Sys.VixenSystem.VideoEffect_CacheFileType;
+
+			ToolTip toolTipVideoEffectCache = new ToolTip();
+			toolTipVideoEffectCache.AutoPopDelay = 5000;
+			toolTipVideoEffectCache.InitialDelay = 1000;
+			toolTipVideoEffectCache.ReshowDelay = 500;
+			toolTipVideoEffectCache.ShowAlways = true;
+
+			toolTipVideoEffectCache.SetToolTip(this.chkBoxClearEffectCacheOnExit, "Frees disk space, but adds some\ntime to rebuild at sequence open");
+			toolTipVideoEffectCache.SetToolTip(this.cmbBoxVideoEffectCacheFileType, "bmp - Fastest/Bigger\npng - Fast/Smaller");
 		}
 
 		private void btnOK_Click(object sender, EventArgs e)
 		{
 			Vixen.Sys.VixenSystem.DefaultUpdateInterval = (int)ctlUpdateInteral.Value;
 			AudioOutputManager.Instance().Latency = (int)wasapiLatency.Value;
+			Vixen.Sys.VixenSystem.ClearEffectCacheOnExit = chkBoxClearEffectCacheOnExit.Checked;
+			Vixen.Sys.VixenSystem.VideoEffect_CacheFileType = cmbBoxVideoEffectCacheFileType.Text;
 		}
 
 		private void buttonBackground_MouseHover(object sender, EventArgs e)
@@ -38,7 +51,5 @@ namespace VixenApplication
 			btn.BackgroundImage = Resources.ButtonBackgroundImage;
 
 		}
-
-
 	}
 }

--- a/src/Vixen.Application/OptionsDialog.resx
+++ b/src/Vixen.Application/OptionsDialog.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/Vixen.Common/ffmpeg/ffmpeg.cs
+++ b/src/Vixen.Common/ffmpeg/ffmpeg.cs
@@ -1,26 +1,36 @@
 ﻿using System.Diagnostics;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Vixen.Common.ffmpeg
 {
-	public class Ffmpeg
+	public partial class Ffmpeg
 	{
 		private static readonly string FfmpegPath;
+
+		//ffmpeg output line: "  Duration: 00:02:29.46, start: 0.00...."
+		[GeneratedRegex(@"Duration: (\d+):(\d{2}):(\d{2})\.(\d{2})")]
+		private static partial Regex parseDuration();
+
+		// look for ", ####x####" where numbers can be 2 to 5 digits long
+		[GeneratedRegex(@", (?<width>\d{2,5})x(?<height>\d{2,5})")]
+		private static partial Regex parseResolution();
 
 		static Ffmpeg()
 		{
 			FfmpegPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"ffmpeg.exe");
 		}
 
+		[Obsolete("Instead use MakeScaledThumbNails to limit the amount of video converted to thumbnails")]
 		//Nutcracker Video Effect
 		public static void MakeThumbnails(string movieFile, int width, int height, string outputPath, int framesPerSecond = 20)
 		{
 			//make arguments string
 			string args;
 			args = " -i \"" + movieFile + "\"" +
-			       " -s " + width + "x" + height +
-			       " -vf " +
-			       " fps=" + framesPerSecond + " \"" + outputPath + "\\%10d.png\"";
+				   " -s " + width + "x" + height +
+				   " -vf " +
+				   " fps=" + framesPerSecond + " \"" + outputPath + "\\%10d.png\"";
 			//create a process
 			Process myProcess = new Process();
 			myProcess.StartInfo.UseShellExecute = false;
@@ -37,30 +47,88 @@ namespace Vixen.Common.ffmpeg
 
 		}
 
-		//Native Video Effect
-		public static void MakeScaledThumbNails(string movieFile, string outputPath, double startPosition, double duration, int width, int height, bool maintainAspect, int rotateVideo, string cropVideo, double fps=20)
+		public static void MakeScaledThumbNails(string movieFile, string outputPath, double startPosition, double duration, int width, int height, bool maintainAspect, int rotateVideo, string cropVideo, double fps = 20, string cacheFileType = "bmp")
 		{
-			int maintainAspectValue = maintainAspect ? -1 : height;
-			//make arguments string
-			string args = $" -y -ss {startPosition} -i \"{movieFile}\" -an -t {duration.ToString(CultureInfo.InvariantCulture)} -vf \"scale={width}:{maintainAspectValue}{cropVideo}, rotate={rotateVideo}*(PI/180)\" -r {fps} \"{outputPath}\\%5d.bmp\"";
-			
-			ProcessStartInfo psi = new ProcessStartInfo(FfmpegPath, args);
-			psi.UseShellExecute = false;
-			psi.CreateNoWindow = true;
-			Process process = new Process();
-			process.StartInfo = psi;
-			
-			process.Start();
-			
-			process.WaitForExit();
+			string args = $" -y -ss {startPosition} -i \"{movieFile}\" -an -t {duration.ToString(CultureInfo.InvariantCulture)} -vf \"scale={width}:{(maintainAspect ? -1 : height)}{cropVideo}, rotate={rotateVideo}*(PI/180)\" -r {fps} \"{outputPath}\\%5d.{cacheFileType}\"";
+
+			ProcessStartInfo psi = new(FfmpegPath, args)
+			{
+				UseShellExecute = false,
+				CreateNoWindow = true
+			};
+			using (Process process = new())
+			{
+				process.StartInfo = psi;
+				process.Start();
+				process.WaitForExit();
+			};
 		}
 
+		public static void GetVideoDurationAndResolution(string videoFile, out TimeSpan duration, out int width, out int height)
+		{
+			duration = TimeSpan.Zero;
+			width = 0;
+			height = 0;
+			
+			string args = $"-hide_banner -an -sn -dn -i \"{videoFile}\"";
+
+			ProcessStartInfo psi = new(FfmpegPath, args)
+			{
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				RedirectStandardError = true
+			};
+			using (Process process = new())
+			{
+				process.StartInfo = psi;
+				process.Start();
+
+				// Keep all the ffmpeg output parsing logic in this class
+				string line;
+				Match match;
+				while ((line = process.StandardError.ReadLine()) != null)
+				{
+					match = parseDuration().Match(line);
+					if (match.Success)
+					{
+						duration = new TimeSpan(0,
+							Int32.Parse(match.Groups[1].Value),
+							Int32.Parse(match.Groups[2].Value),
+							Int32.Parse(match.Groups[3].Value),
+							Int32.Parse(match.Groups[4].Value) * 10);
+					}
+					// Find the " Video: " line, then look for the resolution
+					else if (line.Contains(" Video: "))
+					{
+						match = parseResolution().Match(line);
+						if (match.Success)
+						{
+							width = Int32.Parse(match.Groups["width"].Value);
+							height = Int32.Parse(match.Groups["height"].Value);
+							return; // Since Duration is always before the Video line, once width and height are found, we're done
+						}
+					}
+				}
+				// If we get here, something has failed to be found or parse
+				process.WaitForExit();
+				if (duration == TimeSpan.Zero)
+				{
+					throw new Exception($"Unable to parse Duration from ffmpeg output. Error code {process.ExitCode}");
+				}
+				else
+				{
+					throw new Exception($"Unable to parse Resolution from ffmpeg output. Error code {process.ExitCode}");
+				}
+			};
+		}
+
+		[Obsolete("Instead use GetVideoDurationAndResolution to return duration")]
 		//Get Video Info for native Video effect.
 		public static string GetVideoInfo(string movieFile, string outputPath)
 		{
 			//Gets Video length and will continue if users start position is less then the video length.
 			string args = " -i \"" + movieFile + "\"";
-			
+
 			ProcessStartInfo procStartInfo = new ProcessStartInfo(FfmpegPath, args);
 			procStartInfo.RedirectStandardError = true;
 			procStartInfo.UseShellExecute = false;
@@ -72,12 +140,13 @@ namespace Vixen.Common.ffmpeg
 			return result;
 		}
 
+		[Obsolete("Instead use GetVideoDurationAndResolution to return resolution")]
 		//Get Native Video Size Effect
 		public static void GetVideoSize(string movieFile, string outputPath)
 		{
 			//make arguments string
 			string args = $" -i \"{movieFile}\"  -vframes 1 \"{outputPath}\"";
-			
+
 			//Console.Out.WriteLine(args);
 			ProcessStartInfo psi = new ProcessStartInfo(FfmpegPath, args);
 			psi.UseShellExecute = false;
@@ -87,6 +156,5 @@ namespace Vixen.Common.ffmpeg
 			process.Start();
 			process.WaitForExit();
 		}
-
 	}
 }

--- a/src/Vixen.Core/IO/Policy/SystemConfigFilePolicy.cs
+++ b/src/Vixen.Core/IO/Policy/SystemConfigFilePolicy.cs
@@ -8,6 +8,8 @@
 			WriteIdentity();
 			WriteFilterEvaluationAllowance();
 			WriteDefaultUpdateInterval();
+			WriteClearEffectCacheOnExit();
+			WriteVideoEffectOptions();
 			WriteElements();
 			WriteNodes();
 			WriteControllers();
@@ -22,6 +24,8 @@
 		protected abstract void WriteIdentity();
 		protected abstract void WriteFilterEvaluationAllowance();
 		protected abstract void WriteDefaultUpdateInterval();
+		protected abstract void WriteClearEffectCacheOnExit();
+		protected abstract void WriteVideoEffectOptions();
 		protected abstract void WriteElements();
 		protected abstract void WriteNodes();
 		protected abstract void WriteControllers();
@@ -37,6 +41,8 @@
 			ReadIdentity();
 			ReadFilterEvaluationAllowance();
 			ReadDefaultUpdateInterval();
+			ReadClearEffectCacheOnExit();
+			ReadVideoEffectOptions();
 			ReadElements();
 			ReadNodes();
 			ReadControllers();
@@ -51,6 +57,8 @@
 		protected abstract void ReadIdentity();
 		protected abstract void ReadFilterEvaluationAllowance();
 		protected abstract void ReadDefaultUpdateInterval();
+		protected abstract void ReadClearEffectCacheOnExit();
+		protected abstract void ReadVideoEffectOptions();
 		protected abstract void ReadElements();
 		protected abstract void ReadNodes();
 		protected abstract void ReadControllers();

--- a/src/Vixen.Core/IO/Xml/SystemConfig/XmlSystemConfigFilePolicy.cs
+++ b/src/Vixen.Core/IO/Xml/SystemConfig/XmlSystemConfigFilePolicy.cs
@@ -16,6 +16,8 @@ namespace Vixen.IO.Xml.SystemConfig
 		private const string ELEMENT_EVAL_FILTERS = "AllowFilterEvaluation";
 		private const string ATTR_IS_CONTEXT = "isContext";
 		private const string ELEMENT_DEFAULT_UPDATE_INTERVAL = "DefaultUpdateInterval";
+		private const string ELEMENT_CLEAR_EFFECT_CACHE_ON_EXIT = "ClearEffectCacheOnExit";
+		private const string ELEMENT_VIDEO_EFFECT_CACHE_FILE_TYPE = "VideoEffectCacheFileType";
 
 		public XmlSystemConfigFilePolicy(SystemConfig systemConfig, XElement content)
 		{
@@ -44,6 +46,14 @@ namespace Vixen.IO.Xml.SystemConfig
 		protected override void WriteDefaultUpdateInterval()
 		{
 			_content.Add(new XElement(ELEMENT_DEFAULT_UPDATE_INTERVAL, _systemConfig.DefaultUpdateInterval));
+		}
+		protected override void WriteClearEffectCacheOnExit()
+		{
+			_content.Add(new XElement(ELEMENT_CLEAR_EFFECT_CACHE_ON_EXIT, _systemConfig.ClearEffectCacheOnExit));
+		}
+		protected override void WriteVideoEffectOptions()
+		{
+			_content.Add(new XElement(ELEMENT_VIDEO_EFFECT_CACHE_FILE_TYPE, _systemConfig.VideoEffect_CacheFileType));
 		}
 
 		protected override void WriteElements()
@@ -133,6 +143,17 @@ namespace Vixen.IO.Xml.SystemConfig
 			{
 				_systemConfig.DefaultUpdateInterval = Int32.Parse(identityElement.Value);
 			}
+		}
+		protected override void ReadClearEffectCacheOnExit()
+		{
+			XElement identityElement = _content.Element(ELEMENT_CLEAR_EFFECT_CACHE_ON_EXIT);
+			_systemConfig.ClearEffectCacheOnExit = identityElement == null ? true : Boolean.Parse(identityElement.Value);
+		}
+
+		protected override void ReadVideoEffectOptions()
+		{
+			XElement identityElement = _content.Element(ELEMENT_VIDEO_EFFECT_CACHE_FILE_TYPE);
+			_systemConfig.VideoEffect_CacheFileType = identityElement == null ? "bmp" : identityElement.Value;
 		}
 
 		protected override void ReadElements()

--- a/src/Vixen.Core/Module/Effect/EffectModuleInstanceBase.cs
+++ b/src/Vixen.Core/Module/Effect/EffectModuleInstanceBase.cs
@@ -442,6 +442,12 @@ namespace Vixen.Module.Effect
 			get { return false; }
 		}
 
+		public virtual void Removing()
+		{
+			// Intended for removing cache folders and other external resources if an Effect was deleted.
+			// Used by the Video Effect to remove cache folders
+		}
+
 		#endregion
 
 		#region INotifyPropertyChanged

--- a/src/Vixen.Core/Module/Effect/IEffectModuleInstance.cs
+++ b/src/Vixen.Core/Module/Effect/IEffectModuleInstance.cs
@@ -5,5 +5,6 @@
 		 bool ForceGenerateVisualRepresentation { get;   }
 
 		void MarkDirty();
+		void Removing();
 	}
 }

--- a/src/Vixen.Core/Sys/SystemConfig.cs
+++ b/src/Vixen.Core/Sys/SystemConfig.cs
@@ -143,6 +143,10 @@ namespace Vixen.Sys
 
 		public int DefaultUpdateInterval { get; set; }
 
+		public bool ClearEffectCacheOnExit { get; set; }
+
+		public string VideoEffect_CacheFileType { get; set; }
+
 		public void Save()
 		{
 			FileService.Instance.SaveSystemConfigFile(this);

--- a/src/Vixen.Core/Sys/VixenSystem.cs
+++ b/src/Vixen.Core/Sys/VixenSystem.cs
@@ -322,6 +322,18 @@ namespace Vixen.Sys
 			}
 		}
 
+		public static bool ClearEffectCacheOnExit
+		{
+			get { return SystemConfig.ClearEffectCacheOnExit; }
+			set { SystemConfig.ClearEffectCacheOnExit = value; }
+		}
+
+		public static string VideoEffect_CacheFileType
+		{
+			get { return SystemConfig.VideoEffect_CacheFileType; }
+			set { SystemConfig.VideoEffect_CacheFileType = value; }
+		}
+
 		public static TimeSpan DefaultUpdateTimeSpan { get; private set; }
 
 		public static ElementManager Elements { get; private set; }

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditorForm.cs
@@ -670,9 +670,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 			foreach (var node in _removedNodes)
 			{
-				//Dispose any nodes that where removed
+				//Dispose any nodes that where removed, except if an undo happened
 				if (!_effectNodeToElement.ContainsKey(node))
 				{
+					node.Effect.Removing(); // Notify Effect it has been deleted and to clean up external resources, like cache folders
 					node.Effect.Dispose();
 				}
 			}

--- a/src/Vixen.Modules/Effect/Video/Video.cs
+++ b/src/Vixen.Modules/Effect/Video/Video.cs
@@ -11,6 +11,10 @@ using VixenModules.App.Curves;
 using VixenModules.Effect.Effect;
 using VixenModules.Effect.Effect.Location;
 using VixenModules.EffectEditor.EffectDescriptorAttributes;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Vixen.Extensions;
 
 namespace VixenModules.Effect.Video
 {
@@ -24,6 +28,7 @@ namespace VixenModules.Effect.Video
 		private double _currentMovieImageNum;
 		private static readonly string VideoPath = VideoDescriptor.ModulePath;
 		private static readonly string TempPath = Path.Combine(Path.GetTempPath(), "Vixen", "VideoEffect");
+		private static readonly ConcurrentDictionary<string, SemaphoreSlim> _VideoCacheKeyedSemaphore = new();
 		private bool _processVideo;
 		private double _position;
 		private int _xOffsetAdj;
@@ -41,6 +46,8 @@ namespace VixenModules.Effect.Video
 		private int _renderWidth;
 		private bool _getNewVideoInfo;
 		private string _tempFilePath = String.Empty;
+		private string _videoPathAndFilename = String.Empty;
+		private string _settingsHash = String.Empty;
 
 		public Video()
 		{
@@ -321,9 +328,8 @@ namespace VixenModules.Effect.Video
 		[ProviderCategory(@"Advanced Settings", 3)]
 		[ProviderDisplayName(@"Video Length (sec)")]
 		[ProviderDescription(@"Video Length")]
-		[PropertyEditor("Label")]
 		[PropertyOrder(1)]
-		public int VideoLength
+		public double VideoLength
 		{
 			get { return _data.VideoLength; }
 			private set
@@ -402,6 +408,23 @@ namespace VixenModules.Effect.Video
 			set
 			{
 				_data.IncreaseBrightnessCurve = value;
+				IsDirty = true;
+				_processVideo = false;
+				OnPropertyChanged();
+			}
+		}
+
+		[ReadOnly(true)]
+		[ProviderCategory(@"Advanced Settings", 3)]
+		[ProviderDisplayName(@"Cache Size")]
+		[ProviderDescription(@"Size of cache folder on disk")]
+		[PropertyOrder(8)]
+		public string CacheSize
+		{
+			get { return _data.CacheSize; }
+			private set
+			{
+				_data.CacheSize = value;
 				IsDirty = true;
 				_processVideo = false;
 				OnPropertyChanged();
@@ -537,7 +560,11 @@ namespace VixenModules.Effect.Video
 		{
 			UpdateQualityAttribute();
 			if ( _data.FileName == "") return;
-			
+			_videoPathAndFilename = Path.Combine(VideoPath, _data.FileName);
+
+			CalculateSettingsHash();
+			PopulateTempPath();
+
 			if (_processVideo || !Directory.Exists(_tempFilePath)) ProcessMovie(); // Check if directory exist is needed for when an effect is cloned.
 			if (_videoFileDetected)
 			{
@@ -552,11 +579,25 @@ namespace VixenModules.Effect.Video
 			_processVideo = true;
 		}
 
+		private void CalculateSettingsHash()
+		{
+			StringBuilder settingsToHash = new(_videoPathAndFilename, 200);
+			settingsToHash.Append(StartTimeSeconds);
+			settingsToHash.Append(TimeSpan.TotalSeconds);
+			settingsToHash.Append(PlayBackSpeed);
+			settingsToHash.Append(_renderWidth);
+			settingsToHash.Append(_renderHeight);
+			settingsToHash.Append(MaintainAspect);
+			settingsToHash.Append(RotateVideo);
+			settingsToHash.Append(FrameTime);
+			settingsToHash.Append(StretchToGrid);
+			settingsToHash.Append(ScaleToGrid);
+			settingsToHash.Append(Vixen.Sys.VixenSystem.VideoEffect_CacheFileType);
+			_settingsHash = Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(settingsToHash.ToString())));
+		}
+
 		private void ProcessMovie()
 		{
-			EstablishTempFolder();
-			
-			string videoFilename = Path.Combine(VideoPath, _data.FileName);
 			try
 			{
 				if (VideoQuality == 0 || _getNewVideoInfo) GetVideoInformation();
@@ -615,32 +656,87 @@ namespace VixenModules.Effect.Video
 				if (VideoLength > StartTimeSeconds + (TimeSpan.TotalSeconds * ((double)PlayBackSpeed / 100 + 1)))
 				{
 					_currentMovieImageNum = 0;
+					string cacheFileExt = Vixen.Sys.VixenSystem.VideoEffect_CacheFileType;
+
 					// Height and Width needs to be evenly divisible to work or ffmpeg complains.
 					if (_renderHeight % 2 != 0) _renderHeight++;
 					if (_renderWidth % 2 != 0) _renderWidth++;
-					Ffmpeg.MakeScaledThumbNails(videoFilename, _tempFilePath, StartTimeSeconds, ((TimeSpan.TotalSeconds * ((double)PlayBackSpeed / 100 + 1))),
-						_renderWidth, _renderHeight, MaintainAspect, RotateVideo, cropVideo, 1000.0 / FrameTime);
-					_moviePicturesFileList = Directory.GetFiles(_tempFilePath).OrderBy(f => f).ToList();
 
+					// At this point, everything is determined for the settings
+					// Calculate the hash value of the combined settings and update the cache path
+					CalculateSettingsHash();
+					PopulateTempPath();
+
+					// If multiple Video Effects are selected and being changed at once, we want to ensure only one of them builds the cache folder while the others wait
+					SemaphoreSlim semaphore = _VideoCacheKeyedSemaphore.GetOrAdd(_tempFilePath, _ => new SemaphoreSlim(1, 1));
+					semaphore.Wait();
+					try
+					{
+						// If the hash folder doesn't exist, build it
+						if (!Directory.Exists(_tempFilePath))
+						{
+							Directory.CreateDirectory(_tempFilePath);
+							Ffmpeg.MakeScaledThumbNails(_videoPathAndFilename, _tempFilePath,
+								StartTimeSeconds, ((TimeSpan.TotalSeconds * ((double)PlayBackSpeed / 100 + 1))),
+								_renderWidth, _renderHeight,
+								MaintainAspect, RotateVideo,
+								cropVideo, 1000.0 / FrameTime, cacheFileExt);
+						}
+					}
+					finally
+					{
+						semaphore.Release();
+						if (semaphore.CurrentCount <= 1)
+						{
+							_VideoCacheKeyedSemaphore.TryRemove(_tempFilePath, out _);
+						}
+					}
+					int filesFound = 0;
+					foreach (string f in Directory.EnumerateFiles(TempPath, $"{InstanceId}.*", SearchOption.TopDirectoryOnly))
+					{
+						if (filesFound == 0)
+						{
+							// Update the first existing file to the new pairing, quicker than delete/create
+							File.Move(f, Path.Combine(TempPath, $"{InstanceId}.{_settingsHash}"), true);
+						}
+						else
+						{
+							// Remove any other instances since there can be only one
+							File.Delete(f);
+						}
+						filesFound++;
+					}
+					if (filesFound == 0)
+					{
+						File.Create(Path.Combine(TempPath, $"{InstanceId}.{_settingsHash}")).Close();
+					}
+					
+					_moviePicturesFileList = [.. Directory.GetFiles(_tempFilePath, $"*.{cacheFileExt}", SearchOption.TopDirectoryOnly).OrderBy(f => f)];
+					CacheSize = $"{_moviePicturesFileList.Select(file => new FileInfo(file).Length).Sum() / 1048576.0,0:0.00} MB";
 					_videoFileDetected = true;
 				}
 				else
 				{
-					var messageBox = new MessageBoxForm("Entered Start Time plus Effect length is greater than the Video Length of " + _data.FileName,
-						"Invalid Start Time. Decrease the Start Time", MessageBoxButtons.OK, SystemIcons.Error);
-					messageBox.StartPosition = FormStartPosition.CenterScreen;
-					messageBox.TopMost = true;
+					// TODO: If too long, render as much as possible? Warning about length, option to resize, option to render as much as possible, option to render last frame over and over
+					var messageBox = new MessageBoxForm($"Entered Start Time plus Effect Length exceeds the Video Length of {VideoLength} seconds for {_data.FileName}",
+						"Video Length Exceeded", MessageBoxButtons.OK, SystemIcons.Error)
+					{
+						StartPosition = FormStartPosition.CenterScreen,
+						TopMost = true
+					};
 					messageBox.ShowDialog();
 					_videoFileDetected = false;
 				}
 			}
 			catch (Exception ex)
 			{
-				Logging.Error(ex, $"There was a problem converting {videoFilename}");
-				var messageBox = new MessageBoxForm("There was a problem converting " + videoFilename + ": " + ex.Message,
-					"Error Converting Video", MessageBoxButtons.OK, SystemIcons.Error);
-				messageBox.StartPosition = FormStartPosition.CenterScreen;
-				messageBox.TopMost = true;
+				Logging.Error(ex, $"There was a problem converting {_videoPathAndFilename}");
+				var messageBox = new MessageBoxForm($"There was a problem converting {_videoPathAndFilename}: {ex.Message}",
+					"Error Converting Video", MessageBoxButtons.OK, SystemIcons.Error)
+				{
+					StartPosition = FormStartPosition.CenterScreen,
+					TopMost = true
+				};
 				messageBox.ShowDialog();
 				_videoFileDetected = false;
 			}
@@ -648,31 +744,7 @@ namespace VixenModules.Effect.Video
 
 		private void PopulateTempPath()
 		{
-			_tempFilePath = TempPath + Path.PathSeparator + InstanceId;
-		}
-
-		private void EstablishTempFolder()
-		{
-			//Delete old path and create new path for processed video
-			RemoveTempFiles();
-
-			_tempFilePath = Path.Combine(TempPath, InstanceId.ToString());
-			Directory.CreateDirectory(_tempFilePath);
-		}
-
-		private void RemoveTempFiles()
-		{
-			if (Directory.Exists(_tempFilePath))
-			{
-				try
-				{
-					Directory.Delete(_tempFilePath, true);
-				}
-				catch (Exception e)
-				{
-					Logging.Error(e, "Unable to delete all the video temp files.");
-				}
-			}
+			_tempFilePath = Path.Combine(TempPath, _settingsHash);
 		}
 
 		#region Render Video Effect
@@ -1060,41 +1132,24 @@ namespace VixenModules.Effect.Video
 			// This is only done each time a Video file is changed.
 			// No point doing this every time it needs to render.
 			// So once a user adds a video file to the effect this code will no longer be used.
-			string videoFilename = Path.Combine(VideoPath, _data.FileName);
 			try
 			{
+				Ffmpeg.GetVideoDurationAndResolution(_videoPathAndFilename, out TimeSpan videoTimeSpan, out int width, out int height);
+
 				VideoQuality = 50; // Set quality to 50% when a new file is opened.
-				// Delete old path and create new path for processed video
-				EstablishTempFolder();
-				// Gets Video length and Frame rate will continue if users start position is less then the video length.
-				string result = Ffmpeg.GetVideoInfo(videoFilename, _tempFilePath);
-				// Get Video Length
-				int durationIndex = result.IndexOf("Duration: ", StringComparison.InvariantCulture);
-				string videoInfo = result.Substring(durationIndex + 10, 8);
-				string[] words = videoInfo.Split(':');
-				TimeSpan videoTimeSpan = new TimeSpan(Int32.Parse(words[0]), Int32.Parse(words[1]), Int32.Parse(words[2]));
-				VideoLength = (int) videoTimeSpan.TotalSeconds;
+				VideoLength = videoTimeSpan.TotalSeconds;
 
-				// Saves one frame from video then grabs it to determine Video size.
-				// This was to replace the way Accord did it as it makes sense to do the Video size
-				// conversion when generating all the images. This can reduces each bitmap file size significantly.
-				Ffmpeg.GetVideoSize(videoFilename, _tempFilePath + "\\Temp.bmp");
-				var image = Image.FromFile(_tempFilePath + "\\Temp.bmp");
-				
 				// Saves the Video info to data store.
-				_data.VideoSize = new Size(image.Width, image.Height);
-
-				image.Dispose();
+				_data.VideoSize = new Size(width, height);
 				_getNewVideoInfo = false;
 			}
 			catch (Exception ex)
 			{
-				var messageBox = new MessageBoxForm("There was a problem converting " + videoFilename + ": " + ex.Message,
-					"Error Converting Video", MessageBoxButtons.OK, SystemIcons.Error);
+				var messageBox = new MessageBoxForm($"There was a problem getting video information for {_videoPathAndFilename}: {ex.Message}",
+					"Error Getting Video Information", MessageBoxButtons.OK, SystemIcons.Error);
 				messageBox.ShowDialog();
 				_videoFileDetected = false;
 			}
-
 		}
 
 		private int CalculateXOffset(double intervalPos)
@@ -1112,11 +1167,52 @@ namespace VixenModules.Effect.Video
 			return ScaleCurveToValue(IncreaseBrightnessCurve.GetValue(intervalPos), 100, 10);
 		}
 
+		public override void Removing()
+		{
+			// If the effect was deleted, remove the pairing file(s), Dispose will handle the rest
+			foreach (string f in Directory.EnumerateFiles(TempPath, $"{InstanceId}.*", SearchOption.TopDirectoryOnly))
+			{
+				File.Delete(f);
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing)
+			if (Vixen.Sys.VixenSystem.ClearEffectCacheOnExit)
 			{
-				RemoveTempFiles();
+				Removing();
+				try
+				{
+					Directory.Delete(_tempFilePath, true);
+				}
+				catch (Exception e)
+				{
+					Logging.Error(e, $"Unable to delete {_tempFilePath} on exit");
+				}
+			}
+
+			// Check the Video Effect cache for unneeded folders
+			List<string> dirsToDelete = [.. Directory.EnumerateDirectories(TempPath, "*", SearchOption.TopDirectoryOnly)];
+
+			foreach (string f in Directory.EnumerateFiles(TempPath, "*", SearchOption.TopDirectoryOnly))
+			{
+				string dirName = Path.Combine(TempPath, Path.GetExtension(f)[1..]);
+				if (Directory.Exists(dirName))
+				{
+					dirsToDelete.Remove(dirName);
+				}
+			}
+
+			foreach (string d in dirsToDelete)
+			{
+				try
+				{
+					Directory.Delete(d, true);
+				}
+				catch (Exception e)
+				{
+					Logging.Error(e, $"Unable to delete {d}");
+				}
 			}
 
 			base.Dispose(disposing);

--- a/src/Vixen.Modules/Effect/Video/VideoData.cs
+++ b/src/Vixen.Modules/Effect/Video/VideoData.cs
@@ -18,6 +18,7 @@ namespace VixenModules.Effect.Video
 			MaintainAspect = false;
 			AdvancedSettings = false;
 			Speed = 1;
+			CacheSize = "0.00 MB";
 			IncreaseBrightnessCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 0.0, 0.0 }));
 			PlayBackSpeed = 0;
 			StartTime = 0;
@@ -38,6 +39,9 @@ namespace VixenModules.Effect.Video
 
 		[DataMember(EmitDefaultValue = false)]
 		public int IncreaseBrightness { get; set; }
+
+		[DataMember]
+		public string CacheSize { get; set; }
 
 		[DataMember]
 		public Curve IncreaseBrightnessCurve { get; set; }
@@ -97,7 +101,7 @@ namespace VixenModules.Effect.Video
 		public Curve LevelCurve { get; set; }
 
 		[DataMember]
-		public int VideoLength { get; set; }
+		public double VideoLength { get; set; }
 
 		[DataMember] 
 		public int MovementRate { get; set; }
@@ -145,6 +149,7 @@ namespace VixenModules.Effect.Video
 				YOffsetCurve = new Curve(YOffsetCurve),
 				XOffsetCurve = new Curve(XOffsetCurve),
 				Speed = Speed,
+				CacheSize = CacheSize,
 				IncreaseBrightnessCurve = new Curve(IncreaseBrightnessCurve),
 				VideoLength = VideoLength,
 				RotateVideo =RotateVideo,


### PR DESCRIPTION
VIX-3625 Video Effect Cache Improvements
- Changed the cache folder model from InstanceID based to Settings Hash base with an associating file - In VideoEffect temp folder, (InstanceID).(Settings Hash)
- This allows the same settings to build or use the same cache folder, so multiple effects can use the same cache folder too
- Used MD5 to create the hash so it is consistent between executions of the application
- Added new GetVideoDurationAndResolution function that doesn't use the cache folder and gets both in a single run of ffmpeg
- Refactored Video.cs:GetVideoInformation to use GetVideoDurationAndResolution
- Added a Removing method to allow TimedSequenceEditorForm to let an Effect know when it has been deleted
- Updated Dispose method to clean up cache folder
- Used path functions in Video.cs
- Tweaked error message about Video Length
- Changed VideoLength from int to double
- Marked the unused ffmpeg public functions as Obsolete
- Keyed Semaphore for cache folder use to prevent race condition
- Added a cache folder size under the advanced section
- Adding Video Effect Cache options to UI as global options, file type and clear on exit