### PR TITLE
VIX-3628 Fix Behavior targeting bug on the Chase and Spin Effect

### DIFF
--- a/src/Vixen.Modules/Effect/Chase/Chase.cs
+++ b/src/Vixen.Modules/Effect/Chase/Chase.cs
@@ -378,6 +378,10 @@ namespace VixenModules.Effect.Chase
 		{
 			var depth = DetermineDepth();
 			Dictionary<string, bool> propertyStates = new Dictionary<string, bool>(2);
+			if (depth < 3 && TargetNodeHandling == TargetNodeSelection.Individual)
+			{
+				TargetNodeHandling = TargetNodeSelection.Group;
+			}
 			propertyStates.Add(nameof(TargetNodeHandling), TargetNodes.Length > 1 || depth > 2);
 			propertyStates.Add(nameof(DepthOfEffect), depth > 2);
 			SetBrowsable(propertyStates);

--- a/src/Vixen.Modules/Effect/Spin/Spin.cs
+++ b/src/Vixen.Modules/Effect/Spin/Spin.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using NLog;
 using Vixen.Attributes;
 using Vixen.Module;
@@ -457,6 +458,11 @@ namespace VixenModules.Effect.Spin
 		private void UpdateTargetingAttributes()
 		{
 			var depth = DetermineDepth();
+			Debug.WriteLine($"Depth = {depth}, Selection = {TargetNodeHandling}, Length = {TargetNodes.Length}");
+			if(depth < 3 && TargetNodeHandling == TargetNodeSelection.Individual)
+			{
+				TargetNodeHandling = TargetNodeSelection.Group;
+			}
 			Dictionary<string, bool> propertyStates = new Dictionary<string, bool>(2);
 			propertyStates.Add(nameof(TargetNodeHandling), TargetNodes.Length > 1 || depth > 2);
 			propertyStates.Add(nameof(DepthOfEffect), depth > 2);


### PR DESCRIPTION
* Add logic in the UpdateTargetingAttributes methods to detect if the depth is to shallow for the Individual targeting and correct the selection to Group.