### PR TITLE
VIX-3631 Fix duplicate node rendering in Wipe and Alternate

### DIFF
--- a/src/Vixen.Modules/Effect/Alternating/Alternating.cs
+++ b/src/Vixen.Modules/Effect/Alternating/Alternating.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using NLog;
+using System.ComponentModel;
 using Vixen.Attributes;
 using Vixen.Marks;
 using Vixen.Module;
@@ -52,20 +53,20 @@ namespace VixenModules.Effect.Alternating
 
 			if (!EnableDepth)
 			{
-				renderNodes = TargetNodes.SelectMany(x => x.GetLeafEnumerator());
+				renderNodes = TargetNodes.SelectMany(x => x.GetLeafEnumerator().Distinct());
 			}
 			else
 			{
 				for (int i = 0; i < DepthOfEffect; i++)
 				{
-					renderNodes = renderNodes.SelectMany(x => x.Children);
+					renderNodes = renderNodes.SelectMany(x => x.Children).Distinct();
 				}
 			}
 			
 			// If the given DepthOfEffect results in no nodes (because it goes "too deep" and misses all nodes), 
 			// then we'll default to the LeafElements, which will at least return 1 element (the TargetNode)
 			if (!renderNodes.Any())
-				renderNodes = TargetNodes.SelectMany(x => x.GetLeafEnumerator());
+				renderNodes = TargetNodes.SelectMany(x => x.GetLeafEnumerator().Distinct());
 
 			return renderNodes;
 		}

--- a/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
+++ b/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using NLog;
+using System.ComponentModel;
 using Vixen.Attributes;
 using Vixen.Module;
 using Vixen.Sys;
@@ -57,6 +58,7 @@ namespace VixenModules.Effect.Wipe
 					return new Tuple<IElementNode, int, int, int>(null, -1, -1, -1);
 				})
 				.Where(s => s.Item2 > 0)
+				.Distinct()
 				.ToList();
 
 			if (!renderedNodes.Any()) return;


### PR DESCRIPTION
* Add logic to remove duplicate leaf elements in case the effect is placed on a very deep level prop with multiple redefinition groups.