### PR TITLE
VIX-3636 Fix preview crash due to invalid element links

### DIFF
--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
@@ -24,6 +24,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		private bool _isHighPrecision;
 
 		private List<PreviewPixel> _pixelCache = new List<PreviewPixel>();
+		private static NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();
 
 		public enum StringTypes
 		{
@@ -382,9 +383,20 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		        				
 		public int UpdatePixelCache()
 		{
-			_pixelCache = Pixels.Where(x => x.Node != null).ToList();
+			_pixelCache = Pixels.Where(x => x.Node != null && x.Node.Element != null).ToList();
 			_points = new List<float>(_pixelCache.Count * 8);
 			return _pixelCache.Count;
+		}
+
+		public bool HasInValidElementMapping()
+		{
+			var badLinks = Pixels.FirstOrDefault(x => x.Node != null && x.Node.Element == null);
+			if (badLinks != null)
+			{
+				Logging.Error($"Preview shape mapped to Node {badLinks.Node.Name} without Element");
+			}
+
+			return badLinks != null;
 		}
 
 		public void UpdateDrawPoints(int referenceHeight)

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreviewControl.cs
@@ -576,6 +576,15 @@ namespace VixenModules.Preview.VixenPreview
 			return false;
 		}
 
+		public void SelectItems(IEnumerable<DisplayItem> displayItems)
+		{
+			// First, deselect any currently selected item
+			DeSelectSelectedDisplayItem();
+			SelectedDisplayItems.AddRange(displayItems);
+			OnSelectionChanged?.Invoke(this, EventArgs.Empty);
+			EndUpdate();
+		}
+
 		public void SelectItemUnderPoint(PreviewPoint point, bool addToSelection)
 		{
 			if (!_mouseCaptured)


### PR DESCRIPTION
* Add logic to the node filter to also test for null elements. This will prevent the preview update from seeing invalid links as well as unmapped nodes.
* Add logic and a warning dialog to alert the user of invalid links. Give them the option to cancel and go fix them.
* Highlight the display items that have invalid links when the user is alerted to help them find them quickly.