### PR TITLE
VIX-3640 Fix issue with Color not saving on the Fixture Effect

### DIFF
--- a/src/Vixen.Modules/Effect/Fixture/FixtureEffect/Data/FixtureFunctionData.cs
+++ b/src/Vixen.Modules/Effect/Fixture/FixtureEffect/Data/FixtureFunctionData.cs
@@ -22,7 +22,7 @@ namespace VixenModules.Effect.Fixture
 			FunctionIdentity = FunctionIdentity.Custom;
 			FunctionName = String.Empty;
 			Range = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 0.0, 0.0 }));
-			TimelineColor = Color.White;	
+			TimelineColor = System.Drawing.Color.White;	
 		}
 
 		#endregion
@@ -94,6 +94,23 @@ namespace VixenModules.Effect.Fixture
 		/// </summary>
 		[DataMember]
 		public Color TimelineColor { get; set; }
+
+		/// <summary>
+		/// Color associated with the function.
+		/// </summary>
+		[DataMember]
+		public App.ColorGradients.ColorGradient Color { get; set; }
+
+		#endregion
+
+		#region Deserialization
+
+		[OnDeserialized]
+		public void OnDeserialized(StreamingContext c)
+		{
+			//Ensure Color is populated
+			Color ??= new App.ColorGradients.ColorGradient();
+		}
 
 		#endregion
 	}

--- a/src/Vixen.Modules/Effect/Fixture/FixtureEffect/FixtureModule.cs
+++ b/src/Vixen.Modules/Effect/Fixture/FixtureEffect/FixtureModule.cs
@@ -350,6 +350,7 @@ namespace VixenModules.Effect.Fixture
 				fixtureFunctionExpando.IndexValue = fixtureFunctionData.IndexValue;
 				fixtureFunctionExpando.ColorIndexValue = fixtureFunctionData.ColorIndexValue;
 				fixtureFunctionExpando.TimelineColor = fixtureFunctionData.TimelineColor;
+				fixtureFunctionExpando.Color = fixtureFunctionData.Color;
 
 				// Add the fixture function to the collection
 				functionItemCollection.Add(fixtureFunctionExpando);
@@ -385,6 +386,7 @@ namespace VixenModules.Effect.Fixture
 				{
 					// Save off the intensity as the range
 					functionModel.Range = new Curve(functionViewModel.Intensity);
+					functionModel.Color = functionViewModel.Color;
 				}
 				else
 				{


### PR DESCRIPTION
* Add missing Color property to the data class.
* Add logic to update and retrive the value from the data object.
* Add OnDeserialized logic to ensure the Color property is populated on existing sequences.