### PR TITLE
VIX-3661 Prevent VAO from showing up in shape property settings

### DIFF
--- a/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
+++ b/src/Vixen.Modules/Preview/VixenPreview/Shapes/PreviewLightBaseShape.cs
@@ -60,6 +60,7 @@ namespace VixenModules.Preview.VixenPreview.Shapes
 		/// <summary>
 		/// Vertex Array Object for OpenGL drawing of the light shape.
 		/// </summary>
+		[Browsable(false)]
 		[IgnoreDataMember]
 		public int VAO { get; set; }
 


### PR DESCRIPTION
VIX-3661 Prevent VAO from showing up in shape property settings