### PR TITLE
Bump MessagePack library to latest 2.5.x to clear vulnerability

### DIFF
--- a/src/Vixen.Application/Vixen.Application.csproj
+++ b/src/Vixen.Application/Vixen.Application.csproj
@@ -28,6 +28,7 @@
 
 		<ItemGroup>
 				<PackageReference Include="Catel.Core" Version="6.0.3" />
+				<PackageReference Include="MessagePack" Version="2.5.192" />
 				<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 				<PackageReference Include="NLog" Version="5.3.2" />
 				<PackageReference Include="Orchestra.Core" Version="7.0.1" />

--- a/src/Vixen.Common/WpfPropertyGrid.Themes/WpfPropertyGrid.Themes.csproj
+++ b/src/Vixen.Common/WpfPropertyGrid.Themes/WpfPropertyGrid.Themes.csproj
@@ -10,6 +10,9 @@
 				<AppDesigner Include="Properties\" />
 		</ItemGroup>
 		<ItemGroup>
+		  <PackageReference Include="MessagePack" Version="2.5.192" />
+		</ItemGroup>
+		<ItemGroup>
 				<ProjectReference Include="..\WpfPropertyGrid\WpfPropertyGrid.csproj" />
 		</ItemGroup>
 </Project>

--- a/src/Vixen.Common/WpfPropertyGrid/WpfPropertyGrid.csproj
+++ b/src/Vixen.Common/WpfPropertyGrid/WpfPropertyGrid.csproj
@@ -20,7 +20,7 @@
 				<Page Remove="ValueEditors\EditorResources.xaml" />
 		</ItemGroup>
 		<ItemGroup>
-		  <PackageReference Include="MessagePack" Version="2.5.171" />
+		  <PackageReference Include="MessagePack" Version="2.5.192" />
 		</ItemGroup>
 		<ItemGroup>
 		  <ProjectReference Include="..\WPFCommon\WPFCommon.csproj" />

--- a/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
+++ b/src/Vixen.Modules/App/CustomPropEditor/CustomPropEditor.csproj
@@ -34,6 +34,7 @@
 				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
 				<PackageReference Include="LiteDB" Version="4.1.4" />
+				<PackageReference Include="MessagePack" Version="2.5.192" />
 				<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
 				<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 				<PackageReference Include="NLog" Version="5.3.2" />

--- a/src/Vixen.Modules/App/TimingTrackBrowser/TimingTrackBrowser.csproj
+++ b/src/Vixen.Modules/App/TimingTrackBrowser/TimingTrackBrowser.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Catel.MVVM" Version="6.0.3" />
+    <PackageReference Include="MessagePack" Version="2.5.192" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.2" />
   </ItemGroup>

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditor.csproj
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditor.csproj
@@ -16,6 +16,7 @@
 		  <PackageReference Include="DockPanelSuite" Version="3.1.0" />
 		  <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.0" />
 		  <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
+		  <PackageReference Include="MessagePack" Version="2.5.192" />
 		  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		  <PackageReference Include="NLog" Version="5.3.2" />
 		</ItemGroup>

--- a/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
+++ b/src/Vixen.Modules/Preview/VixenPreview/VixenPreview.csproj
@@ -10,6 +10,7 @@
 				<PackageReference Include="Catel.MVVM" Version="6.0.3" />
 				<PackageReference Include="DockPanelSuite" Version="3.1.0" />
 				<PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.0" />
+				<PackageReference Include="MessagePack" Version="2.5.192" />
 				<PackageReference Include="NLog" Version="5.3.2" />
 				<PackageReference Include="OpenTK" Version="4.8.2" />
 		</ItemGroup>


### PR DESCRIPTION
* This will clear the vulnerability and stop the Dependabot from reporting.