### PR TITLE
VIX-3664 Fix modified time logic to specify UTC

### DIFF
--- a/src/Vixen.Common/WPFCommon/Services/DownloadService.cs
+++ b/src/Vixen.Common/WPFCommon/Services/DownloadService.cs
@@ -24,7 +24,7 @@ namespace Common.WPFCommon.Services
 				throw new ArgumentNullException(nameof(targetPath));
 			}
 
-			var modifiedTime = DateTime.MinValue;
+			var modifiedTime = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
 			if (isNewer && File.Exists(targetPath))
 			{
 				modifiedTime = File.GetLastWriteTime(targetPath).ToUniversalTime();


### PR DESCRIPTION
* The logic that initializes modified time for comparison should specify it is a UTC time in order to accomodate timezones > UTC
* Logic change based on info found on stackoverflow.