### PR TITLE
VIX-3124 Added "End Stop" option to Text Effect 

### DIFF
--- a/src/Vixen.Modules/Effect/Text/Text.cs
+++ b/src/Vixen.Modules/Effect/Text/Text.cs
@@ -341,7 +341,25 @@ namespace VixenModules.Effect.Text
 			get { return _data.CenterStop; }
 			set
 			{
-				_data.CenterStop = value;
+				if (_data.CenterStop = value == true)
+					EndStop = false;
+				IsDirty = true;
+				OnPropertyChanged();
+			}
+		}
+
+		[Value]
+		[ProviderCategory(@"Movement", 2)]
+		[ProviderDisplayName(@"EndStop")]
+		[ProviderDescription(@"EndStop")]
+		[PropertyOrder(5)]
+		public bool EndStop
+		{
+			get { return _data.EndStop; }
+			set
+			{
+				if (_data.EndStop = value == true)
+					CenterStop = false;
 				IsDirty = true;
 				OnPropertyChanged();
 			}
@@ -683,6 +701,8 @@ namespace VixenModules.Effect.Text
 
 				{"CenterStop", Direction < TextDirection.Rotate},
 
+				{"EndStop", Direction < TextDirection.Rotate},
+
 				{"ExplodePositionCurve", Direction == TextDirection.Explode},
 
 				{"FallSpeedCurve", Direction == TextDirection.Fall},
@@ -888,34 +908,42 @@ namespace VixenModules.Effect.Text
 				switch (Direction)
 				{
 					case TextDirection.Left:
-						// left
 						int leftX = bufferWi - (int) (_directionPosition * (textsize.Width + bufferWi));
-						point =
-							new Point(Convert.ToInt32(CenterStop ? Math.Max(leftX, (bufferWi - (int) textsize.Width) / 2) : leftX),
-								offsetTop);
+						if (CenterStop == true)
+							leftX = Math.Max(leftX, (bufferWi - (int)textsize.Width) / 2);
+						else if (EndStop == true)
+							leftX = Math.Max(leftX, bufferWi - (int)textsize.Width);
+						point = new Point(leftX, offsetTop);
 						break;
+
 					case TextDirection.Right:
-						// right
 						int rightX = -_maxTextSize + (int) (_directionPosition * (_maxTextSize + bufferWi));
-						point =
-							new Point(Convert.ToInt32(CenterStop ? Math.Min(rightX, (bufferWi - (int) textsize.Width) / 2) : rightX),
-								offsetTop);
+						if (CenterStop == true)
+							rightX = Math.Min(rightX, (bufferWi - (int)textsize.Width) / 2);
+						else if (EndStop == true)
+							rightX = Math.Min(rightX, 0);
+						point = new Point(rightX, offsetTop);
 						break;
+
 					case TextDirection.Up:
-						// up
 						int upY = bufferHt - (int) (((textsize.Height * numberLines) + bufferHt) * _directionPosition);
-						point = new Point(offsetLeft,
-							Convert.ToInt32(CenterStop ? Math.Max(upY, (bufferHt - (int) (textsize.Height * numberLines)) / 2) : upY));
+						if (CenterStop == true)
+							upY = Math.Max(upY, (bufferHt - (int)(textsize.Height * numberLines)) / 2);
+						else if (EndStop == true)
+							upY = Math.Max(upY, bufferHt - (int)textsize.Height);
+						point = new Point(offsetLeft, upY);
 						break;
+
 					case TextDirection.Down:
-						// down
 						int downY = -(int) (textsize.Height * numberLines) +
 						            (int) (((textsize.Height * numberLines) + bufferHt) * _directionPosition);
-						point = new Point(offsetLeft,
-							Convert.ToInt32(CenterStop
-								? Math.Min(downY, (bufferHt - (int) (textsize.Height * numberLines)) / 2)
-								: downY));
+						if (CenterStop == true)
+							downY = Math.Min(downY, (bufferHt - (int)(textsize.Height * numberLines)) / 2);
+						else if (EndStop == true)
+							downY = Math.Min(downY, 0);
+						point = new Point(offsetLeft, downY);
 						break;
+
 					default:
 						// no movement - centered
 						point = new Point((bufferWi - _maxTextSize) / 2 + xOffset, offsetTop);

--- a/src/Vixen.Modules/Effect/Text/TextData.cs
+++ b/src/Vixen.Modules/Effect/Text/TextData.cs
@@ -25,6 +25,7 @@ namespace VixenModules.Effect.Text
 			FontScaleCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 100.0, 100.0 }));
 			ScaleText = 0;
 			CenterStop = false;
+			EndStop = false;
 			Text = new List<string>{String.Empty};
 			GradientMode = GradientMode.AcrossElement;
 			Orientation=StringOrientation.Vertical;
@@ -69,6 +70,9 @@ namespace VixenModules.Effect.Text
 
 		[DataMember]
 		public bool CenterStop { get; set; }
+
+		[DataMember]
+		public bool EndStop { get; set; }
 
 		[DataMember]
 		public bool CenterText { get; set; }
@@ -213,6 +217,7 @@ namespace VixenModules.Effect.Text
 				Direction = Direction,
 				Speed = Speed,
 				CenterStop = CenterStop,
+				EndStop = EndStop,
 				Orientation = Orientation,
 				YOffSetCurve = new Curve(YOffSetCurve),
 				XOffsetCurve = new Curve(XOffsetCurve),

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -141,7 +141,10 @@
   <data name="CenterStop" xml:space="preserve">
     <value>Moves the text into view and stops it in the center.</value>
   </data>
-  <data name="CenterText" xml:space="preserve">
+	<data name="EndStop" xml:space="preserve">
+    <value>Moves the text into view and stops it at the end.</value>
+  </data>
+	<data name="CenterText" xml:space="preserve">
     <value>Center each line of text instead of left justified.</value>
   </data>
   <data name="ChangePercent" xml:space="preserve">

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
@@ -141,7 +141,10 @@
   <data name="CenterStop" xml:space="preserve">
     <value>Center Stop</value>
   </data>
-  <data name="CenterText" xml:space="preserve">
+	<data name="EndStop" xml:space="preserve">
+    <value>End Stop</value>
+  </data>
+	<data name="CenterText" xml:space="preserve">
     <value>Center Text</value>
   </data>
   <data name="Interval" xml:space="preserve">


### PR DESCRIPTION
Stops scrolling when the text reaches the end. This option is exclusive of the existing option, "Center Stop".