### PR TITLE
Patch to fix missing PackageReferences in the Deploy - Installer projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,5 @@
     <PackageVersion Include="WixToolset.Bal.wixext" Version="5.0.0" />
     <PackageVersion Include="WixToolset.Netfx.wixext" Version="5.0.0" />
     <PackageVersion Include="WixToolset.Util.wixext" Version="5.0.0" />
-    <ProjectVersion Include="..\Vixen.Installer\Vixen.Installer.wixproj" />
   </ItemGroup>
 </Project>

--- a/src/Vixen.DeployBundle/Vixen.DeployBundle.wixproj
+++ b/src/Vixen.DeployBundle/Vixen.DeployBundle.wixproj
@@ -24,6 +24,14 @@
     <OutputName>Vixen-$(App_Version)-Setup-32bit</OutputName>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="WixToolset.Bal.wixext" />
+    <PackageReference Include="WixToolset.Netfx.wixext" />
+    <PackageReference Include="WixToolset.Util.wixext" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Vixen.Installer\Vixen.Installer.wixproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="VixenTheme.xml" />
   </ItemGroup>
 </Project>

--- a/src/Vixen.Installer/Vixen.Installer.wixproj
+++ b/src/Vixen.Installer/Vixen.Installer.wixproj
@@ -41,4 +41,7 @@
   <ItemGroup>
     <Content Include="EnvironmentInclude.wxi" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Patches an issue with the installer and deploy projects that were missing the PackageReferences.