### PR TITLE
VIX-3712 Refactor to update documentation and variable names in the Prop classes

### DIFF
--- a/src/Vixen.Core/Sys/Props/BaseProp.cs
+++ b/src/Vixen.Core/Sys/Props/BaseProp.cs
@@ -9,6 +9,14 @@ using Vixen.Sys.Props.Components;
 
 namespace Vixen.Sys.Props
 {
+	/// <summary>
+	/// Represents the base class for all Prop types in the Vixen system.
+	/// </summary>
+	/// <remarks>
+	/// This abstract class provides common functionality and properties for all Props,
+	/// including unique identification, creation and modification metadata, and management
+	/// of associated components and target nodes.
+	/// </remarks>
 	[Serializable]
 	public abstract class BaseProp : BindableBase, IProp
 	{
@@ -46,6 +54,13 @@ namespace Vixen.Sys.Props
 		}
 
 		#endregion
+		/// <summary>
+		/// Gets the unique identifier for the Prop.
+		/// </summary>
+		/// <remarks>
+		/// This identifier is automatically generated upon the creation of the Prop
+		/// and is used to uniquely distinguish it within the Vixen system.
+		/// </remarks>
 		[Browsable(false)]
 		public Guid Id
 		{
@@ -53,13 +68,33 @@ namespace Vixen.Sys.Props
 			init => SetProperty(ref _id, value);
 		}
 
+		/// <summary>
+		/// Gets or sets the name of the Prop.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="Name"/> property is a friendly name for the Prop.
+		/// Changing this property triggers the renaming of associated Prop elements.
+		/// </remarks>
 		[PropertyOrder(0)]
 		public string Name
 		{
 			get => _name;
-			set => SetProperty(ref _name, value);
+			set
+			{
+				SetProperty(ref _name, value);
+				PropModified();
+			}
 		}
 
+		/// <summary>
+		/// Gets or sets the name of the user who created this Prop.
+		/// </summary>
+		/// <value>
+		/// A <see cref="string"/> representing the creator's username.
+		/// </value>
+		/// <remarks>
+		/// This property is used to track the origin of the Prop for auditing and informational purposes.
+		/// </remarks>
 		[PropertyOrder(100)]
 		[DisplayName("Created By")]
 		public string CreatedBy
@@ -68,10 +103,23 @@ namespace Vixen.Sys.Props
 			set => SetProperty(ref _createdBy, value);
 		}
 
+		/// <summary>
+		/// Gets the date and time when the Prop was created.
+		/// </summary>
+		/// <remarks>
+		/// This property is initialized during the construction of the Prop and remains immutable.
+		/// It provides metadata about the creation of the Prop for tracking and auditing purposes.
+		/// </remarks>
 		[PropertyOrder(101)]
 		[DisplayName("Creation Date")]
 		public DateTime CreationDate { get; init; }
 
+		/// <summary>
+		/// Gets or sets the date and time when the Prop was last modified.
+		/// </summary>
+		/// <value>
+		/// A <see cref="DateTime"/> representing the last modification date and time of the Prop.
+		/// </value>
 		[PropertyOrder(102)]
 		[DisplayName("Modified Date")]
 		public DateTime ModifiedDate
@@ -87,22 +135,83 @@ namespace Vixen.Sys.Props
 
 
 
+		/// <summary>
+		/// Gets or sets the unique identifier of the root <see cref="ElementNode"/> 
+		/// associated with this Prop.
+		/// </summary>
+		/// <remarks>
+		/// This property serves as a link between the Prop and its corresponding 
+		/// root <see cref="ElementNode"/> in the legacy ElementNode tree. 
+		/// If the identifier is <see cref="Guid.Empty"/>, it indicates that no 
+		/// root <see cref="ElementNode"/> is currently associated with the Prop.
+		/// </remarks>
 		[Browsable(false)]
 		public Guid RootPropElementNodeId { get; protected set; } = Guid.Empty;
 
+		/// <summary>
+		/// Gets the prefix used for automatically generated property names in the Prop system.
+		/// </summary>
+		/// <remarks>
+		/// This property provides a consistent prefix for naming automatically generated properties.
+		/// It is primarily used internally for constructing names for various Prop-related elements.
+		/// </remarks>
 		protected string AutoPropPrefix => "Auto-Prop";
 
+		/// <summary>
+		/// Gets the automatically generated name for the Prop, combining a predefined prefix with the Prop's name.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="AutoPropName"/> property is used to create a unique and descriptive name for the Props linked ElementNodes.
+		/// It is constructed by concatenating the <c>AutoPropPrefix</c> with the <see cref="Name"/> property.
+		/// This name is primarily utilized for internal identification and ElementNode creation purposes.
+		/// </remarks>
 		protected string AutoPropName => $"{AutoPropPrefix} {Name}";
 
+		/// <summary>
+		/// Gets the name of the auto-generated string associated with the Prop.
+		/// </summary>
+		/// <remarks>
+		/// This property provides a standardized name for the auto-generated string ElementNodes
+		/// linked to the Prop, using a predefined prefix followed by the word "String".
+		/// This name is primarily utilized for internal identification and ElementNode creation purposes.
+		/// </remarks>
 		protected string AutoPropStringName => $"{AutoPropPrefix} String";
 
+		/// <summary>
+		/// Gets the automatically generated name for a Prop linked leaf ElementNode.
+		/// </summary>
+		/// <remarks>
+		/// This property combines a predefined prefix with the word "Node" to create a standardized
+		/// name for prop nodes. It is primarily used for internal naming purposes when creating or
+		/// managing prop elements.
+		/// Example: In a pixel based Prop, this would represent one of the light nodes, but it is not limited to lights.
+		/// </remarks>
 		protected string AutoPropNodeName => $"{AutoPropPrefix} Node";
 
+		/// <summary>
+		/// Gets or sets the visual model associated with the Prop.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="IPropModel"/> represents the underlying data structure or configuration
+		/// for the Props visual that is used to draw it. This property can be overridden in derived classes to
+		/// provide specific implementations of the Prop model.
+		/// </remarks>
 		[Browsable(false)]
 		public virtual IPropModel PropModel { get; protected set; } = null!;
 
+		/// <summary>
+		/// Gets the target <see cref="IElementNode"/> associated with this Prop.
+		/// </summary>
+		/// <remarks>
+		/// This property retrieves the backing <see cref="IElementNode"/> for the Prop. 
+		/// If the backing node does not exist, it will be created using the 
+		/// <see cref="GetOrCreateElementNode"/> method.
+		/// </remarks>
+		/// <value>
+		/// The <see cref="IElementNode"/> representing the target node of the Prop.
+		/// </value>
 		[Browsable(false)]
-		public virtual IElementNode TargetNode => GetOrCreatePropElementNode();
+		public virtual IElementNode TargetNode => GetOrCreateElementNode();
 		
 		[Browsable(false)]
 		public ObservableCollection<IPropComponent> PropComponents { get; init; }
@@ -112,9 +221,33 @@ namespace Vixen.Sys.Props
 
 		public virtual void CleanUp()
 		{
-			RemovePropElements();
+			RemovePropElementNode();
+			PropModified();
 		}
 
+		/// <summary>
+		/// Minimally updates the <see cref="ModifiedDate"/> property to the current date and time.
+		/// </summary>
+		/// <remarks>
+		/// This method should be called internally by implementations whenever a modification occurs to ensure
+		/// the <see cref="ModifiedDate"/> reflects the latest changes.
+		/// </remarks>
+		protected void PropModified()
+		{
+			ModifiedDate = DateTime.Now;
+		}
+
+		/// <summary>
+		/// Attempts to retrieve the backing <see cref="ElementNode"/> associated with the current prop.
+		/// </summary>
+		/// <param name="elementNode">
+		/// When this method returns, contains the <see cref="ElementNode"/> associated with the current prop
+		/// in the legacy ElementNode tree,
+		/// if one exists; otherwise, <c>null</c>.
+		/// </param>
+		/// <returns>
+		/// <c>true</c> if the <see cref="ElementNode"/> was successfully retrieved; otherwise, <c>false</c>.
+		/// </returns>
 		protected bool TryGetPropElementNode([NotNullWhen(true)] out ElementNode? elementNode)
 		{
 			elementNode = null;
@@ -126,29 +259,66 @@ namespace Vixen.Sys.Props
 			return elementNode is not null;
 		}
 
-		protected ElementNode GetOrCreatePropElementNode()
+		/// <summary>
+		/// Retrieves the existing backing <see cref="ElementNode"/> associated with the Prop,
+		/// or creates a new one if it does not exist.
+		/// </summary>
+		/// <returns>
+		/// The <see cref="ElementNode"/> in the legacy ElementNode tree representing the Prop.
+		/// </returns>
+		/// <remarks>
+		/// This method ensures that the property has a backing <see cref="ElementNode"/>.
+		/// If an existing <see cref="ElementNode"/> is not found, a new one is created.
+		/// The newly created node is linked to the Prop by assigning its ID to <see cref="RootPropElementNodeId"/>.
+		/// </remarks>
+		protected ElementNode GetOrCreateElementNode()
 		{
-			ElementNode? propNode = null;
+			ElementNode? backingElementNode;
 			if (TryGetPropElementNode(out var elementNode))
 			{
-				propNode = elementNode;
+				backingElementNode = elementNode;
 			}
 			else
 			{
-				propNode = ElementNodeService.Instance.CreateSingle(VixenSystem.Nodes.PropRootNode, AutoPropName, true, false);
-				RootPropElementNodeId = propNode.Id;
+				backingElementNode = ElementNodeService.Instance.CreateSingle(VixenSystem.Nodes.PropRootNode, AutoPropName, true, false);
+				RootPropElementNodeId = backingElementNode.Id;
 			}
 
-			return propNode;
+			return backingElementNode;
 
 		}
 
+		/// <summary>
+		/// Renames the backing <see cref="ElementNode"/> associated with the Prop to reflect the current name of the Prop.
+		/// </summary>
+		/// <remarks>
+		/// This method ensures that the <see cref="ElementNode"/> representing the Prop is updated with a new name
+		/// derived from the Prop's current name and the <see cref="AutoPropPrefix"/>.
+		/// The renaming operation is performed using the <see cref="VixenSystem.Nodes"/> manager.
+		/// </remarks>
 		protected void RenamePropElement()		
 		{
-			var propNode = GetOrCreatePropElementNode();
+			var propNode = GetOrCreateElementNode();
 			VixenSystem.Nodes.RenameNode(propNode, AutoPropName, false);
 		}
 
+		/// <summary>
+		/// Adds a specified number of child nodes to the given parent node and returns the newly created nodes.
+		/// </summary>
+		/// <param name="node">The parent <see cref="ElementNode"/> to which the child nodes will be added.</param>
+		/// <param name="count">The number of child nodes to add. Must be greater than zero.</param>
+		/// <param name="namingIndex">
+		/// The starting index for naming the new nodes. The names will be generated sequentially starting from this index.
+		/// </param>
+		/// <returns>
+		/// An <see cref="IEnumerable{T}"/> of <see cref="IElementNode"/> representing the newly created child nodes.
+		/// </returns>
+		/// <remarks>
+		/// The method generates names for the new nodes using a predefined naming pattern and ensures that the nodes are 
+		/// created as children of the specified parent node. If <paramref name="count"/> is zero, an empty collection is returned.
+		/// </remarks>
+		/// <exception cref="ArgumentNullException">Thrown if the <paramref name="node"/> parameter is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="count"/> is less than zero.</exception>
 		protected IEnumerable<IElementNode> AddNodeElements(ElementNode node, int count, int namingIndex = 0)
 		{
 			if (count == 0) return [];
@@ -164,7 +334,20 @@ namespace Vixen.Sys.Props
 			return nodesAdded;
 		}
 
-		protected void RemoveElements(ElementNode node, int count)
+		/// <summary>
+		/// Removes a specified number of child elements from the given <see cref="ElementNode"/>.
+		/// </summary>
+		/// <param name="node">The <see cref="ElementNode"/> from which child elements will be removed.</param>
+		/// <param name="count">The number of child elements to remove from the end of the node's children.</param>
+		/// <remarks>
+		/// This method removes the specified number of child elements from the end of the provided node's children collection.
+		/// It ensures that the nodes are properly removed from the system using <see cref="VixenSystem.Nodes.RemoveNode"/>.
+		/// </remarks>
+		/// <exception cref="ArgumentNullException">Thrown if the <paramref name="node"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Thrown if <paramref name="count"/> is greater than the number of children in the <paramref name="node"/>.
+		/// </exception>
+		protected void RemoveElementNodes(ElementNode node, int count)
 		{
 			var nodesToRemove = node.Children.Skip(node.Children.Count() - count).ToList();
 			foreach (var nodeToRemove in nodesToRemove)
@@ -174,11 +357,16 @@ namespace Vixen.Sys.Props
 		}
 
 		/// <summary>
-		/// Removes the entire Prop element tree. 
+		/// Removes the entire linked <see cref="ElementNode"/> tree associated with this Prop.
 		/// </summary>
-		protected virtual void RemovePropElements()
+		/// <remarks>
+		/// This method removes the backing element node of the Prop from the system's node hierarchy.
+		/// It ensures that the node is detached from its parent and cleans up any associated resources.
+		/// </remarks>
+		protected virtual void RemovePropElementNode()
 		{
-			VixenSystem.Nodes.RemoveNode(GetOrCreatePropElementNode(), VixenSystem.Nodes.PropRootNode, true);
+			VixenSystem.Nodes.RemoveNode(GetOrCreateElementNode(), VixenSystem.Nodes.PropRootNode, true);
+			RootPropElementNodeId = Guid.Empty;
 		}
 
 		// Add logic to manage Element structure into the regular element tree, including supported properties

--- a/src/Vixen.Modules/App/Props/Models/Arch/Arch.cs
+++ b/src/Vixen.Modules/App/Props/Models/Arch/Arch.cs
@@ -152,7 +152,7 @@ namespace VixenModules.App.Props.Models.Arch
 			{
 				bool hasUpdated = false;
 
-				var propNode = GetOrCreatePropElementNode();
+				var propNode = GetOrCreateElementNode();
 				if (propNode.IsLeaf)
 				{
 					AddNodeElements(propNode, NodeCount);
@@ -187,7 +187,7 @@ namespace VixenModules.App.Props.Models.Arch
 
 		private void UpdateDefaultPropComponents()
 		{
-			var head = GetOrCreatePropElementNode();
+			var head = GetOrCreateElementNode();
 			
 			//Update the left and right to match the new node count
 			var propComponentLeft = PropComponents.FirstOrDefault(x => x.Name == $"{Name} Left");

--- a/src/Vixen.Modules/App/Props/Models/BaseLightProp.cs
+++ b/src/Vixen.Modules/App/Props/Models/BaseLightProp.cs
@@ -95,7 +95,7 @@ namespace VixenModules.App.Props.Models
 		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 		protected async Task UpdateStringNodeCount(int nodeCount, ElementNode? propNode = null)
 		{
-			propNode ??= GetOrCreatePropElementNode();
+			propNode ??= GetOrCreateElementNode();
 			
 			if (propNode.IsLeaf || propNode.GetMaxChildDepth() > 2)
 			{
@@ -118,7 +118,7 @@ namespace VixenModules.App.Props.Models
 			}
 			else
 			{
-				RemoveElements(propNode, existingNodes - nodeCount);
+				RemoveElementNodes(propNode, existingNodes - nodeCount);
 			}
 
 			UpdateInProgress = false;
@@ -144,7 +144,7 @@ namespace VixenModules.App.Props.Models
 		/// </exception>
 		protected async Task UpdateNodesPerString(int nodesPerString, ElementNode? propNode = null)
 		{
-			propNode ??= GetOrCreatePropElementNode();
+			propNode ??= GetOrCreateElementNode();
 			
 			if (propNode.IsLeaf || propNode.GetMaxChildDepth() > 3)
 			{
@@ -169,7 +169,7 @@ namespace VixenModules.App.Props.Models
 				}
 				else
 				{
-					RemoveElements(propString, existingNodes - nodesPerString);
+					RemoveElementNodes(propString, existingNodes - nodesPerString);
 				}
 			}
 
@@ -198,7 +198,7 @@ namespace VixenModules.App.Props.Models
 		/// </returns>
 		protected async Task UpdateStrings(int strings, ElementNode? propNode = null)
 		{
-			propNode ??= GetOrCreatePropElementNode();
+			propNode ??= GetOrCreateElementNode();
 			
 			while (UpdateInProgress)
 			{
@@ -216,7 +216,7 @@ namespace VixenModules.App.Props.Models
 			}
 			else
 			{
-				RemoveElements(propNode, existingStrings - strings);
+				RemoveElementNodes(propNode, existingStrings - strings);
 			}
 
 			UpdateInProgress = false;
@@ -283,7 +283,7 @@ namespace VixenModules.App.Props.Models
 			}
 			
 			UpdateInProgress = true;
-			var propNode = GetOrCreatePropElementNode();
+			var propNode = GetOrCreateElementNode();
 			PropertySetupHelper.AddOrUpdatePatchingOrder(propNode, startLocation, zigZag, zigZagOffset);
 			
 			UpdateInProgress = false;
@@ -311,7 +311,7 @@ namespace VixenModules.App.Props.Models
 			UpdateInProgress = true;
 			try
 			{
-				var propNode = node ?? GetOrCreatePropElementNode();
+				var propNode = node ?? GetOrCreateElementNode();
 				PropertySetupHelper.AddOrUpdateColorHandling(propNode, GetColorConfiguration());
 			}
 			catch (Exception e)

--- a/src/Vixen.Modules/App/Props/Models/Tree/Tree.cs
+++ b/src/Vixen.Modules/App/Props/Models/Tree/Tree.cs
@@ -302,7 +302,7 @@ namespace VixenModules.App.Props.Models.Tree
 
 			try
 			{
-				var propNode = GetOrCreatePropElementNode();
+				var propNode = GetOrCreateElementNode();
 				if (propNode.IsLeaf && Strings > 0)
 				{
 					AddStringElements(propNode, Strings, NodesPerString);
@@ -354,7 +354,7 @@ namespace VixenModules.App.Props.Models.Tree
 
 		private void CreateOrUpdateStringPropComponents()
 		{
-			var head = GetOrCreatePropElementNode();
+			var head = GetOrCreateElementNode();
 			var nameIndex = AutoPropPrefix.Length;
 			if (!PropComponents.Any())
 			{
@@ -391,7 +391,7 @@ namespace VixenModules.App.Props.Models.Tree
 
 		private void CreateOrUpdateTreeHalfPropComponents()
 		{
-			var head = GetOrCreatePropElementNode();
+			var head = GetOrCreateElementNode();
 
 			//Update the left and right to match the new node count
 			var propComponentLeft = PropComponents.FirstOrDefault(x => x.Name == $"{Name} Left");


### PR DESCRIPTION
* Added xml docs to most all of the methods and properties so other developers have a better idea of what they do.
* Refactor the GetOrCreateElementNode variables to be more descriptive. Considered renaming the method itself, but do not want to break existing work by other devs.
* Added PropModified method to update the modified date time so implementors can call it instead of writing their own.