### PR TITLE
VIX-3723 Fix controller stop bug

### DIFF
--- a/src/Vixen.Application/Setup/DisplaySetup.cs
+++ b/src/Vixen.Application/Setup/DisplaySetup.cs
@@ -282,7 +282,7 @@ namespace VixenApplication.Setup
 			//Just doing it in Ok as if we cancel it reloads the system anyway.
 			VixenSystem.Filters.RemoveOrphanedFilters();
 			Vixen.Sys.PropertyManager.RemoveOrphanedProperties();
-			_setupControllersSimple.ReorderControllers();
+			_setupControllersSimple?.ReorderControllers();
 		}
 	}
 }

--- a/src/Vixen.Common/Controls/ControllerTree.cs
+++ b/src/Vixen.Common/Controls/ControllerTree.cs
@@ -718,10 +718,13 @@ namespace Common.Controls
 		public void ReorderControllers()
 		{
 			// Get the list of controller names in the order they are displayed in the treeview.
-			var sortList = new List<string>();
+			var sortList = new List<Guid>();
 			foreach (TreeNode node in treeview.Nodes)
 			{
-				sortList.Add(node.Text);
+                if (node.Tag is IControllerDevice device)
+                {
+                    sortList.Add(device.Id);
+                }
 			}
 
 			// Reorder the controllers in the system to match the new order in the treeview.


### PR DESCRIPTION
* Add logic to maintain the state of the controllers when they are reordered in the mediator.
* Change the sort order logic to use the controller id over the controller name as the key to ensure the proper order.
* TODO The logic should really maintain whether the controller order actually changed and avoid the arbitrary reorder each time the setup is closed.