### PR TITLE
VIX-3872 Props (Tree & Arch) should delegate state to the Model

### DIFF
--- a/src/Vixen.Core/Sys/Props/BaseProp.cs
+++ b/src/Vixen.Core/Sys/Props/BaseProp.cs
@@ -20,7 +20,8 @@ namespace Vixen.Sys.Props
 	/// of associated components and target nodes.
 	/// </remarks>
 	[Serializable]
-	public abstract class BaseProp<TModel> : BindableBase, IProp where TModel : BasePropModel, IPropModel
+	public abstract class BaseProp<TModel> : BindableBase, IProp 
+		where TModel : BasePropModel, IPropModel, new ()
 	{
 		#region Protected Static Properties
 
@@ -37,6 +38,9 @@ namespace Vixen.Sys.Props
 
 		protected BaseProp(string name, PropType propType)
 		{
+			// Create the prop model
+			PropModel = new TModel();
+			
 			Id = Guid.NewGuid();
 			_name = name;
 			CreationDate = _modifiedDate = DateTime.Now;
@@ -49,11 +53,16 @@ namespace Vixen.Sys.Props
 			Rotations.Add(new AxisRotationModel() { Axis = Axis.YAxis, RotationAngle = 0 });
 			Rotations.Add(new AxisRotationModel() { Axis = Axis.ZAxis, RotationAngle = 0 });
 
-			PropertyChanged += BaseProp_PropertyChanged;
+			PropertyChanged += Prop_PropertyChanged;
 		}
 		#endregion
-
-		private void BaseProp_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+				
+		/// <summary>
+		/// Property changed event handler.
+		/// </summary>
+		/// <param name="sender">Event sender</param>
+		/// <param name="e">Event arguments</param>
+		protected virtual void Prop_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName != null)
 			{
@@ -61,9 +70,9 @@ namespace Vixen.Sys.Props
 				{
 					case nameof(Rotations):
 						HandleRotationsChanged();
-						break;
+						break;					
 				}
-            if (e.PropertyName != nameof(ModifiedDate))
+				if (e.PropertyName != nameof(ModifiedDate))
 				{
 					PropModified();
 				}

--- a/src/Vixen.Core/Sys/Props/Model/BaseLightModel.cs
+++ b/src/Vixen.Core/Sys/Props/Model/BaseLightModel.cs
@@ -8,14 +8,15 @@ namespace Vixen.Sys.Props.Model
 	/// Maintains a base light model.
 	/// </summary>
 	public abstract class BaseLightModel : BasePropModel, ILightPropModel
-	{
+	{		
 		#region Protected Methods
+
 		/// <summary>
 		/// Updates the nodes when a model property changes.
 		/// </summary>
 		/// <param name="sender">Event sender</param>
 		/// <param name="e">Event arguments</param>
-		protected void PropertyModelChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+		protected override void PropertyModelChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
 			//TODO make this smarter to do the minimal to add, subtract, or update node size or rotation angle.			
 			Nodes.Clear();
@@ -47,7 +48,7 @@ namespace Vixen.Sys.Props.Model
 		public int LightSize
 		{
 			get => _lightSize;
-			set => _lightSize = value;
+			set => SetProperty(ref _lightSize, value);
 		}
 
 		#endregion

--- a/src/Vixen.Core/Sys/Props/Model/BasePropModel.cs
+++ b/src/Vixen.Core/Sys/Props/Model/BasePropModel.cs
@@ -9,6 +9,19 @@ namespace Vixen.Sys.Props.Model
 	/// </summary>
 	public abstract class BasePropModel : BindableBase
 	{
+		#region Constructor
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		protected BasePropModel()
+		{
+			// Register for model property changes
+			PropertyChanged += PropertyModelChanged;
+		}
+
+		#endregion
+
 		#region IPropModel
 
 		/// <inheritdoc/>		
@@ -23,15 +36,22 @@ namespace Vixen.Sys.Props.Model
 	        get => _axisRotationModel;
 	        set => _axisRotationModel = value;
         }
-        #endregion
+		#endregion
 
-        #region Protected Methods
+		#region Protected Methods
 
-        /// <summary>
-        /// Rotates the specified vertices by up to three axis rotations.
-        /// </summary>
-        /// <param name="vertices">Vertices to rotate</param>
-        protected void RotatePoints(List<NodePoint> vertices, ObservableCollection<AxisRotationModel>rotations)
+		/// <summary>
+		/// Allows derived models to update calculated state when a model property changes.
+		/// </summary>
+		/// <param name="sender">Event sender</param>
+		/// <param name="e">Event arguments</param>
+		protected abstract void PropertyModelChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e);
+
+		/// <summary>
+		/// Rotates the specified vertices by up to three axis rotations.
+		/// </summary>
+		/// <param name="vertices">Vertices to rotate</param>
+		protected void RotatePoints(List<NodePoint> vertices, ObservableCollection<AxisRotationModel>rotations)
 		{
 			if (rotations == null)
 			{

--- a/src/Vixen.Modules/App/Props/Models/Arch/Arch.cs
+++ b/src/Vixen.Modules/App/Props/Models/Arch/Arch.cs
@@ -1,10 +1,8 @@
 ﻿
 #nullable enable
-using AsyncAwaitBestPractices;
 using Common.Controls.ColorManagement.ColorModels;
 using Common.Controls.Theme;
 using Common.WPFCommon.Converters;
-using Debounce.Core;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Vixen.Extensions;
@@ -27,17 +25,14 @@ namespace VixenModules.App.Props.Models.Arch
 	/// </summary>
 	public class Arch : BaseLightProp<ArchModel>, IProp
 	{
-		private readonly Debouncer _generateDebouncer;
+		#region Constructors
 
 		public Arch() : this("Arch Temp")
 		{
 		}
 
 		public Arch(string name, int nodeCount = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Arch)
-		{
-			// Create Preview model
-			PropModel = new ArchModel();
-
+		{			
 			// Set some default parameters
 			Name = name;
 			NodeCount = 24;
@@ -55,27 +50,24 @@ namespace VixenModules.App.Props.Models.Arch
 			{
 				var ColorSetNames = new ObservableCollection<string>(staticData.GetColorSetNames());
 				SelectedColorSet = ColorSetNames[0];
-			}
-
-			_generateDebouncer = new Debouncer(() =>
-			{
-				GenerateElementsAsync().SafeFireAndForget();
-			}, 500);
-
-			PropertyChanged += Arch_PropertyChanged;
+			}						
 		}
 
-		#region Properties
-		private int _nodeCount;
+		#endregion
+
+		#region Public Properties
+
 		public int NodeCount
 		{
-			get => _nodeCount;
+			get => PropModel.NumPoints;
 			set
 			{
-				_nodeCount = value;
-				PropModel.NumPoints = _nodeCount;
-				PropModel.UpdatePropNodes();
-				_generateDebouncer?.Debounce();
+				if (value == PropModel.NumPoints)
+				{
+					return;
+				}
+
+				PropModel.NumPoints = value;
 				OnPropertyChanged(nameof(NodeCount));
 			}
 		}
@@ -87,7 +79,6 @@ namespace VixenModules.App.Props.Models.Arch
 			set
 			{
 				_archWiringStart = value;
-				UpdatePatchingOrder().SafeFireAndForget(); ;
 				OnPropertyChanged(nameof(ArchWiringStart));
 			}
 		}
@@ -103,29 +94,10 @@ namespace VixenModules.App.Props.Models.Arch
 				UpdateDefaultPropComponents();
 			}
 		}
+
 		#endregion
-
-		private void Arch_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-		{
-			if (e.PropertyName != null)
-			{
-				switch (e.PropertyName)
-				{
-					case nameof(NodeCount):
-						HandleArchChanged();
-						break;
-				}
-			}
-		}
-
-		private void HandleArchChanged()
-		{
-			if (PropModel == null)
-				return;
-
-			PropModel.NumPoints = NodeCount;
-			PropModel.UpdatePropNodes();
-		}
+		
+		#region Public Method Overrides
 
 		/// <summary>
 		/// Get the HTML summary of all the parameter values
@@ -161,11 +133,15 @@ namespace VixenModules.App.Props.Models.Arch
 			return Summary;
 		}
 
+		#endregion
+
+		#region Protected Methods
+
 		/// <summary>
 		/// 
 		/// </summary>
 		/// <returns></returns>
-		protected async Task GenerateElementsAsync()
+		protected override async Task GenerateElementsAsync()
 		{
 			await Task.Factory.StartNew(async () =>
 			{
@@ -197,12 +173,44 @@ namespace VixenModules.App.Props.Models.Arch
 			});
 		}
 
+		protected override async void Prop_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+            try
+            {
+				if (e.PropertyName != null)
+				{
+					// Call base class implementation
+					base.Prop_PropertyChanged(sender, e);
+
+					switch (e.PropertyName)
+					{
+						case nameof(StringType):
+							GenerateDebouncer.Debounce();
+							break;
+						case nameof(NodeCount):
+							PropModel.UpdatePropNodes();
+							GenerateDebouncer.Debounce();
+							break;
+						case nameof(ArchWiringStart):
+                            await UpdatePatchingOrder();
+							break;						
+					}
+				}
+            }
+            catch (Exception ex)
+            {
+				Logging.Error(ex, $"An error occured handling Arch property {e.PropertyName} changed");
+			}
+		}
+		
+		#endregion
+
+		#region Private Methods
+
 		private async Task UpdatePatchingOrder()
 		{
 			await AddOrUpdatePatchingOrder(ArchWiringStart == ArchStartLocation.Left ? Props.StartLocation.BottomLeft : Props.StartLocation.BottomRight);
 		}
-
-		#region PropComponents
 
 		/// <summary>
 		/// Update the nodes for the Arch Prop
@@ -299,6 +307,6 @@ namespace VixenModules.App.Props.Models.Arch
 				}
 			}
 		}
-		#endregion
+		#endregion		
 	}
 }

--- a/src/Vixen.Modules/App/Props/Models/Arch/ArchModel.cs
+++ b/src/Vixen.Modules/App/Props/Models/Arch/ArchModel.cs
@@ -7,10 +7,18 @@ namespace VixenModules.App.Props.Models.Arch
 	/// </summary>
 	public class ArchModel: BaseLightModel
 	{
+		#region Constructor
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
 		public ArchModel()
-		{
-			PropertyChanged += PropertyModelChanged;
+		{			
 		}
+
+		#endregion
+
+		#region Public Properties
 
 		private int _numPoints = 3;
 		public int NumPoints
@@ -18,6 +26,10 @@ namespace VixenModules.App.Props.Models.Arch
 			get => _numPoints;
 			set => _numPoints = value;
 		}
+
+		#endregion
+
+		#region Protected Overrides
 
 		/// <summary>
 		/// Calculates the 3-D points that make up the arch.
@@ -51,5 +63,7 @@ namespace VixenModules.App.Props.Models.Arch
 
 			return vertices;
 		}
+
+		#endregion
 	}
 }

--- a/src/Vixen.Modules/App/Props/Models/BaseLightProp.cs
+++ b/src/Vixen.Modules/App/Props/Models/BaseLightProp.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
+using AsyncAwaitBestPractices;
 using Common.WPFCommon.Converters;
-using System.Collections.ObjectModel;
+using Debounce.Core;
 using System.ComponentModel;
 using System.Drawing;
-using System.Windows.Media.Imaging;
 using Vixen.Services;
 using Vixen.Sys;
 using Vixen.Sys.Props;
@@ -13,21 +13,26 @@ using VixenModules.Property.Color;
 
 namespace VixenModules.App.Props.Models
 {
-	public abstract class BaseLightProp<TModel> : BaseProp<TModel> where TModel : BaseLightModel, IPropModel
+	public abstract class BaseLightProp<TModel> : BaseProp<TModel> 
+		where TModel : BaseLightModel, IPropModel, new()	
 	{
 		protected bool UpdateInProgress = false;
 
 		protected BaseLightProp(string name, PropType propType) : base(name, propType)
 		{
+			GenerateDebouncer = new Debouncer(() =>
+			{
+				GenerateElementsAsync().SafeFireAndForget();
+			}, 500);
+
 			StringType = StringTypes.ColorMixingRGB;
 			Brightness = 100;
 			Gamma = 1.0;
-			SingleColorOption = System.Drawing.Color.RoyalBlue;
-
-			PropertyChanged += BaseLightProp_PropertyChanged;
+			SingleColorOption = System.Drawing.Color.RoyalBlue;				
 		}
 
-		#region Properties
+		#region Public Properties
+		
 		/// <summary>
 		/// Gets or sets the type of string used in the light prop.
 		/// </summary>
@@ -51,14 +56,18 @@ namespace VixenModules.App.Props.Models
 			get => _stringType;
 			set => SetProperty(ref _stringType, value);
 		}
-
-		private int _lightSize;
+		
 		public int LightSize
 		{
-			get => _lightSize;
+			get => PropModel.LightSize;
 			set
 			{
-				_lightSize = value;
+				if (value == PropModel.LightSize)
+				{
+					return;
+				}
+
+				PropModel.LightSize = value;
 				OnPropertyChanged(nameof(LightSize));
 			}
 		}
@@ -117,29 +126,41 @@ namespace VixenModules.App.Props.Models
 				OnPropertyChanged(nameof(SelectedColorSet));
 			}
 		}
+
 		#endregion
 
-		private void BaseLightProp_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		#region Protected Properties
+
+		/// <summary>
+		/// Utility for deferring element generation for the prop.
+		/// </summary>		
+		protected Debouncer GenerateDebouncer { get; set; }
+
+		#endregion
+
+		#region Protected Methods
+
+		protected override void Prop_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName != null)
 			{
 				switch (e.PropertyName)
 				{
+					case nameof(StringType):
+						GenerateDebouncer.Debounce();
+						break;
 					case nameof(LightSize):
-						HandleLightPropChanged();
+						PropModel.UpdatePropNodes();						
 						break;
 				}
 			}
 		}
-
-		private void HandleLightPropChanged()
-		{
-			if (PropModel == null)
-				return;
-
-			PropModel.LightSize = LightSize;
-			PropModel.UpdatePropNodes();
-		}
+		
+		/// <summary>
+		/// Allows derived light props to generate or update the elements associated with the prop.
+		/// </summary>
+		/// <returns>Task to generate elements</returns>
+		protected abstract Task GenerateElementsAsync();
 
 		/// <summary>
 		/// Adds a specified number of string elements to the given element node.
@@ -460,5 +481,7 @@ namespace VixenModules.App.Props.Models
 
 			return summary;
 		}
+
+		#endregion
 	}
 }

--- a/src/Vixen.Modules/App/Props/Models/IntelligentFixture/IntelligentFixtureModel.cs
+++ b/src/Vixen.Modules/App/Props/Models/IntelligentFixture/IntelligentFixtureModel.cs
@@ -1,13 +1,7 @@
-﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
-
-using OpenTK.Mathematics;
+﻿using System.ComponentModel;
 using Vixen.Sys.Props.Model;
 using VixenModules.App.Props.Models.IntelligentFixture;
 using VixenModules.Editor.FixtureGraphics;
-using VixenModules.Editor.FixtureGraphics.OpenGL;
-
-
 
 namespace VixenModules.App.Props.Models.IntellligentFixture
 {
@@ -159,6 +153,15 @@ namespace VixenModules.App.Props.Models.IntellligentFixture
 		public YesNoType InvertTiltDirection { get; set; }
 
 		public MountingPositionType MountingPosition { get; set; }
+		#endregion
+
+		#region Protected Methods
+
+		/// <inheritdoc/>
+		protected override void PropertyModelChanged(object? sender, PropertyChangedEventArgs e)
+		{
+		}
+
 		#endregion
 	}
 }

--- a/src/Vixen.Modules/App/Props/Models/Tree/Tree.cs
+++ b/src/Vixen.Modules/App/Props/Models/Tree/Tree.cs
@@ -1,10 +1,8 @@
 ﻿#nullable enable
 
-using AsyncAwaitBestPractices;
 using Common.Controls.ColorManagement.ColorModels;
 using Common.Controls.Theme;
 using Common.WPFCommon.Converters;
-using Debounce.Core;
 using System.ComponentModel;
 using Vixen.Extensions;
 using Vixen.Sys;
@@ -14,14 +12,12 @@ using Vixen.Sys.Props.Components;
 
 namespace VixenModules.App.Props.Models.Tree
 {
+	/// <summary>
+	/// Maintains a tree prop.
+	/// </summary>
 	public class Tree : BaseLightProp<TreeModel>, IProp
-	{
-		#region Fields
-
-		private readonly Debouncer _generateDebouncer;
-
-		#endregion
-
+	{		
+		#region Constructors
 
 		public Tree() : this("Tree 1", 0, 0)
 		{
@@ -33,7 +29,7 @@ namespace VixenModules.App.Props.Models.Tree
 		}
 
 		public Tree(string name, int strings = 0, int nodesPerString = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Tree)
-		{
+		{			
 			PropType = PropType.Tree;
 			Name = name;
 			StringType = stringType;
@@ -48,18 +44,12 @@ namespace VixenModules.App.Props.Models.Tree
 			NodesPerString = 50;
 			LightSize = 2;
 			TopRadius = 10;
-			BottomRadius = 100;
-
-			// Create Preview model
-			PropModel = new TreeModel(strings, nodesPerString);
-
-			_generateDebouncer = new Debouncer(() =>
-			{
-				GenerateElementsAsync().SafeFireAndForget();
-			}, 500);
-
-			PropertyChanged += Tree_PropertyChanged;
+			BottomRadius = 100;					
 		}
+
+		#endregion
+
+		#region Public Override Methods
 
 		override public string GetSummary()
 		{
@@ -102,17 +92,20 @@ namespace VixenModules.App.Props.Models.Tree
 			return Summary;
 		}
 
+		#endregion
+
+		#region Public Properties
+
 		/// <summary>
 		/// The number of light strings
 		/// </summary>
-		private int _strings;
 		public int Strings
 		{
-			get => _strings;
+			get => PropModel.Strings;
 			set
 			{
 				if (value <= 0) return;
-				SetProperty(ref _strings, value);
+				PropModel.Strings = value;
 				OnPropertyChanged(nameof(Strings));
 			}
 		}
@@ -120,18 +113,17 @@ namespace VixenModules.App.Props.Models.Tree
 		/// <summary>
 		/// The number of light nodes per string
 		/// </summary>
-		private int _nodesPerString;
 		public int NodesPerString
 		{
-			get => _nodesPerString;
+			get => PropModel.NodesPerString;
 			set
 			{
 				if (value <= 0) return;
-				if (value == _nodesPerString)
+				if (value == PropModel.NodesPerString)
 				{
 					return;
 				}
-				SetProperty(ref _nodesPerString, value);
+				PropModel.NodesPerString = value;
 				OnPropertyChanged(nameof(NodesPerString));
 			}
 		}
@@ -139,18 +131,18 @@ namespace VixenModules.App.Props.Models.Tree
 		/// <summary>
 		/// The degrees of coverage for the Tree. ex. 180 for a half tree.
 		/// </summary>
-		private int _degreesCoverage;
+		
 		public int DegreesCoverage
 		{
-			get => _degreesCoverage;
+			get => PropModel.DegreesCoverage;
 			set
 			{
 				if (value > 360 || value <= 0) return;
-				if (value == _degreesCoverage)
+				if (value == PropModel.DegreesCoverage)
 				{
 					return;
 				}
-				SetProperty(ref _degreesCoverage, value);
+				PropModel.DegreesCoverage = value;
 				OnPropertyChanged(nameof(DegreesCoverage));
 			}
 		}
@@ -161,48 +153,48 @@ namespace VixenModules.App.Props.Models.Tree
 		private int _degreesOffset;
 		public int DegreeOffset
 		{
-			get => _degreesOffset;
+			get => PropModel.DegreesOffset;
 			set
 			{
 				if (value > 359 || value < -359) return;
-				if (value == _degreesOffset)
+				if (value == PropModel.DegreesOffset)
 				{
 					return;
 				}
 
-				SetProperty(ref _degreesOffset, value);
+				PropModel.DegreesOffset = value;
 				OnPropertyChanged(nameof(DegreeOffset));
 			}
 		}
 
-		private int _baseHeight;
+	
 		public int BaseHeight
 		{
-			get => _baseHeight;
+			get => PropModel.BaseHeight;
 			set
 			{
-				if (value <= 0)
+				if (value <= 0 || value == PropModel.BaseHeight)
 				{
 					return;
 				}
 
-				SetProperty(ref _baseHeight, value);
+				PropModel.BaseHeight = value;
 				OnPropertyChanged(nameof(BaseHeight));
 			}
 		}
 
-		private int _topHeight;
+	
 		public int TopHeight
 		{
-			get => _topHeight;
+			get => PropModel.TopHeight;
 			set
 			{
-				if (value <= 0)
+				if (value <= 0 || value == PropModel.TopHeight)
 				{
 					return;
 				}
 
-				SetProperty(ref _topHeight, value);
+				PropModel.TopHeight = value;
 				OnPropertyChanged(nameof(TopHeight));
 			}
 		}
@@ -210,15 +202,15 @@ namespace VixenModules.App.Props.Models.Tree
 		private int _topWidth;
 		public int TopWidth
 		{
-			get => _topWidth;
+			get => PropModel.TopWidth;
 			set
 			{
-				if (value <= 0)
+				if (value <= 0 || value == PropModel.TopHeight)
 				{
 					return;
 				}
 
-				SetProperty(ref _topWidth, value);
+				PropModel.TopHeight = value;
 				OnPropertyChanged(nameof(TopWidth));
 			}
 		}
@@ -251,13 +243,12 @@ namespace VixenModules.App.Props.Models.Tree
 		/// <summary>
 		/// Top radius of the tree as a percentage.
 		/// </summary>
-		private float _topRadius;
 		public float TopRadius
 		{
-			get => _topRadius;
+			get => PropModel.TopRadius;
 			set
 			{
-				SetProperty(ref _topRadius, value);
+				PropModel.TopRadius = value;
 				OnPropertyChanged(nameof(TopRadius));
 			}
 		}
@@ -265,116 +256,22 @@ namespace VixenModules.App.Props.Models.Tree
 		/// <summary>
 		/// Bottom radius of the tree as a percentage.
 		/// </summary>
-		private float _bottomRadius;
 		public float BottomRadius
 		{
-			get => _bottomRadius;
+			get => PropModel.BottomRadius;
 			set
 			{
-				SetProperty(ref _bottomRadius, value);
+				PropModel.BottomRadius = value;
 				OnPropertyChanged(nameof(BottomRadius));
 			}
 		}
+		
+		//TODO Map element structure to model nodes
+					
+		#endregion
 
-		private async void Tree_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-		{
-			try
-			{
-				// Name is handled in the base class so we need to handle our own.
-				if (e.PropertyName != null)
-				{
-					switch (e.PropertyName)
-					{
-						case nameof(StringType):
-							_generateDebouncer.Debounce();
-							break;
-
-						case nameof(StartLocation):
-						case nameof(ZigZag):
-						case nameof(ZigZagOffset):
-							await AddOrUpdatePatchingOrder(_startLocation, _zigZag, _zigZagOffset);
-							break;
-
-						case nameof(NodesPerString):
-						case nameof(TopRadius):
-						case nameof(BottomRadius):
-						case nameof(DegreesCoverage):
-						case nameof(DegreeOffset):
-						case nameof(Strings):
-							HandleTreeChanged();
-							break;
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Logging.Error(ex, $"An error occured handling Tree property {e.PropertyName} changed");
-			}
-		}
-
-		private void HandleTreeChanged()
-		{
-			if (PropModel == null)
-				return;
-
-			PropModel.NodesPerString = NodesPerString;
-			PropModel.TopRadius = TopRadius;
-			PropModel.BottomRadius = BottomRadius;
-			PropModel.DegreesCoverage = DegreesCoverage;
-			PropModel.DegreesOffset = DegreeOffset;
-			PropModel.Strings = Strings;
-			PropModel.UpdatePropNodes();
-		}
-
-		protected async Task GenerateElementsAsync()
-		{
-			bool hasUpdatedStrings = false;
-			bool hasUpdatedNodes = false;
-
-			try
-			{
-				var propNode = GetOrCreateElementNode();
-				if (propNode.IsLeaf && Strings > 0)
-				{
-					AddStringElements(propNode, Strings, NodesPerString);
-					hasUpdatedStrings = true;
-				}
-				else if (propNode.Children.Count() != Strings)
-				{
-					await UpdateStrings(Strings).ConfigureAwait(false);
-					hasUpdatedStrings = true;
-				}
-
-				if (propNode.Children.Any())
-				{
-					if (propNode.Children.First().Children.Count() != NodesPerString)
-					{
-						await UpdateNodesPerString(NodesPerString).ConfigureAwait(false);
-						hasUpdatedStrings = true;
-					}
-				}
-
-				if (hasUpdatedStrings || hasUpdatedNodes)
-				{
-					await AddOrUpdatePatchingOrder(_startLocation, _zigZag, _zigZagOffset)
-						.ConfigureAwait(false);
-
-					await AddOrUpdateColorHandling().ConfigureAwait(false);
-				}
-
-				if (hasUpdatedStrings)
-				{
-					UpdateDefaultPropComponents();
-				}
-
-			}
-			catch (Exception e)
-			{
-				Logging.Error(e, "An exception occured creating the prop");
-			}
-
-		}
-
+		#region Private Methods
+		
 		private void UpdateDefaultPropComponents()
 		{
 
@@ -470,5 +367,95 @@ namespace VixenModules.App.Props.Models.Tree
 			VixenSystem.PropComponents.AddPropComponent(propComponentLeft, parentPropComponentNode);
 			VixenSystem.PropComponents.AddPropComponent(propComponentRight, parentPropComponentNode);
 		}
+
+		#endregion
+
+		#region Protected Methods
+
+		protected async void Prop_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			try
+			{			
+				// Name is handled in the base class so we need to handle our own.
+				if (e.PropertyName != null)
+				{
+					// Call base class implementation
+					base.Prop_PropertyChanged(sender, e);
+
+					switch (e.PropertyName)
+					{
+						case nameof(StartLocation):
+						case nameof(ZigZag):
+						case nameof(ZigZagOffset):
+							await AddOrUpdatePatchingOrder(_startLocation, _zigZag, _zigZagOffset);
+							break;
+
+						case nameof(NodesPerString):
+						case nameof(TopRadius):
+						case nameof(BottomRadius):
+						case nameof(DegreesCoverage):
+						case nameof(DegreeOffset):
+						case nameof(Strings):
+							GenerateDebouncer.Debounce();
+							break;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Logging.Error(ex, $"An error occured handling Tree property {e.PropertyName} changed");
+			}
+		}
+		
+		protected override async Task GenerateElementsAsync()
+		{
+			bool hasUpdatedStrings = false;
+			bool hasUpdatedNodes = false;
+
+			try
+			{
+				var propNode = GetOrCreateElementNode();
+				if (propNode.IsLeaf && Strings > 0)
+				{
+					AddStringElements(propNode, Strings, NodesPerString);
+					hasUpdatedStrings = true;
+				}
+				else if (propNode.Children.Count() != Strings)
+				{
+					await UpdateStrings(Strings).ConfigureAwait(false);
+					hasUpdatedStrings = true;
+				}
+
+				if (propNode.Children.Any())
+				{
+					if (propNode.Children.First().Children.Count() != NodesPerString)
+					{
+						await UpdateNodesPerString(NodesPerString).ConfigureAwait(false);
+						hasUpdatedStrings = true;
+					}
+				}
+
+				if (hasUpdatedStrings || hasUpdatedNodes)
+				{
+					await AddOrUpdatePatchingOrder(_startLocation, _zigZag, _zigZagOffset)
+						.ConfigureAwait(false);
+
+					await AddOrUpdateColorHandling().ConfigureAwait(false);
+				}
+
+				if (hasUpdatedStrings)
+				{
+					UpdateDefaultPropComponents();
+				}
+
+			}
+			catch (Exception e)
+			{
+				Logging.Error(e, "An exception occured creating the prop");
+			}
+
+		}
+
+		#endregion
 	}
 }

--- a/src/Vixen.Modules/App/Props/Models/Tree/TreeModel.cs
+++ b/src/Vixen.Modules/App/Props/Models/Tree/TreeModel.cs
@@ -11,23 +11,12 @@ namespace VixenModules.App.Props.Models.Tree
 	public class TreeModel : BaseLightModel
 	{
 		#region Constructor
-
+		
 		/// <summary>
 		/// Constructor
-		/// </summary>
-		public TreeModel() : this(16, 50, 2)
-		{
-		}
-
-		/// <summary>
-		/// Constructor
-		/// </summary>
-		/// <param name="strings">Number of string</param>
-		/// <param name="nodesPerString">Nodes (lights) per string</param>
-		/// <param name="nodeSize">Node (light) size </param>
-		public TreeModel(int strings = 16, int nodesPerString = 50, int nodeSize = 2)
-		{
-			PropertyChanged += PropertyModelChanged;
+		/// </summary>		
+		public TreeModel()
+		{ 			
 		}
 
 		#endregion
@@ -122,6 +111,8 @@ namespace VixenModules.App.Props.Models.Tree
 
 		#endregion
 
+		#region Protected Override Methods
+
 		/// <summary>
 		/// Creates the 3-D points that make up the tree.
 		/// </summary>
@@ -150,7 +141,7 @@ namespace VixenModules.App.Props.Models.Tree
 				double angle = (DegreesCoverage / Strings) * i + DegreesOffset;
 
 				// Add a strand to the tree
-				treePoints.AddRange(CreateStrand(NodesPerString, angle, bottomRadius, radiusDelta, -height / 2.0, +height / NodesPerString));
+				treePoints.AddRange(CreateStrand(NodesPerString, angle, bottomRadius, radiusDelta, -height / 2.0, + height / NodesPerString));
 			}
 
 			// (Optionally) rotate the points along the X, Y, and Z axis			
@@ -158,6 +149,10 @@ namespace VixenModules.App.Props.Models.Tree
 
 			return treePoints;
 		}
+
+		#endregion
+
+		#region Private Methods
 
 		/// <summary>
 		/// Creates a strand of nodes.
@@ -208,8 +203,8 @@ namespace VixenModules.App.Props.Models.Tree
 			// Return the node points that make up the strand
 			return strandPoints;
 		}
-
-		public static List<PointF> GetEllipsePoints(
+				
+		private static List<PointF> GetEllipsePoints(
 			double leftOffset,
 			double topOffset,
 			double width,
@@ -248,5 +243,7 @@ namespace VixenModules.App.Props.Models.Tree
 			}
 			return points;
 		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
VIX-3872 Props (Tree & Arch) should delegate state to the Model

It was easier to update the Tree and the Arch together than to work them separately.
One additional thing I did in this pull request was to have the base prop create the model using the template argument.
I initially thought this was necessary to avoid a null exception but I think that turned out to be wrong.
This change prevents us from using constructor arguments on the model but does reduce the need for null checks that the model has been initialized so I left it in.  This should allow all levels in the prop inheritance to configure properties on the model.
