### PR TITLE
VIX-3875 Rename Tree and Arch to TreeProp and ArchProp to better distinguish from the respective models

### DIFF
--- a/src/Vixen.Application/SetupDisplay/ViewModels/SetupDisplayViewModel.cs
+++ b/src/Vixen.Application/SetupDisplay/ViewModels/SetupDisplayViewModel.cs
@@ -760,9 +760,9 @@ namespace VixenApplication.SetupDisplay.ViewModels
 		{
 			PropManager propManager = VixenSystem.Props;
 
-			propManager.RootNode.AddChild(MockPropNodeGroup<Tree>("Mini Tree"));
+			propManager.RootNode.AddChild(MockPropNodeGroup<TreeProp>("Mini Tree"));
 
-			propManager.RootNode.AddChild(MockPropNodeGroup<Arch>("Arch"));
+			propManager.RootNode.AddChild(MockPropNodeGroup<ArchProp>("Arch"));
 
 			propManager.RootNode.AddChild(MockPropNodeGroup<IntelligentFixtureProp>("Intelligent Fixture"));
 		}

--- a/src/Vixen.Application/SetupDisplay/Wizards/Pages/TreePropWizardPage.cs
+++ b/src/Vixen.Application/SetupDisplay/Wizards/Pages/TreePropWizardPage.cs
@@ -237,7 +237,7 @@ namespace VixenApplication.SetupDisplay.Wizards.Pages
 
         public IProp GetProp()
         {
-            var tree = VixenSystem.Props.CreateProp<Tree>(Name);
+            var tree = VixenSystem.Props.CreateProp<TreeProp>(Name);
             tree.Strings = Strings;
             tree.NodesPerString = NodesPerString;
             //TODO add in other fields when wizard has full function

--- a/src/Vixen.Application/SetupDisplay/Wizards/PropFactories/ArchPropFactory.cs
+++ b/src/Vixen.Application/SetupDisplay/Wizards/PropFactories/ArchPropFactory.cs
@@ -18,7 +18,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         public IPropGroup GetProps(IPropWizard wizard)
         {
             // Create the Arch prop
-            Arch arch = VixenSystem.Props.CreateProp<Arch>(VixenSystem.Props.GenerateUniquePropTitle(PropType.Arch));
+            ArchProp arch = VixenSystem.Props.CreateProp<ArchProp>(VixenSystem.Props.GenerateUniquePropTitle(PropType.Arch));
 
             // Transfer the data from the wizard into the arch prop
             UpdateProp(arch, wizard);
@@ -40,7 +40,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         /// <param name="wizard">Specifies the Arch prop wizard destination</param>
         public void LoadWizard(IProp prop, IPropWizard wizard)
         {
-            Arch arch = (Arch)prop;
+            ArchProp arch = (ArchProp)prop;
 
             // Configure the wizard with the base Arch properties
             ArchPropWizardPage archPropPage = (ArchPropWizardPage)wizard.Pages.Single(page => page is ArchPropWizardPage);
@@ -73,7 +73,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         /// <param name="wizard">Specifies the Arch prop wizard source</param>
         public void UpdateProp(IProp prop, IPropWizard wizard)
         {
-            Arch arch = (Arch)prop;
+            ArchProp arch = (ArchProp)prop;
 
             // Configure the base Arch properties
             ArchPropWizardPage archPropPage = (ArchPropWizardPage)wizard.Pages.Single(page => page is ArchPropWizardPage);

--- a/src/Vixen.Application/SetupDisplay/Wizards/PropFactories/TreePropFactory.cs
+++ b/src/Vixen.Application/SetupDisplay/Wizards/PropFactories/TreePropFactory.cs
@@ -18,7 +18,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         public IPropGroup GetProps(IPropWizard wizard)
         {
             // Create the Tree prop
-            Tree tree = VixenSystem.Props.CreateProp<Tree>(VixenSystem.Props.GenerateUniquePropTitle(PropType.Tree));
+            TreeProp tree = VixenSystem.Props.CreateProp<TreeProp>(VixenSystem.Props.GenerateUniquePropTitle(PropType.Tree));
 
             // Transfer the data from the wizard into the tree prop
             UpdateProp(tree, wizard);
@@ -40,7 +40,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         /// <param name="wizard">Specifies the Tree prop wizard destination</param>
         public void LoadWizard(IProp prop, IPropWizard wizard)
         {
-            Tree tree = (Tree)prop;
+            TreeProp tree = (TreeProp)prop;
 
             // Configure the wizard with the base Tree properties
             TreePropWizardPage treePropPage = (TreePropWizardPage)wizard.Pages.Single(page => page is TreePropWizardPage);
@@ -83,7 +83,7 @@ namespace VixenApplication.SetupDisplay.Wizards.PropFactories
         /// <param name="wizard">Specifies the Tree prop wizard source</param>
         public void UpdateProp(IProp prop, IPropWizard wizard)
         {
-            Tree tree = (Tree)prop;
+            TreeProp tree = (TreeProp)prop;
 
             // Configure the base Tree properties
             TreePropWizardPage treePropPage = (TreePropWizardPage)wizard.Pages.Single(page => page is TreePropWizardPage);

--- a/src/Vixen.Modules/App/Props/Models/Arch/ArchProp.cs
+++ b/src/Vixen.Modules/App/Props/Models/Arch/ArchProp.cs
@@ -23,15 +23,15 @@ namespace VixenModules.App.Props.Models.Arch
 	/// <summary>
 	/// A class that defines an Arch Prop
 	/// </summary>
-	public class Arch : BaseLightProp<ArchModel>, IProp
+	public class ArchProp : BaseLightProp<ArchModel>, IProp
 	{
 		#region Constructors
 
-		public Arch() : this("Arch Temp")
+		public ArchProp() : this("Arch Temp")
 		{
 		}
 
-		public Arch(string name, int nodeCount = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Arch)
+		public ArchProp(string name, int nodeCount = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Arch)
 		{			
 			// Set some default parameters
 			Name = name;

--- a/src/Vixen.Modules/App/Props/Models/Tree/TreeProp.cs
+++ b/src/Vixen.Modules/App/Props/Models/Tree/TreeProp.cs
@@ -15,20 +15,20 @@ namespace VixenModules.App.Props.Models.Tree
 	/// <summary>
 	/// Maintains a tree prop.
 	/// </summary>
-	public class Tree : BaseLightProp<TreeModel>, IProp
+	public class TreeProp : BaseLightProp<TreeModel>, IProp
 	{		
 		#region Constructors
 
-		public Tree() : this("Tree 1", 0, 0)
+		public TreeProp() : this("Tree 1", 0, 0)
 		{
 			//Set initial to 0 so creation does not trigger element generation.
 		}
 
-		public Tree(string name, int strings, int nodesPerString) : this(name, strings, nodesPerString, StringTypes.ColorMixingRGB)
+		public TreeProp(string name, int strings, int nodesPerString) : this(name, strings, nodesPerString, StringTypes.ColorMixingRGB)
 		{
 		}
 
-		public Tree(string name, int strings = 0, int nodesPerString = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Tree)
+		public TreeProp(string name, int strings = 0, int nodesPerString = 0, StringTypes stringType = StringTypes.ColorMixingRGB) : base(name, PropType.Tree)
 		{			
 			PropType = PropType.Tree;
 			Name = name;


### PR DESCRIPTION
VIX-3875 Rename Tree and Arch to TreeProp and ArchProp to better distinguish from the respective models