### PR TITLE
VIX-3150 Changed the green button color to match the output

### DIFF
--- a/src/Vixen.Common/Controls/ColorPicker/ColorPicker.cs
+++ b/src/Vixen.Common/Controls/ColorPicker/ColorPicker.cs
@@ -64,7 +64,7 @@ namespace Common.Controls.ColorManagement.ColorPicker
 			whiteButton.BackgroundImage = null;
 			redButton.BackColor = System.Drawing.Color.Red;
 			redButton.BackgroundImage = null;
-			greenButton.BackColor = System.Drawing.Color.Green;
+			greenButton.BackColor = System.Drawing.Color.Lime;
 			greenButton.BackgroundImage = null;
 			blueButton.BackColor = System.Drawing.Color.Blue;
 			blueButton.BackgroundImage = null;


### PR DESCRIPTION
VIX-3150 Changed the green color button on the color picker to lime which matches R0 G255 B0 instead of the green it was set to which is R0, G128, B0

I choose lime because when you push the "green" button it was selecting G255 as the color choice but the button color didn't match.