### PR TITLE
VIX-3927 Fix Mark Collection panel bugs

### DIFF
--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionViewModel.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using Catel.Data;
 using Catel.IoC;
 using Catel.MVVM;
+using Common.Controls.ColorManagement.ColorModels;
 using Common.WPFCommon.Services;
 using Vixen.Marks;
 using VixenModules.App.Marks;
@@ -382,6 +383,7 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 		private void PickColor()
 		{
 			var picker = new Common.Controls.ColorManagement.ColorPicker.ColorPicker();
+			picker.Color = XYZ.FromRGB(Decorator.Color);
 			var result = picker.ShowDialog();
 			if (result == DialogResult.OK)
 			{

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Views/MarkExportWindow.xaml
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Views/MarkExportWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:viewModels="clr-namespace:TimedSequenceEditor.Forms.WPF.MarksDocker.ViewModels"
         xmlns:views="clr-namespace:TimedSequenceEditor.Forms.WPF.MarksDocker.Views"
-        mc:Ignorable="d"  WindowStartupLocation="CenterOwner" 
+        mc:Ignorable="d"  WindowStartupLocation="CenterScreen"
               CanCloseUsingEscape="True" WindowStyle="ToolWindow"
         Title="Export Mark Collections" Height="400" Width="600">
 
@@ -27,9 +27,13 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Vertical">
-                <Label Content="Select Mark Collections To Export" FontWeight="Bold"/>
-                <ScrollViewer DockPanel.Dock="Bottom" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Black">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Label Grid.Row="0" Content="Select Mark Collections To Export" FontWeight="Bold"/>
+                <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Black">
                     <Border Margin="1" BorderBrush="{StaticResource BackColorBrush}" BorderThickness="1">
                         <Grid Grid.IsSharedSizeScope="True">
                             <Grid.Resources>
@@ -61,7 +65,7 @@
                         </Grid>
                     </Border>
                 </ScrollViewer>
-            </StackPanel>
+            </Grid>
 
             <StackPanel Grid.Column="1" Orientation="Vertical">
                 <Border BorderThickness="1">


### PR DESCRIPTION
- The color picker is now seeded with the current color of the Mark Collection when the user edits the color.
- Replace the StackPanel with a Grid so the scrollviewer will work. The StackPanel would just keep growing.
- Add CenterScreen to the Export dialog to force it to open in the center of the screen instead of some random location.