### PR TITLE
VIX-3503 Fix divide-by-zero in Icicles template generation

### DIFF
--- a/src/Vixen.Application/Setup/ElementTemplates/Icicles.Designer.cs
+++ b/src/Vixen.Application/Setup/ElementTemplates/Icicles.Designer.cs
@@ -212,6 +212,7 @@
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
 			this.Text = "Icicles Setup";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Icicles_FormClosed);
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Icicles_FormClosing);
 			this.Load += new System.EventHandler(this.Icicles_Load);
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDownStrings)).EndInit();
 			this.ResumeLayout(false);

--- a/src/Vixen.Application/Setup/ElementTemplates/Icicles.cs
+++ b/src/Vixen.Application/Setup/ElementTemplates/Icicles.cs
@@ -1,4 +1,5 @@
-﻿using Common.Controls.Theme;
+﻿using Common.Controls;
+using Common.Controls.Theme;
 using NLog;
 using Vixen.Rule;
 using Vixen.Services;
@@ -66,6 +67,12 @@ namespace VixenApplication.Setup.ElementTemplates
 			//Grabs the individual string sizes and removes any empty ones just in case the user entered something like 4,5,,9
 			string[] pixelsPerStringArray = _pixelsPerStringPattern.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
+			if (pixelsPerStringArray.Length == 0)
+			{
+				Logging.Error("pixels per string pattern is empty or invalid");
+				return await Task.FromResult(result);
+			}
+
 			//Loops through the number of Strings to be added.
 			for (int i = 0; i < _stringCount; i++)
 			{
@@ -103,6 +110,22 @@ namespace VixenApplication.Setup.ElementTemplates
 			textBoxTreeName.Text = _treeName;
 			numericUpDownStrings.Value = _stringCount;
 			textBoxStringPattern.Text = _pixelsPerStringPattern;
+		}
+
+		private void Icicles_FormClosing(object sender, FormClosingEventArgs e)
+		{
+			if (DialogResult != DialogResult.OK)
+				return;
+
+			string[] pixelsPerStringArray = textBoxStringPattern.Text.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+
+			if (pixelsPerStringArray.Length == 0)
+			{
+				var messageBox = new MessageBoxForm("Please enter at least one pixel count in the String Pattern field, e.g. 7,9,5.",
+					"Invalid String Pattern", MessageBoxButtons.OK, SystemIcons.Warning);
+				messageBox.ShowDialog();
+				e.Cancel = true;
+			}
 		}
 
 		private void Icicles_FormClosed(object sender, FormClosedEventArgs e)


### PR DESCRIPTION
An empty or invalid Pixels/String Pattern field caused a DivideByZeroException when generating elements, since the parsed pattern array had zero entries and was used as a modulo divisor.

Guard GenerateElements against an empty pattern array, and validate the field on dialog close using the standard MessageBoxForm so users can correct it before generation runs.