### PR TITLE
VIX-2369 Fix effect resize edge snapping

### DIFF
--- a/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid.cs
@@ -1862,6 +1862,9 @@ namespace Common.Controls.Timeline
 						if (details.SnapRow != null && details.SnapRow != thisElementsRow)
 							continue;
 
+						if (ShouldIgnoreSnapPointForResize(details, orig, resize))
+							continue;
+
 						// figure out if the element start time or end times are in the snap range; if not, skip it
 						bool startInRange = (orig.StartTime + offset > details.SnapStart && orig.StartTime + offset < details.SnapEnd);
 						bool endInRange = (orig.EndTime + offset > details.SnapStart && orig.EndTime + offset < details.SnapEnd);
@@ -1895,6 +1898,18 @@ namespace Common.Controls.Timeline
 			}
 
 			return snappedOffset;
+		}
+
+		private static bool ShouldIgnoreSnapPointForResize(SnapDetails details, ElementTimeInfo originalTimeInfo, ResizeZone resize)
+		{
+			if (details.ElementEdge == ElementSnapEdge.None)
+				return false;
+
+			return resize switch {
+				ResizeZone.Front => details.ElementEdge == ElementSnapEdge.Start && details.SnapTime == originalTimeInfo.EndTime,
+				ResizeZone.Back => details.ElementEdge == ElementSnapEdge.End && details.SnapTime == originalTimeInfo.StartTime,
+				_ => false
+			};
 		}
 
 		public void SwapElementPlacement(Dictionary<Element, ElementTimeInfo> changedElements)
@@ -2794,6 +2809,14 @@ namespace Common.Controls.Timeline
 		public Color SnapColor; // the color to draw the snap point
 		public bool SnapBold; // snap point is bold
 		public bool SnapSolidLine; // snap point is a solidline or dotted
+		internal ElementSnapEdge ElementEdge; // the element edge that created this snap point, if any
+	}
+
+	internal enum ElementSnapEdge
+	{
+		None,
+		Start,
+		End
 	}
 
 	///<summary>Maintains all necessary information during the user modification of selected Elements.</summary>

--- a/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
+++ b/src/Vixen.Common/Controls/TimeLineControl/Grid_Mouse.cs
@@ -731,6 +731,7 @@ namespace Common.Controls.Timeline
 					// row its from in the generated point, so when snapping we can check against only elements from this row.
 					SnapDetails details = CalculateSnapDetailsForPoint(element.StartTime, SnapPriorityForElements, Color.Empty, false, false);
 					details.SnapRow = row;
+					details.ElementEdge = ElementSnapEdge.Start;
 
 					if (!CurrentDragSnapPoints.ContainsKey(details.SnapTime)) {
 						CurrentDragSnapPoints[details.SnapTime] = new List<SnapDetails>();
@@ -739,6 +740,7 @@ namespace Common.Controls.Timeline
 
 					details = CalculateSnapDetailsForPoint(element.EndTime, SnapPriorityForElements, Color.Empty, false, false);
 					details.SnapRow = row;
+					details.ElementEdge = ElementSnapEdge.End;
 
 					if (!CurrentDragSnapPoints.ContainsKey(details.SnapTime)) {
 						CurrentDragSnapPoints[details.SnapTime] = new List<SnapDetails>();


### PR DESCRIPTION
Adjacent effects could snap a resized edge to the fixed edge of the selected effect, causing the duration to jump to the minimum width when shortening an effect beside another effect.

Track whether generated effect snap points come from an effect start or end, and ignore the opposing fixed-edge snap during resize while preserving normal mark and edge snapping.