### PR TITLE
VIX-580 Adjust the Color property setup to use the helper workflow

### DIFF
--- a/src/Vixen.Application/Setup/SetupElementsTree.cs
+++ b/src/Vixen.Application/Setup/SetupElementsTree.cs
@@ -13,6 +13,7 @@ using Vixen.Services;
 using Vixen.Sys;
 using Vixen.Sys.Output;
 using VixenModules.App.Modeling;
+using VixenModules.Property.Color;
 
 namespace VixenApplication.Setup
 {
@@ -218,7 +219,15 @@ namespace VixenApplication.Setup
 				if (property != null)
 				{
 
-					if (property.HasSetup)
+					// This is a bit of a hack to ensure the color property edits update any color breakdown patching
+					if (property is ColorModule cm)
+					{
+						ColorSetupHelper helper = new ColorSetupHelper();
+						helper.SetupColors(cm.ColorType, cm.ColorSetName, cm.SingleColor);
+						helper.Perform(SelectedElements);
+						OnElementsChanged(new ElementsChangedEventArgs(ElementsChangedEventArgs.ElementsChangedAction.Edit));
+					}
+					else if (property.HasSetup)
 					{
 						result = property.Setup();
 						if (result)

--- a/src/Vixen.Modules/Property/Color/ColorSetupHelper.cs
+++ b/src/Vixen.Modules/Property/Color/ColorSetupHelper.cs
@@ -17,6 +17,7 @@ namespace VixenModules.Property.Color
 		private const string Green = "Green";
 		private const string Blue = "Blue";
 		private const string White = "White";
+		private string _colorSetNameSelectedItem = string.Empty;
 
 		public ColorSetupHelper()
 		{
@@ -301,6 +302,24 @@ namespace VixenModules.Property.Color
 			}
 		}
 
+		public void SetupColors(ElementColorType colorType, string colorSetName, System.Drawing.Color singleColor)
+		{
+			switch (colorType)
+			{
+				case ElementColorType.FullColor:
+					radioButtonOptionFullColor.Checked = true;
+					break;
+				case ElementColorType.MultipleDiscreteColors:
+					radioButtonOptionMultiple.Checked = true;
+					_colorSetNameSelectedItem = colorSetName;
+					break;
+				default:
+					radioButtonOptionSingle.Checked = true;
+					colorPanelSingleColor.Color = singleColor;
+					break;
+			}
+		}
+
 		public void SetColorType(ElementColorType colorType)
 		{
 			switch (colorType)
@@ -354,6 +373,11 @@ namespace VixenModules.Property.Color
 
 			if (comboBoxColorSet.SelectedIndex < 0) {
 				comboBoxColorSet.SelectedIndex = 0;
+			}
+
+			if (_colorSetNameSelectedItem != string.Empty)
+			{
+				comboBoxColorSet.SelectedItem = _colorSetNameSelectedItem;
 			}
 
 			comboBoxColorSet.EndUpdate();


### PR DESCRIPTION
Add logic to intercept the color property setup and invoke the helper workflow that is used in most places. This is more familiar to the user can can also reconfigure the breakdown filter.