### PR TITLE
VIX-2686 Fix center hole bug when size is zero

### DIFF
--- a/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
@@ -540,7 +540,7 @@ namespace VixenModules.Effect.PinWheel
 		private double CalculateCenterStartPct(double intervalPos)
 		{
 			var value = CenterHubCurve.GetValue(intervalPos);
-			if (value < 1) value = 1;
+			if (value < 0) value = 0;
 
 			return value/100.0;
 		}


### PR DESCRIPTION
PinWheel center hub size was never allowed to render as zero. CalculateCenterStartPct forced any value below 1 up to 1, so a user-configured Center Hub value of 0 became 1%. Because the render logic applies the hub as a percentage of maxRadius, and maxRadius increases with the PinWheel Size, the forced 1% center gap became larger as the pinwheel size increased. Fix: allow zero as a valid center hub value by changing the clamp from < 1 => 1 to < 0 => 0. This preserves negative-value protection while making Center Hub = 0 render as no hub gap.