### PR TITLE
VIX-3950 Prevent stale curve drag state

### DIFF
--- a/src/Vixen.Common/WPFCommon/Input/DragDropManager.cs
+++ b/src/Vixen.Common/WPFCommon/Input/DragDropManager.cs
@@ -204,70 +204,95 @@ namespace Common.WPFCommon.Input
 
 		private static void DragSource_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
 		{
+			ResetDragSourceState();
 			if (e.ClickCount > 1) return;
-			// Make this the new drag source
-			CurrentDragSourceAdvisor = GetDragSourceAdvisor(sender as DependencyObject);
-			CurrentDragSourceAdvisor.SourceUI = sender as UIElement;
 
-			if (CurrentDragSourceAdvisor.IsDraggable(e.OriginalSource as UIElement) == false)
+			// Make this the new drag source
+			var dragSourceAdvisor = GetDragSourceAdvisor(sender as DependencyObject);
+			if (dragSourceAdvisor == null) return;
+
+			dragSourceAdvisor.SourceUI = sender as UIElement;
+
+			if (dragSourceAdvisor.IsDraggable(e.OriginalSource as UIElement) == false)
 			{
+				dragSourceAdvisor.SourceUI = null;
 				return;
 			}
 
+			CurrentDragSourceAdvisor = dragSourceAdvisor;
 			_draggedElt = e.OriginalSource as UIElement;
 		
-			_dragStartPoint = e.GetPosition(CurrentDragSourceAdvisor.GetTopContainer());
+			_dragStartPoint = e.GetPosition(dragSourceAdvisor.GetTopContainer());
 			_offsetPoint = e.GetPosition(_draggedElt);
 			_isMouseDown = true;
 		}
 
 		private static void DragSource_PreviewMouseMove(object sender, MouseEventArgs e)
 		{
-			if (_isMouseDown && CurrentDragSourceAdvisor != null &&
-			    IsDragGesture(e.GetPosition(CurrentDragSourceAdvisor.GetTopContainer())))
+			if (e.LeftButton != MouseButtonState.Pressed)
+			{
+				ResetDragSourceState();
+				return;
+			}
+
+			if (!_isMouseDown) return;
+			if (CurrentDragSourceAdvisor == null)
+			{
+				ResetDragSourceState();
+				return;
+			}
+
+			var isDragGesture = IsDragGesture(e.GetPosition(CurrentDragSourceAdvisor.GetTopContainer()));
+			if (ShouldStartDrag(_isMouseDown, e.LeftButton, isDragGesture))
 			{
 				DragStarted(sender as UIElement);
 			}
-			//else
-			//{
-			//	//Mouse.Capture(null);
-			//}
 		}
 
 		private static void DragSource_PreviewMouseUp(object sender, MouseButtonEventArgs e)
 		{
-			_isMouseDown = false;
-			_draggedElt = null;
-			if (CurrentDragSourceAdvisor != null)
-			{
-				CurrentDragSourceAdvisor.SourceUI = null;
-				CurrentDragSourceAdvisor = null;
-			}
-			//Mouse.Capture(null);
+			ResetDragSourceState();
 			e.Handled = false;
 		}
 
 		private static void DragStarted(UIElement uiElt)
 		{
 			_isMouseDown = false;
-			if (uiElt == null || _draggedElt == null) return;
-			//Mouse.Capture(uiElt);
+			if (uiElt == null || _draggedElt == null || CurrentDragSourceAdvisor == null)
+			{
+				ResetDragSourceState();
+				return;
+			}
 
-			DataObject data = CurrentDragSourceAdvisor.GetDataObject(_draggedElt);
+			var draggedElement = _draggedElt;
+			var dragSourceAdvisor = CurrentDragSourceAdvisor;
 
-			data.SetData(DragOffsetFormat, _offsetPoint);
-			DragDropEffects supportedEffects = CurrentDragSourceAdvisor.SupportedEffects;
+			try
+			{
+				var data = dragSourceAdvisor.GetDataObject(draggedElement);
 
-			// Perform DragDrop
+				data.SetData(DragOffsetFormat, _offsetPoint);
+				var supportedEffects = dragSourceAdvisor.SupportedEffects;
 
-			DragDropEffects effects = DragDrop.DoDragDrop(_draggedElt, data, supportedEffects);
-			CurrentDragSourceAdvisor.FinishDrag(_draggedElt, effects);
-
-			// Clean up
-			RemovePreviewAdorner();
-			//Mouse.Capture(null);
-			_draggedElt = null;
+				// Perform DragDrop
+				var effects = DragDrop.DoDragDrop(draggedElement, data, supportedEffects);
+				dragSourceAdvisor.FinishDrag(draggedElement, effects);
+			}
+			finally
+			{
+				try
+				{
+					RemovePreviewAdorner();
+				}
+				finally
+				{
+					ResetDragSourceState();
+				}
+			}
 		}
+
+		internal static bool ShouldStartDrag(bool isMouseDown, MouseButtonState leftButtonState, bool isDragGesture) =>
+			isMouseDown && leftButtonState == MouseButtonState.Pressed && isDragGesture;
 
 		private static bool IsDragGesture(Point point)
 		{
@@ -277,6 +302,18 @@ namespace Common.WPFCommon.Input
 			                SystemParameters.MinimumVerticalDragDistance;
 
 			return (hGesture | vGesture);
+		}
+
+		private static void ResetDragSourceState()
+		{
+			_isMouseDown = false;
+			_draggedElt = null;
+
+			if (CurrentDragSourceAdvisor != null)
+			{
+				CurrentDragSourceAdvisor.SourceUI = null;
+				CurrentDragSourceAdvisor = null;
+			}
 		}
 
 		/* ____________________________________________________________________

--- a/src/Vixen.Common/WPFCommon/WPFCommon.csproj
+++ b/src/Vixen.Common/WPFCommon/WPFCommon.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	  <InternalsVisibleTo Include="Vixen.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Catel.Core" />
     <PackageReference Include="Catel.MVVM" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />

--- a/src/Vixen.Tests/Common/WPFCommon/DragDropManagerTests.cs
+++ b/src/Vixen.Tests/Common/WPFCommon/DragDropManagerTests.cs
@@ -1,0 +1,30 @@
+using System.Windows.Input;
+using Common.WPFCommon.Input;
+using Xunit;
+
+namespace Vixen.Tests.Common.WPFCommon;
+
+public sealed class DragDropManagerTests
+{
+	[Fact]
+	public void ShouldStartDrag_WhenMouseIsDownAndButtonIsPressedAndMovementIsDragGesture_ReturnsTrue()
+	{
+		var result = DragDropManager.ShouldStartDrag(true, MouseButtonState.Pressed, true);
+
+		Assert.True(result);
+	}
+
+	[Theory]
+	[InlineData(false, MouseButtonState.Pressed, true)]
+	[InlineData(true, MouseButtonState.Released, true)]
+	[InlineData(true, MouseButtonState.Pressed, false)]
+	public void ShouldStartDrag_WhenAnyRequiredConditionIsMissing_ReturnsFalse(
+		bool isMouseDown,
+		MouseButtonState leftButtonState,
+		bool isDragGesture)
+	{
+		var result = DragDropManager.ShouldStartDrag(isMouseDown, leftButtonState, isDragGesture);
+
+		Assert.False(result);
+	}
+}

--- a/src/Vixen.Tests/Vixen.Tests.csproj
+++ b/src/Vixen.Tests/Vixen.Tests.csproj
@@ -21,6 +21,7 @@
 		<ProjectReference Include="..\Vixen.Common\Controls\Controls.csproj" />
 		<ProjectReference Include="..\Vixen.Common\Messages\Messages.csproj" />
 		<ProjectReference Include="..\Vixen.Common\Utilities\Utilities.csproj" />
+		<ProjectReference Include="..\Vixen.Common\WPFCommon\WPFCommon.csproj" />
 		<ProjectReference Include="..\Vixen.Core\Vixen.Core.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\App\CustomPropEditor\CustomPropEditor.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\App\FPPClient\FPPClient.csproj" />


### PR DESCRIPTION
Inline curve editing could leave the shared drag manager armed when mouse capture routed the button-up event away from the source image. Hovering a nearby curve could then copy the edited value without an intentional drag.

Require an active left-button gesture and clear pending drag state on every completion or cancellation path. Add regression coverage for valid and invalid drag-start conditions.