### PR TITLE
VIX-3953 Defer State property attachment

### DIFF
--- a/src/Vixen.Modules/Property/State/Setup/Services/IStateMapperDialogService.cs
+++ b/src/Vixen.Modules/Property/State/Setup/Services/IStateMapperDialogService.cs
@@ -1,0 +1,17 @@
+using Vixen.Sys;
+
+namespace VixenModules.Property.State.Setup.Services;
+
+/// <summary>
+/// Displays the State mapper for an element node.
+/// </summary>
+internal interface IStateMapperDialogService
+{
+	/// <summary>
+	/// Displays the mapper for the supplied State property data.
+	/// </summary>
+	/// <param name="node">The element node being configured.</param>
+	/// <param name="data">The State property data to configure.</param>
+	/// <returns><see langword="true" /> if the mapper is accepted; otherwise, <see langword="false" />.</returns>
+	bool Show(IElementNode node, StateData data);
+}

--- a/src/Vixen.Modules/Property/State/Setup/Services/StateMapperDialogService.cs
+++ b/src/Vixen.Modules/Property/State/Setup/Services/StateMapperDialogService.cs
@@ -1,0 +1,28 @@
+using System.Windows.Forms;
+using System.Windows.Forms.Integration;
+using System.Windows.Interop;
+using Vixen.Sys;
+using VixenModules.Property.State.Setup.ViewModels;
+using VixenModules.Property.State.Setup.Views;
+
+namespace VixenModules.Property.State.Setup.Services;
+
+/// <summary>
+/// Displays the WPF State mapper dialog.
+/// </summary>
+internal sealed class StateMapperDialogService : IStateMapperDialogService
+{
+	/// <inheritdoc />
+	public bool Show(IElementNode node, StateData data)
+	{
+		var viewModel = new StateMapperViewModel(node, data, new StateColorPickerService());
+		var mapper = new StateMapperView(viewModel);
+		if (Form.ActiveForm != null)
+		{
+			new WindowInteropHelper(mapper).Owner = Form.ActiveForm.Handle;
+		}
+
+		ElementHost.EnableModelessKeyboardInterop(mapper);
+		return mapper.ShowDialog() == true;
+	}
+}

--- a/src/Vixen.Modules/Property/State/StateSetupHelper.cs
+++ b/src/Vixen.Modules/Property/State/StateSetupHelper.cs
@@ -1,20 +1,45 @@
-using System.Windows.Forms.Integration;
-using System.Windows.Interop;
 using Common.Controls;
+using Vixen.Module.Property;
 using Vixen.Rule;
+using Vixen.Services;
 using Vixen.Sys;
 using VixenModules.Property.State.Setup.Services;
-using VixenModules.Property.State.Setup.ViewModels;
-using VixenModules.Property.State.Setup.Views;
 
 namespace VixenModules.Property.State
 {
+	/// <summary>
+	/// Configures State properties for a selected element node.
+	/// </summary>
 	public class StateSetupHelper: IElementSetupHelper
 	{
+		private readonly Func<IPropertyModuleInstance?> _stateModuleFactory;
+		private readonly IStateMapperDialogService _dialogService;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="StateSetupHelper"/> class.
+		/// </summary>
+		public StateSetupHelper()
+			: this(CreateStateModule, new StateMapperDialogService())
+		{
+		}
+
+		internal StateSetupHelper(
+			Func<IPropertyModuleInstance?> stateModuleFactory,
+			IStateMapperDialogService dialogService)
+		{
+			ArgumentNullException.ThrowIfNull(stateModuleFactory);
+			ArgumentNullException.ThrowIfNull(dialogService);
+
+			_stateModuleFactory = stateModuleFactory;
+			_dialogService = dialogService;
+		}
+
 		#region Implementation of IElementSetupHelper
 
+		/// <inheritdoc />
 		public string HelperName { get { return "State Mapping"; } }
 		
+		/// <inheritdoc />
 		public bool Perform(IEnumerable<IElementNode> nodes)
 		{
 			var selectedNodes = nodes.Take(2).ToList();
@@ -26,31 +51,70 @@ namespace VixenModules.Property.State
 				return false;
 			}
 
-			var data = new StateData();
 			var node = selectedNodes[0];
 			if (node.Properties.Contains(StateDescriptor.ModuleId))
 			{
-				if (node.Properties.Get(StateDescriptor.ModuleId)?.ModuleData is StateData existingData)
-				{
-					data = existingData;
-				}
-			}
-			var vm = new StateMapperViewModel(node, data, new StateColorPickerService());
-			var mapper = new StateMapperView(vm);
-			if (Form.ActiveForm != null)
-			{
-				new WindowInteropHelper(mapper).Owner = Form.ActiveForm.Handle;
+				return node.Properties.Get(StateDescriptor.ModuleId)?.ModuleData is StateData existingData &&
+				       ShowMapper(node, existingData);
 			}
 
-			ElementHost.EnableModelessKeyboardInterop(mapper);
-			var response = mapper.ShowDialog();
-			if (response == true)
+			IPropertyModuleInstance? stateModule = null;
+			StateData? stateData = null;
+			try
 			{
-				var sm = node.Properties.Add(StateDescriptor.ModuleId) as StateModule;
-				sm?.ModuleData = data;
+				stateModule = _stateModuleFactory();
+				if (stateModule?.ModuleData is StateData data)
+				{
+					stateData = data;
+				}
 			}
-			
-			return response == true;
+			catch
+			{
+				stateModule?.Dispose();
+				return false;
+			}
+
+			if (stateModule is null || stateData is null)
+			{
+				stateModule?.Dispose();
+				return false;
+			}
+
+			bool accepted;
+			try
+			{
+				accepted = ShowMapper(node, stateData);
+			}
+			catch
+			{
+				stateModule.Dispose();
+				return false;
+			}
+
+			if (!accepted)
+			{
+				stateModule.Dispose();
+				return false;
+			}
+
+			node.Properties.AddWithoutDefaults(stateModule);
+			if (ReferenceEquals(node.Properties.Get(StateDescriptor.ModuleId), stateModule))
+			{
+				return true;
+			}
+
+			stateModule.Dispose();
+			return false;
+		}
+
+		private static IPropertyModuleInstance? CreateStateModule()
+		{
+			return ApplicationServices.Get<IPropertyModuleInstance>(StateDescriptor.ModuleId);
+		}
+
+		private bool ShowMapper(IElementNode node, StateData data)
+		{
+			return _dialogService.Show(node, data);
 		}
 
 		#endregion

--- a/src/Vixen.Tests/Property/State/StateSetupHelperTests.cs
+++ b/src/Vixen.Tests/Property/State/StateSetupHelperTests.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using Moq;
+using Vixen.Module;
+using Vixen.Module.Property;
+using Vixen.Sys;
+using VixenModules.Property.State;
+using VixenModules.Property.State.Setup.Services;
+using Xunit;
+
+namespace Vixen.Tests.Property.State;
+
+[Collection(StateMapperTestCollection.Name)]
+public sealed class StateSetupHelperTests
+{
+	[Fact]
+	public void Perform_NewPropertyAccepted_AttachesConfiguredModuleWithOriginalDataReference()
+	{
+		// Arrange
+		InitializeModuleStore();
+		var node = CreateNode();
+		var stateModule = CreateStateModule();
+		var expectedData = Assert.IsType<StateData>(stateModule.ModuleData);
+		var dialogService = new RecordingStateMapperDialogService(true, data => data.Id = Guid.NewGuid());
+		var helper = new StateSetupHelper(() => stateModule, dialogService);
+
+		// Act
+		var result = helper.Perform([node]);
+
+		// Assert
+		Assert.True(result);
+		Assert.Same(expectedData, dialogService.Data);
+		var attachedModule = node.Properties.Get(StateDescriptor.ModuleId);
+		Assert.Same(stateModule, attachedModule);
+		Assert.Same(expectedData, attachedModule!.ModuleData);
+	}
+
+	[Fact]
+	public void Perform_NewPropertyCancelled_AttachesNothing()
+	{
+		// Arrange
+		var node = CreateNode();
+		var stateModule = CreateStateModule();
+		var helper = new StateSetupHelper(() => stateModule, new RecordingStateMapperDialogService(false));
+
+		// Act
+		var result = helper.Perform([node]);
+
+		// Assert
+		Assert.False(result);
+		Assert.False(node.Properties.Contains(StateDescriptor.ModuleId));
+	}
+
+	[Fact]
+	public void Perform_ExistingPropertyAccepted_MutatesExistingDataInstance()
+	{
+		// Arrange
+		var node = CreateNode();
+		var stateModule = CreateStateModule();
+		var data = Assert.IsType<StateData>(stateModule.ModuleData);
+		AddPropertyWithoutModuleStore(node.Properties, stateModule);
+		var helper = new StateSetupHelper(
+			() => throw new InvalidOperationException("A new module must not be created."),
+			new RecordingStateMapperDialogService(true, stateData => stateData.Id = Guid.NewGuid()));
+
+		// Act
+		var result = helper.Perform([node]);
+
+		// Assert
+		Assert.True(result);
+		Assert.Same(data, node.Properties.Get(StateDescriptor.ModuleId)!.ModuleData);
+		Assert.NotEqual(Guid.Empty, data.Id);
+	}
+
+	[Fact]
+	public void Perform_ExistingPropertyCancelled_PreservesExistingData()
+	{
+		// Arrange
+		var node = CreateNode();
+		var stateModule = CreateStateModule();
+		var data = Assert.IsType<StateData>(stateModule.ModuleData);
+		var originalId = data.Id;
+		AddPropertyWithoutModuleStore(node.Properties, stateModule);
+		var helper = new StateSetupHelper(
+			() => throw new InvalidOperationException("A new module must not be created."),
+			new RecordingStateMapperDialogService(false, stateData => stateData.Id = Guid.NewGuid()));
+
+		// Act
+		var result = helper.Perform([node]);
+
+		// Assert
+		Assert.False(result);
+		Assert.Same(data, node.Properties.Get(StateDescriptor.ModuleId)!.ModuleData);
+		Assert.Equal(originalId, data.Id);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void Perform_InvalidNewModuleCreation_ReturnsFalse(bool returnsInvalidData)
+	{
+		// Arrange
+		var node = CreateNode();
+		var dialogService = new RecordingStateMapperDialogService(true);
+		var helper = new StateSetupHelper(
+			returnsInvalidData ? CreateInvalidDataModule : () => null,
+			dialogService);
+
+		// Act
+		var result = helper.Perform([node]);
+
+		// Assert
+		Assert.False(result);
+		Assert.Null(dialogService.Data);
+		Assert.False(node.Properties.Contains(StateDescriptor.ModuleId));
+	}
+
+	private static IElementNode CreateNode()
+	{
+		var node = new Mock<IElementNode>();
+		var properties = new PropertyManager(node.Object);
+		node.SetupGet(elementNode => elementNode.Properties).Returns(properties);
+
+		return node.Object;
+	}
+
+	private static StateModule CreateStateModule()
+	{
+		return new StateModule { Descriptor = new StateDescriptor() };
+	}
+
+	private static IPropertyModuleInstance CreateInvalidDataModule()
+	{
+		var module = new Mock<IPropertyModuleInstance>();
+		module.SetupGet(instance => instance.ModuleData).Returns(Mock.Of<IModuleDataModel>());
+
+		return module.Object;
+	}
+
+	private static void AddPropertyWithoutModuleStore(PropertyManager properties, IPropertyModuleInstance property)
+	{
+		var itemsField = typeof(PropertyManager).GetField("_items", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(itemsField);
+		var items = Assert.IsType<Dictionary<Guid, IPropertyModuleInstance>>(itemsField.GetValue(properties));
+		items[property.TypeId] = property;
+	}
+
+	private static void InitializeModuleStore()
+	{
+		var moduleStoreProperty = typeof(VixenSystem).GetProperty("ModuleStore", BindingFlags.Static | BindingFlags.NonPublic);
+		Assert.NotNull(moduleStoreProperty);
+		moduleStoreProperty.SetValue(null, new ModuleStore());
+	}
+
+	private sealed class RecordingStateMapperDialogService(bool result, Action<StateData>? configure = null) : IStateMapperDialogService
+	{
+		public StateData? Data { get; private set; }
+
+		public bool Show(IElementNode node, StateData data)
+		{
+			Data = data;
+			if (result)
+			{
+				configure?.Invoke(data);
+			}
+
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
Avoid attaching a default State property before its mapper is accepted, so canceling leaves the element unchanged.

Attach the configured module only after confirmation and add coverage for accepted, canceled, and invalid creation flows.