### PR TITLE
VIX-2451 Add disable logic

### DIFF
--- a/src/Vixen.Modules/App/LipSyncApp/LipSyncMapSelector.cs
+++ b/src/Vixen.Modules/App/LipSyncApp/LipSyncMapSelector.cs
@@ -239,7 +239,7 @@ namespace VixenModules.App.LipSyncApp
 		{
 			buttonEditMap.Enabled = (mappingsListView.SelectedIndices.Count == 1);
 			buttonCloneMap.Enabled = (mappingsListView.SelectedIndices.Count >= 1);
-			buttonDeleteMap.Enabled = (mappingsListView.SelectedIndices.Count >= 1);
+			buttonDeleteMap.Enabled = (mappingsListView.Items.Count > 1) && (mappingsListView.SelectedIndices.Count >= 1);
 		}
 
 		private void mappingsListView_AfterLabelEdit(object sender, LabelEditEventArgs e)


### PR DESCRIPTION
The Remove button would be enabled, but the logic would silently refuse to remove the last map. Now the button mimics the rule and is disabled when only one is left.