### PR TITLE
VIX-3973 Fix fixture function editor crash

### DIFF
--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorViewModel.cs
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/ViewModels/FixturePropertyEditorViewModel.cs
@@ -26,7 +26,7 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 			Functions = new ObservableCollection<string>();
 
 			// Create button commands
-			EditFunctionsCommand = new Command(EditFunctions);
+			EditFunctionsCommand = new Command<ChannelItemViewModel>(EditFunctions, channel => channel != null);
 			LoadSpecificationCommand = new Command(LoadSpecification);			
 
 			// Create the collection of allowable channel numbers
@@ -464,16 +464,17 @@ namespace VixenModules.Editor.FixturePropertyEditor.ViewModels
 		/// <summary>
 		/// Edits the functions associated with this fixture.
 		/// </summary>
-		private void EditFunctions()
+		private void EditFunctions(ChannelItemViewModel channelItem)
 		{	
-			// Create the function type editor window indicating which function to select
-			FunctionTypeWindowView view = new FunctionTypeWindowView(_fixtureSpecification.FunctionDefinitions, SelectedItem.Function);
+			var view = new FunctionTypeWindowView(
+				_fixtureSpecification.FunctionDefinitions,
+				channelItem.Function);
 
 			// Display the function type editor window
 			bool? result = view.ShowDialog();
 
 			// If the user selected to commit the function changes then...
-			if (result.Value)
+			if (result == true)
 			{
 				// Retrieve the function data
 				_fixtureSpecification.FunctionDefinitions = view.GetFunctionData();

--- a/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorView.xaml
+++ b/src/Vixen.Modules/Editor/FixturePropertyEditor/Views/FixturePropertyEditorView.xaml
@@ -141,8 +141,8 @@
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Button Command="{Binding Path=EditFunctionsCommand}"
-										ToolTip="Select to Edit the function associated with the channel."
-										>
+                                        CommandParameter="{Binding}"
+										ToolTip="Select to Edit the function associated with the channel.">
                                     <Image Source="{Binding Path=EditFunctionsImageSource}"/>
                                 </Button>
                             </DataTemplate>


### PR DESCRIPTION
Pass the channel row to the edit command so the function editor does not depend on DataGrid selection state.

Treat a dialog closed without a result as cancellation to prevent a nullable result exception.