### PR TITLE
VIX-3978 Text/Numeric editors focus lost commit

### DIFF
--- a/docs/reviews/integral-editor-design-review.md
+++ b/docs/reviews/integral-editor-design-review.md
@@ -1,0 +1,35 @@
+# Integral editor design review
+
+## Context
+
+`IntegerEditor` is a WPF control whose dependency properties and calculation fields are currently
+typed as `int`. The Effect Editor also needs the same interaction model for `byte`, `ushort`, `uint`,
+and `ulong` properties without maintaining a control and resource dictionary for every numeric type.
+
+## Options considered
+
+### Generic WPF control
+
+An `IntegerEditor<T>` could share its C# implementation through generic math. However, WPF resource
+dictionaries cannot instantiate or target an open generic type. Each supported closed type would
+still need a concrete XAML-visible control type, style registration, and editor resource entry. This
+moves duplication instead of eliminating it and makes editor discovery more complex.
+
+### One runtime-typed integral control
+
+Keep one `IntegerEditor` control and one XAML template. Its `Value` dependency property can accept a
+boxed supported integral value, remember that runtime type, perform calculations using `decimal`,
+and convert the result back to the original integral type before the two-way binding updates the
+property model. `decimal` is appropriate for the internal calculation because it represents the
+entire `ulong` range exactly.
+
+## Recommendation
+
+Use the runtime-typed control. Register each supported property type in `EditorCollection` with its
+actual edited type and the existing integer editor key. Intersect configured `NumberRange` limits
+with the intrinsic limits of the runtime value type, preventing overflow even when no range metadata
+is present. Retain `IntegerEditor` as the public control name to avoid unnecessary XAML and API churn.
+
+This design uses the Strategy pattern at the conversion boundary: the runtime integral type selects
+the appropriate bounds and result conversion while the editor interaction remains shared. It keeps
+the control cohesive, preserves exact values, and requires no factory or dependency-injection changes.

--- a/src/Vixen.Modules/Editor/EffectEditor/Controls/IntegerEditor.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/Controls/IntegerEditor.cs
@@ -15,6 +15,7 @@
  */
 
 using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -33,10 +34,12 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		private Point _dragStartPoint;
 		private Point _lastDragPoint;
 
-		private int _changeValue;
-		private double _changeOffset;
+		private decimal _changeValue;
+		private decimal _changeOffset;
 		private bool _isMouseDown;
-		private int _holdValue ;
+		private bool _isUpdatingText;
+		private decimal _holdValue;
+		private Type _valueType = typeof(int);
 
 		private const double DragTolerance = 2.0;
 
@@ -101,38 +104,44 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// <summary>
 		/// Identifies the <see cref="Value"/> dependency property.
 		/// </summary>
-		public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof (int), ThisType,
-			new PropertyMetadata(0, ValueChanged));
+		public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(object), ThisType,
+			new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, ValueChanged, CoerceValue));
+
+		/// <summary>
+		/// Identifies the <see cref="Text"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), ThisType,
+			new FrameworkPropertyMetadata("0", FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, TextChanged));
 
 		/// <summary>
 		/// Identifies the <see cref="SmallChange"/> dependency property.
 		/// </summary>
 		public static readonly DependencyProperty SmallChangeProperty = DependencyProperty.Register("SmallChange",
-			typeof (int), ThisType, new PropertyMetadata(1));
+			typeof(double), ThisType, new PropertyMetadata(1.0));
 
 		/// <summary>
 		/// Identifies the <see cref="LargeChange"/> dependency property.
 		/// </summary>
 		public static readonly DependencyProperty LargeChangeProperty = DependencyProperty.Register("LargeChange",
-			typeof (int), ThisType, new PropertyMetadata(1));
+			typeof(double), ThisType, new PropertyMetadata(1.0));
 
 		/// <summary>
 		/// Identifies the <see cref="DefaultChange"/> dependency property.
 		/// </summary>
 		public static readonly DependencyProperty DefaultChangeProperty = DependencyProperty.Register("DefaultChange",
-			typeof (int), ThisType, new PropertyMetadata(1));
+			typeof(double), ThisType, new PropertyMetadata(1.0));
 
 		/// <summary>
 		/// Identifies the <see cref="Minimum"/> dependency property.
 		/// </summary>
-		public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register("Minimum", typeof (int),
-			ThisType, new PropertyMetadata(0, OnMinimumChanged));
+		public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register("Minimum", typeof(double),
+			ThisType, new PropertyMetadata(0.0, OnMinimumChanged));
 
 		/// <summary>
 		/// Identifies the <see cref="Maximum"/> dependency property.
 		/// </summary>
-		public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register("Maximum", typeof (int),
-			ThisType, new PropertyMetadata(int.MaxValue, OnMaximumChanged));
+		public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register("Maximum", typeof(double),
+			ThisType, new PropertyMetadata(double.MaxValue, OnMaximumChanged));
 
 		/// <summary>
 		/// Identifies the <see cref="MaxPrecision"/> dependency property.
@@ -168,7 +177,7 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		{
 			var ve = (IntegerEditor) sender;
 
-			ve._changeValue = ve.Value;
+			ve._changeValue = Convert.ToDecimal(ve.Value, CultureInfo.CurrentCulture);
 			ve._changeOffset = 0;
 			ve.CalculateValue(ve.DefaultChange);
 		}
@@ -177,7 +186,7 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		{
 			var ve = (IntegerEditor) sender;
 
-			ve._changeValue = ve.Value;
+			ve._changeValue = Convert.ToDecimal(ve.Value, CultureInfo.CurrentCulture);
 			ve._changeOffset = 0;
 			ve.CalculateValue(-ve.DefaultChange);
 		}
@@ -209,20 +218,33 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// Gets or sets the value. This is a dependency property.
 		/// </summary>
 		/// <value>The value.</value>
-		[TypeConverter(typeof (LengthConverter))]
-		public int Value
+		/// <remarks>
+		/// Supported values are the built-in signed and unsigned integral types. The editor preserves the
+		/// runtime type when it commits a changed value.
+		/// </remarks>
+		public object Value
 		{
-			get { return (int) GetValue(ValueProperty); }
+			get { return GetValue(ValueProperty); }
 			set { SetValue(ValueProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets the editable text representation of the value. This is a dependency property.
+		/// </summary>
+		/// <value>The editable value text.</value>
+		public string Text
+		{
+			get { return (string)GetValue(TextProperty); }
+			set { SetValue(TextProperty, value); }
 		}
 
 		/// <summary>
 		/// Gets or sets the small change value. This is a dependency property.
 		/// </summary>
 		/// <value>The small change value.</value>
-		public int SmallChange
+		public double SmallChange
 		{
-			get { return (int) GetValue(SmallChangeProperty); }
+			get { return (double) GetValue(SmallChangeProperty); }
 			set { SetValue(SmallChangeProperty, value); }
 		}
 
@@ -230,9 +252,9 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// Gets or sets the default change value. This is a dependency property.
 		/// </summary>
 		/// <value>The default change value.</value>
-		public int DefaultChange
+		public double DefaultChange
 		{
-			get { return (int) GetValue(DefaultChangeProperty); }
+			get { return (double) GetValue(DefaultChangeProperty); }
 			set { SetValue(DefaultChangeProperty, value); }
 		}
 
@@ -240,9 +262,9 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// Gets or sets the large change value. This is a dependency property.
 		/// </summary>
 		/// <value>The large change value.</value>
-		public int LargeChange
+		public double LargeChange
 		{
-			get { return (int) GetValue(LargeChangeProperty); }
+			get { return (double) GetValue(LargeChangeProperty); }
 			set { SetValue(LargeChangeProperty, value); }
 		}
 
@@ -250,9 +272,9 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// Gets or sets the minimum. This is a dependency property.
 		/// </summary>
 		/// <value>The minimum.</value>
-		public int Minimum
+		public double Minimum
 		{
-			get { return (int) GetValue(MinimumProperty); }
+			get { return (double) GetValue(MinimumProperty); }
 			set { SetValue(MinimumProperty, value); }
 		}
 
@@ -260,9 +282,9 @@ namespace VixenModules.Editor.EffectEditor.Controls
 		/// Gets or sets the maximum. This is a dependency property.
 		/// </summary>
 		/// <value>The maximum.</value>
-		public int Maximum
+		public double Maximum
 		{
-			get { return (int) GetValue(MaximumProperty); }
+			get { return (double) GetValue(MaximumProperty); }
 			set { SetValue(MaximumProperty, value); }
 		}
 
@@ -295,21 +317,39 @@ namespace VixenModules.Editor.EffectEditor.Controls
 
 		private static void ValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			var doubleEditor = (IntegerEditor) d;
-			if (!doubleEditor.IsInitialized)
-				return;
+			var integerEditor = (IntegerEditor)d;
+			integerEditor._holdValue = Convert.ToDecimal(e.NewValue, CultureInfo.CurrentCulture);
+			integerEditor.UpdateText();
+		}
 
-			doubleEditor.Value = doubleEditor.EnforceLimitsAndPrecision((int) e.NewValue);
+		private static void TextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var integerEditor = (IntegerEditor)d;
+			if (integerEditor._isUpdatingText)
+			{
+				return;
+			}
+
+			if (e.NewValue is string text &&
+				decimal.TryParse(text, NumberStyles.Integer, CultureInfo.CurrentCulture, out var parsedValue))
+			{
+				integerEditor.SetCurrentValue(ValueProperty,
+					integerEditor.ConvertValue(integerEditor.EnforceLimitsAndPrecision(parsedValue)));
+			}
+			else
+			{
+				integerEditor.UpdateText();
+			}
 		}
 
 		private static void OnMinimumChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			var doubleEditor = (IntegerEditor) d;
+			d.CoerceValue(ValueProperty);
 		}
 
 		private static void OnMaximumChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			var doubleEditor = (IntegerEditor) d;
+			d.CoerceValue(ValueProperty);
 		}
 
 		private static void OnIsDraggingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -343,7 +383,7 @@ namespace VixenModules.Editor.EffectEditor.Controls
 			base.OnMouseDown(e);
 			if (e.LeftButton == MouseButtonState.Pressed)
 			{
-				_holdValue = Value;
+				_holdValue = Convert.ToDecimal(Value, CultureInfo.CurrentCulture);
 				_isMouseDown = true;
 				_dragStartPoint = e.GetPosition(this);
 
@@ -377,7 +417,7 @@ namespace VixenModules.Editor.EffectEditor.Controls
 						_dragStartPoint = position;
 
 						_lastDragPoint = _dragStartPoint;
-						_changeValue = Value;
+						_changeValue = Convert.ToDecimal(Value, CultureInfo.CurrentCulture);
 						_changeOffset = 0;
 					}
 				}
@@ -434,26 +474,134 @@ namespace VixenModules.Editor.EffectEditor.Controls
 			else
 				changeValue *= DefaultChange;
 
-			_changeOffset += changeValue;
-			int newValue = (int) (_changeValue + _changeOffset);
+			_changeOffset += Convert.ToDecimal(changeValue);
+			var newValue = _changeValue + _changeOffset;
 			//
 			// Make sure the change is line up with Max/Min Limits and set the precission as specified.
 			var template = Template;
 			var textControl = (TextBox)template.FindName("textboxEditor", this);
 			_holdValue = EnforceLimitsAndPrecision(newValue);
-			textControl.Text = _holdValue.ToString();
+			textControl.Text = ConvertValue(_holdValue).ToString();
 			StartTimer();
 			
 		}
 
 		protected override void SetValue()
 		{
-			Value = _holdValue;
+			Value = ConvertValue(_holdValue);
 		}
 
-		private int EnforceLimitsAndPrecision(int value)
+		private static object CoerceValue(DependencyObject d, object value)
 		{
-			return Math.Max(Minimum, Math.Min(Maximum, value));
+			var integerEditor = (IntegerEditor)d;
+
+			if (value is string text)
+			{
+				if (!decimal.TryParse(text, NumberStyles.Integer, CultureInfo.CurrentCulture, out var parsedValue))
+				{
+					return integerEditor.ConvertValue(integerEditor._holdValue);
+				}
+
+				return integerEditor.ConvertValue(integerEditor.EnforceLimitsAndPrecision(parsedValue));
+			}
+
+			var valueType = value?.GetType();
+			if (valueType == null || !IsSupportedIntegralType(valueType))
+			{
+				return integerEditor.ConvertValue(integerEditor._holdValue);
+			}
+
+			integerEditor._valueType = valueType;
+			var numericValue = Convert.ToDecimal(value, CultureInfo.CurrentCulture);
+			return integerEditor.ConvertValue(integerEditor.EnforceLimitsAndPrecision(numericValue));
+		}
+
+		private decimal EnforceLimitsAndPrecision(decimal value)
+		{
+			var (typeMinimum, typeMaximum) = GetTypeBounds(_valueType);
+			var minimum = decimal.Clamp(ToDecimal(Minimum), typeMinimum, typeMaximum);
+			var maximum = decimal.Clamp(ToDecimal(Maximum), typeMinimum, typeMaximum);
+
+			if (minimum > maximum)
+			{
+				maximum = minimum;
+			}
+
+			return decimal.Clamp(decimal.Truncate(value), minimum, maximum);
+		}
+
+		private object ConvertValue(decimal value)
+		{
+			return Type.GetTypeCode(_valueType) switch
+			{
+				TypeCode.SByte => (sbyte)value,
+				TypeCode.Byte => (byte)value,
+				TypeCode.Int16 => (short)value,
+				TypeCode.UInt16 => (ushort)value,
+				TypeCode.Int32 => (int)value,
+				TypeCode.UInt32 => (uint)value,
+				TypeCode.Int64 => (long)value,
+				TypeCode.UInt64 => (ulong)value,
+				_ => throw new InvalidOperationException($"{_valueType.Name} is not a supported integral type.")
+			};
+		}
+
+		private static bool IsSupportedIntegralType(Type type)
+		{
+			return Type.GetTypeCode(type) is TypeCode.SByte or TypeCode.Byte or TypeCode.Int16 or TypeCode.UInt16 or
+				TypeCode.Int32 or TypeCode.UInt32 or TypeCode.Int64 or TypeCode.UInt64;
+		}
+
+		private static (decimal Minimum, decimal Maximum) GetTypeBounds(Type type)
+		{
+			return Type.GetTypeCode(type) switch
+			{
+				TypeCode.SByte => (sbyte.MinValue, sbyte.MaxValue),
+				TypeCode.Byte => (byte.MinValue, byte.MaxValue),
+				TypeCode.Int16 => (short.MinValue, short.MaxValue),
+				TypeCode.UInt16 => (ushort.MinValue, ushort.MaxValue),
+				TypeCode.Int32 => (int.MinValue, int.MaxValue),
+				TypeCode.UInt32 => (uint.MinValue, uint.MaxValue),
+				TypeCode.Int64 => (long.MinValue, long.MaxValue),
+				TypeCode.UInt64 => (ulong.MinValue, ulong.MaxValue),
+				_ => throw new InvalidOperationException($"{type.Name} is not a supported integral type.")
+			};
+		}
+
+		private static decimal ToDecimal(double value)
+		{
+			if (double.IsNaN(value))
+			{
+				return 0;
+			}
+
+			try
+			{
+				return Convert.ToDecimal(value);
+			}
+			catch (OverflowException)
+			{
+				return value < 0 ? decimal.MinValue : decimal.MaxValue;
+			}
+		}
+
+		private void UpdateText()
+		{
+			var text = ConvertValue(_holdValue).ToString();
+			if (Text == text)
+			{
+				return;
+			}
+
+			_isUpdatingText = true;
+			try
+			{
+				SetCurrentValue(TextProperty, text);
+			}
+			finally
+			{
+				_isUpdatingText = false;
+			}
 		}
 
 		#endregion Helpers

--- a/src/Vixen.Modules/Editor/EffectEditor/Editors/EditorCollection.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/Editors/EditorCollection.cs
@@ -38,6 +38,10 @@ namespace VixenModules.Editor.EffectEditor.Editors
 		{
 			{typeof (bool), new TypeEditor(typeof (bool), EditorKeys.BooleanEditorKey)},
 			{KnownTypes.Wpf.Integer, new TypeEditor(KnownTypes.Wpf.Integer, EditorKeys.IntegerEditorKey)},
+			{KnownTypes.Wpf.Byte, new TypeEditor(KnownTypes.Wpf.Byte, EditorKeys.IntegerEditorKey)},
+			{KnownTypes.Wpf.UShort, new TypeEditor(KnownTypes.Wpf.UShort, EditorKeys.IntegerEditorKey)},
+			{KnownTypes.Wpf.UInt, new TypeEditor(KnownTypes.Wpf.UInt, EditorKeys.IntegerEditorKey)},
+			{KnownTypes.Wpf.ULong, new TypeEditor(KnownTypes.Wpf.ULong, EditorKeys.IntegerEditorKey)},
 			{KnownTypes.Wpf.Double, new TypeEditor(KnownTypes.Wpf.Double, EditorKeys.DoubleEditorKey)},
 			{KnownTypes.Vixen.Color, new ColorTypeEditor()},
 			{KnownTypes.Vixen.Curve, new CurveEditor()},

--- a/src/Vixen.Modules/Editor/EffectEditor/KnownTypes.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/KnownTypes.cs
@@ -62,6 +62,26 @@ namespace VixenModules.Editor.EffectEditor
 			public static readonly Type Cursor = typeof (Cursor);
 			public static readonly Type Brush = typeof (Brush);
 			public static readonly Type Integer = typeof (int);
+
+			/// <summary>
+			/// Identifies the unsigned 8-bit integer type.
+			/// </summary>
+			public static readonly Type Byte = typeof (byte);
+
+			/// <summary>
+			/// Identifies the unsigned 16-bit integer type.
+			/// </summary>
+			public static readonly Type UShort = typeof (ushort);
+
+			/// <summary>
+			/// Identifies the unsigned 32-bit integer type.
+			/// </summary>
+			public static readonly Type UInt = typeof (uint);
+
+			/// <summary>
+			/// Identifies the unsigned 64-bit integer type.
+			/// </summary>
+			public static readonly Type ULong = typeof (ulong);
 			public static readonly Type Double = typeof(double);
 		}
 

--- a/src/Vixen.Modules/Editor/EffectEditor/Themes/IntegerEditor.xaml
+++ b/src/Vixen.Modules/Editor/EffectEditor/Themes/IntegerEditor.xaml
@@ -10,7 +10,7 @@
 				<ControlTemplate TargetType="{x:Type controls:IntegerEditor}">
 					<StackPanel>
 						<TextBox x:Name="textboxEditor" 
-						         Text="{Binding Path=Value, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
+						         Text="{Binding Path=Text, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
 								 utils:TextBoxExtender.CommitOnEnter="true"
 								 utils:TextBoxExtender.RollbackOnEscape="true"
 								 utils:TextBoxExtender.CommitOnTyping="false"/>

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FormEffectEditor.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FormEffectEditor.cs
@@ -13,6 +13,8 @@ using Element = Common.Controls.Timeline.Element;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using PropertyValueChangedEventArgs = VixenModules.Editor.EffectEditor.PropertyValueChangedEventArgs;
 using Timer = System.Timers.Timer;
+using WpfTextBox = System.Windows.Controls.TextBox;
+using WpfKeyboardFocusChangedEventArgs = System.Windows.Input.KeyboardFocusChangedEventArgs;
 
 namespace VixenModules.Editor.TimedSequenceEditor
 {
@@ -26,6 +28,7 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private readonly EffectPropertyEditorGrid _effectPropertyEditorGridEffectEffectPropertiesEditor;
 		private bool _previewState;
 		private ElementHost host;
+		private WpfTextBox _activeTextBox;
 
 		private readonly DispatcherTimer _selectionChangeBuffer;
 
@@ -48,7 +51,10 @@ namespace VixenModules.Editor.TimedSequenceEditor
 
 			// Establish automation to intercept quick keys meant for the Timeline window
 			host.Child.KeyDown += Form_EffectEditorKeyDown;
+			host.Child.PreviewGotKeyboardFocus += EffectPropertyEditorPreviewGotKeyboardFocus;
+			host.Child.LostKeyboardFocus += EffectPropertyEditorLostKeyboardFocus;
 			host.Enter += Form_EffectEditorEnter;
+			host.Leave += Form_EffectEditorLeave;
 
 			_selectionChangeBuffer = new DispatcherTimer
 			{
@@ -100,6 +106,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			{
 				_effectPropertyEditorGridEffectEffectPropertiesEditor.PropertyValueChanged -= EffectPropertyEditorValueChanged;
 				_effectPropertyEditorGridEffectEffectPropertiesEditor.PreviewChanged -= EditorPreviewStateChanged;
+				_effectPropertyEditorGridEffectEffectPropertiesEditor.PreviewGotKeyboardFocus -= EffectPropertyEditorPreviewGotKeyboardFocus;
+				_effectPropertyEditorGridEffectEffectPropertiesEditor.LostKeyboardFocus -= EffectPropertyEditorLostKeyboardFocus;
+			}
+
+			if (host != null)
+			{
+				host.Leave -= Form_EffectEditorLeave;
 			}
 			
 			_previewLoopTimer.Elapsed -= PreviewLoopTimerOnElapsed;
@@ -162,6 +175,38 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		private void Form_EffectEditorEnter(object sender, EventArgs e)
 		{
 			host.Child.Focus();
+		}
+
+		private void Form_EffectEditorLeave(object sender, EventArgs e)
+		{
+			CommitTextBoxValue(_activeTextBox);
+			_activeTextBox = null;
+		}
+
+		private void EffectPropertyEditorPreviewGotKeyboardFocus(object sender, WpfKeyboardFocusChangedEventArgs e)
+		{
+			_activeTextBox = e.NewFocus as WpfTextBox;
+		}
+
+		private void EffectPropertyEditorLostKeyboardFocus(object sender, WpfKeyboardFocusChangedEventArgs e)
+		{
+			var textBox = e.OldFocus as WpfTextBox;
+			CommitTextBoxValue(textBox);
+
+			if (ReferenceEquals(_activeTextBox, textBox))
+			{
+				_activeTextBox = null;
+			}
+		}
+
+		private static void CommitTextBoxValue(WpfTextBox textBox)
+		{
+			if (textBox == null)
+			{
+				return;
+			}
+
+			textBox.GetBindingExpression(WpfTextBox.TextProperty)?.UpdateSource();
 		}
 
 		/// <summary>

--- a/src/Vixen.Modules/Effect/CustomValue/CustomValue.cs
+++ b/src/Vixen.Modules/Effect/CustomValue/CustomValue.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.Serialization;
 using NLog;
+using Vixen.Attributes;
 using Vixen.Commands;
 using Vixen.Data.Value;
 using Vixen.Intent;
@@ -272,6 +273,7 @@ namespace VixenModules.Effect.CustomValue
 		[ProviderCategory(@"Config")]
 		[DisplayName(@"Value")]
 		[Description(@"Sets the value.")]
+		[NumberRange(byte.MinValue, byte.MaxValue, 1)]
 		public byte Value8Bit
 		{
 			get { return _data.Value8Bit; }
@@ -287,6 +289,7 @@ namespace VixenModules.Effect.CustomValue
 		[ProviderCategory(@"Config")]
 		[DisplayName(@"Value")]
 		[Description(@"Sets the value.")]
+		[NumberRange(ushort.MinValue, ushort.MaxValue, 1)]
 		public ushort Value16Bit
 		{
 			get { return _data.Value16Bit; }
@@ -302,6 +305,7 @@ namespace VixenModules.Effect.CustomValue
 		[ProviderCategory(@"Config")]
 		[DisplayName(@"Value")]
 		[Description(@"Sets the value.")]
+		[NumberRange(uint.MinValue, uint.MaxValue, 1)]
 		public uint Value32Bit
 		{
 			get { return _data.Value32Bit; }
@@ -317,6 +321,7 @@ namespace VixenModules.Effect.CustomValue
 		[ProviderCategory(@"Config")]
 		[DisplayName(@"Value")]
 		[Description(@"Sets the value.")]
+		[NumberRange(ulong.MinValue, ulong.MaxValue, 1)]
 		public ulong Value64Bit
 		{
 			get { return _data.Value64Bit; }


### PR DESCRIPTION
- Expanded the existing `IntegerEditor` to support `byte`, `ushort`, `uint`, and `ulong` without duplicate editor controls or templates. It preserves the original numeric runtime type, performs calculations with exact `decimal` arithmetic, respects `NumberRange` metadata, and safely clamps values to each type’s valid range—including the full `ulong` range.

- Updated type registration and Custom Value metadata so 8-, 16-, 32-, and 64-bit unsigned values use the shared integer editor and expose appropriate limits.

- Fixed pending text edits being discarded when focus moves from the WPF Effect Editor to the WinForms timeline. The Effect Editor now commits the active text binding on WPF keyboard-focus loss and when its `ElementHost` loses focus, before the timeline selection refresh replaces the editor context. This covers integer, string, and other text-backed editors.

- Validated with full MSBuild of the Timed Sequence Editor project, including its C++/CLI dependencies.