### PR TITLE
VIX-3980 Block propagating keystokes if they originate in a text box

### DIFF
--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FormEffectEditor.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/FormEffectEditor.cs
@@ -216,6 +216,13 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		/// <param name="e">Contains the event data</param>
 		private void Form_EffectEditorKeyDown(object sender, KeyEventArgs e)
 		{
+			if (e.OriginalSource is System.Windows.Controls.TextBox)
+			{
+				// Do not publish to KeydownSWI because the user is typing in a text box.
+				// Do not mark e.Handled: the WPF editor retains normal editing behavior.
+				return;
+			}
+			
 			Broadcast.Publish<KeyEventArgs>("KeydownSWI", e);
 		}
 


### PR DESCRIPTION
The effect editor forwards keystrokes via the broadcast publish so things like the space bar can still start playing when the focus is in the effect editor, but if the user is typing in a text entry control this is not desireable. Added a filter to exclude those keys when the source is a textbox.