### PR TITLE
VIX-3984 Fix the forwarding of keyboard events from textboxes.

### DIFF
--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Marks.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/Form_Marks.cs
@@ -42,6 +42,12 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		/// <param name="e">Contains the event data</param>
 		private void Form_MarksKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
 		{
+			if (e.OriginalSource is System.Windows.Controls.TextBox)
+			{
+				// Do not publish to KeydownSWI because the user is typing in a text box.
+				// Do not mark e.Handled: the WPF editor retains normal editing behavior.
+				return;
+			}
 			Broadcast.Publish<System.Windows.Input.KeyEventArgs>("KeydownSWI", e);
 		}
 

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/LayerEditor.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/LayerEditor.cs
@@ -54,6 +54,12 @@ namespace VixenModules.Editor.TimedSequenceEditor
 		/// <param name="e">Contains the event data</param>
 		private void Form_LayerKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
 		{
+			if (e.OriginalSource is System.Windows.Controls.TextBox)
+			{
+				// Do not publish to KeydownSWI because the user is typing in a text box.
+				// Do not mark e.Handled: the WPF editor retains normal editing behavior.
+				return;
+			}
 			Broadcast.Publish<System.Windows.Input.KeyEventArgs>("KeydownSWI", e);
 		}
 


### PR DESCRIPTION
Applied the same fix as was done to the effect editor in VIX-3980.