### PR TITLE
VIX-3988 Add Pangolin Beyond mark import

### DIFF
--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -11,7 +11,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 - [x] (2026-08-18 00:00Z) Inspected the existing import dialog, import/export service, Marks Docker dispatch, mark model, unique-name helper use, ColorPicker use, and test-project visibility.
 - [x] (2026-08-18 15:46Z) Updated VIX-3988 with the user-facing Summary, Scope, Acceptance Criteria, and Validation Plan.
 - [x] (2026-08-18 15:49Z) Added the Pangolin Beyond dialog selection, Marks Docker dispatch, and documented compile-safe service entry point; the affected Release build succeeded.
-- [ ] Add pure parser and materializer internals plus focused unit tests.
+- [x] (2026-08-18 16:00Z) Added pure internal parser/materializer types and seven focused tests; the x64 test target build and `PangolinBeyondMarkImportTests` pass.
 - [ ] Implement the file, choice, color-picker, and collection-mutation workflow.
 - [ ] Build, run focused and full tests, perform a manual editor import check, and post validation results to VIX-3988.
 
@@ -25,6 +25,9 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 - Observation: Creating `new Mark(startTime)` deliberately gives the mark a 450 ms duration.
   Evidence: `src/Vixen.Modules/App/Marks/Mark.cs` assigns `TimeSpan.FromMilliseconds(450)` in its `Mark(TimeSpan)` constructor.
+
+- Observation: `MarkCollection.AddMarks` enumerates its input once to assign parents and again to add it.
+  Evidence: The initial focused factory test passed a lazy projection and observed two resulting marks with `Parent == null`; materializing the `Mark` list before the single `AddMarks` invocation made all seven focused tests pass.
 
 ## Decision Log
 
@@ -46,7 +49,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 ## Outcomes & Retrospective
 
-Milestones 1 and 2 are complete. The UI now offers and routes the Pangolin Beyond selection, but its service entry point intentionally performs no import until the parser and workflow milestones are complete. The affected `TimedSequenceEditor` Release build succeeded; it reported pre-existing warnings in dependent projects and no errors. At completion, record the actual test counts, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
+Milestones 1 through 3 are complete. The UI now offers and routes the Pangolin Beyond selection, and pure internal parsing/materialization code validates Vixen's CSV shape, BGR colors, grouping order, and default durations. The service entry point intentionally performs no import until the file/dialog workflow milestone is complete. The x64 test target build succeeded and the focused suite passed 7 tests; both builds reported pre-existing warnings in dependent projects and no errors. At completion, record the actual full-suite count, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
 
 ## Context and Orientation
 
@@ -182,6 +185,14 @@ The expected grouped result is:
 
 Both imported collections set `ShowMarkBar = true`. Every listed mark has a 450 ms duration unless a future product requirement explicitly adds Beyond duration serialization.
 
+Milestone 3 validation evidence:
+
+    msbuild Vixen.sln -m -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+    Build succeeded with zero errors.
+
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PangolinBeyondMarkImportTests
+    Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7.
+
 ## Interfaces and Dependencies
 
 No package, solution, or project-reference change is expected. Use existing `System.Globalization.CultureInfo.InvariantCulture`, `System.Drawing.Color`, `System.Windows.Forms` dialogs, `NLog`, `VixenModules.App.Marks.Mark`, `MarkCollection`, `MarkCollectionNameService`, `MessageBoxForm`, and `Common.Controls.ColorManagement.ColorPicker.ColorPicker` dependencies.
@@ -210,3 +221,5 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Completed Milestone 1 by updating VIX-3988 with a concise user-facing Summary, Scope, Acceptance Criteria, and Validation Plan. Detailed parser, UI, and test design remains in this repository-local ExecPlan.
 
 2026-08-18: Completed Milestone 2 by adding the legacy dialog radio button and `IsPangolinBeyondSelection` property, routing it from Marks Docker, and adding the documented `ImportPangolinBeyondMarks` entry point. Verified with `msbuild src\\Vixen.Modules\\Editor\\TimedSequenceEditor\\TimedSequenceEditor.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -v:m`, which completed with zero errors.
+
+2026-08-18: Completed Milestone 3 by adding separate internal record, mode, parser, and collection-factory files plus seven focused tests. The initial test exposed that `MarkCollection.AddMarks` re-enumerates its input, so the factory now materializes marks before its required single bulk-add call.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -1,0 +1,210 @@
+# VIX-3988: Import Pangolin Beyond marks into the Marks Docker
+
+This ExecPlan is a living document. Maintain its `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections as work proceeds. Follow `.agents/PLANS.md` from the repository root when revising this document.
+
+## Purpose / Big Picture
+
+Timed Sequence Editor users can already export mark collections in Pangolin Beyond's CSV shape, but cannot bring that CSV back into the Marks Docker. After this work, a user can choose `Pangolin Beyond` from the existing import-type dialog, select a CSV exported by Vixen, and either retain the source colors as separate mark collections or replace every source color with one selected color. The user can see the imported marks immediately in the Marks Bar; invalid files and cancelled choices leave the current sequence unchanged.
+
+## Progress
+
+- [x] (2026-08-18 00:00Z) Inspected the existing import dialog, import/export service, Marks Docker dispatch, mark model, unique-name helper use, ColorPicker use, and test-project visibility.
+- [x] (2026-08-18 15:46Z) Updated VIX-3988 with the user-facing Summary, Scope, Acceptance Criteria, and Validation Plan.
+- [ ] Add the Pangolin Beyond import choice and service dispatch.
+- [ ] Add pure parser and materializer internals plus focused unit tests.
+- [ ] Implement the file, choice, color-picker, and collection-mutation workflow.
+- [ ] Build, run focused and full tests, perform a manual editor import check, and post validation results to VIX-3988.
+
+## Surprises & Discoveries
+
+- Observation: The existing import-type dialog is a WinForms `BaseForm`, even though the Marks Docker view model is a Catel/WPF type.
+  Evidence: `src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.cs` exposes checked WinForms radio buttons, and `MarkDockerViewModel.ImportCollection()` creates it directly.
+
+- Observation: The required test friend-assembly relationship already exists.
+  Evidence: `src/Vixen.Modules/Editor/TimedSequenceEditor/TimedSequenceEditor.csproj` declares `InternalsVisibleToAttribute` for `Vixen.Tests`, and `src/Vixen.Tests/Vixen.Tests.csproj` already references the Timed Sequence Editor project.
+
+- Observation: Creating `new Mark(startTime)` deliberately gives the mark a 450 ms duration.
+  Evidence: `src/Vixen.Modules/App/Marks/Mark.cs` assigns `TimeSpan.FromMilliseconds(450)` in its `Mark(TimeSpan)` constructor.
+
+## Decision Log
+
+- Decision: Parse and materialize through internal, UI-free helpers, while keeping open-file dialogs, prompts, messages, and mutations in `MarkImportExportService`.
+  Rationale: The legacy service already owns all of those UI concerns. Separating only deterministic work lets unit tests cover success and failure behavior without WinForms automation or a new public service API.
+  Date/Author: 2026-08-18 / Codex
+
+- Decision: Treat the required `ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection>)` service entry point as the one requested integration member; all new supporting records, enum values, parser, and materializer remain `internal`.
+  Rationale: The handoff explicitly requires that service dispatch but prohibits broadening the public API. Existing test visibility makes internals directly testable.
+  Date/Author: 2026-08-18 / Codex
+
+- Decision: Preserve source-color group order by first row occurrence rather than sorting colors or names.
+  Rationale: This makes grouped imports stable and preserves the order users see in the CSV. A dictionary for lookup plus a separate ordered color list avoids relying on dictionary enumeration order.
+  Date/Author: 2026-08-18 / Codex
+
+- Decision: Reject a malformed file before asking any grouping/color question or adding a collection.
+  Rationale: This guarantees invalid-file atomicity and avoids prompting the user for an import that cannot succeed.
+  Date/Author: 2026-08-18 / Codex
+
+## Outcomes & Retrospective
+
+Milestone 1 is complete: VIX-3988 now describes the import outcome, cancellation and invalid-file safeguards, and reviewable acceptance criteria. Implementation has not started. At completion, record the actual test counts, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
+
+## Context and Orientation
+
+`src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs` is the command owner for the Marks Docker toolbar. Its private `ImportCollection()` method displays `MarkCollectionImportDialog` and dispatches each selected legacy file format to `MarkImportExportService`.
+
+`src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.cs` and its `.Designer.cs` file define the existing WinForms import format selector. It currently exposes a Boolean property for each radio button. Add one radio button and one read-only Boolean property; do not introduce a separate dialog or migrate this legacy dialog to WPF.
+
+`src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs` owns the existing import and export workflows. It retains the last selected folder, creates `OpenFileDialog` and `MessageBoxForm` instances, logs through NLog, has `CreateNewCollection`, `AddUniqueCollection`, and `SetDefaultCollection` helpers, and already writes the Beyond CSV on the `MarkExportType.PangolinBeyond` branch. Its exporter writes the exact header `#,Name,Start,Color`, then rows `M<number>,<text>,<time>,<six BGR hexadecimal digits>`; it uses `mm:ss.fff` below one hour and `hh:mm:ss.fff` at one hour or later.
+
+Pangolin's CSV color field here is BGR: the first two hexadecimal digits are blue, the next two are green, and the final two are red. Thus `112233` represents RGB `#332211`, created as `Color.FromArgb(0x33, 0x22, 0x11)`. Parsing must use `CultureInfo.InvariantCulture`, never the workstation culture. It must accept only the two exact timestamp shapes written by Vixen: `mm:ss.fff` and `hh:mm:ss.fff`.
+
+`src/Vixen.Modules/App/Marks/MarkCollection.cs` provides `AddMarks(IEnumerable<IMark>)`, which assigns parents, bulk-adds, orders marks, and raises one collection notification. Each newly imported collection must call it once, not use repeated `AddMark` calls. `AddUniqueCollection` in the import service must remain the only route used to append imported collections so existing names are not duplicated. `SetDefaultCollection` must run only if the target has no default collection after import.
+
+`Common.Controls.ColorManagement.ColorPicker.ColorPicker` is the existing WinForms color picker. It accepts its color as `XYZ` and yields an RGB color via `picker.Color.ToRGB().ToArgb()`, as shown in `MarkCollectionViewModel.PickColor()`. Use this picker only for the one-collection (No) response.
+
+## Plan of Work
+
+### Milestone 1: Record the approved issue contract in Jira
+
+Before implementation, update VIX-3988 through the repository Jira workflow. State that Vixen-exported Beyond CSV files have the fixed header and BGR colors; malformed headers, fields, timestamps, or colors show `Pangolin Beyond Import Error`, log an NLog error, and add nothing; Yes creates source-color collections, No opens the existing picker for one replacement-color collection, and Cancel changes nothing. Include automated parser/materializer coverage and the manual import scenarios from this plan. Use the project `jira` skill before modifying the tracker. If tracker access is unavailable, record the exact failure under `Surprises & Discoveries`, continue local work, and leave the final tracker update pending.
+
+### Milestone 2: Expose and route the new import selection
+
+Read all of `MarkCollectionImportDialog.cs`, `MarkCollectionImportDialog.Designer.cs`, `MarkDockerViewModel.cs`, and the relevant import-service methods before editing. Add a `radioPangolinBeyond` radio button labeled `Pangolin Beyond` to the existing mutually exclusive group. Place it after the current choices, increase the form client/minimum height enough that it and the existing OK/Cancel buttons do not overlap, and keep the existing default selection and tab order behavior coherent. Add `public bool IsPangolinBeyondSelection => radioPangolinBeyond.Checked;` to the dialog, with XML documentation consistent with the existing public dialog properties because this is a public API modification; use the project `csharp-docs` skill while implementing this public-member change.
+
+In `MarkDockerViewModel.ImportCollection()`, add an independent selection branch matching the existing style:
+
+    if (aDialog.IsPangolinBeyondSelection)
+        MarkImportExportService.ImportPangolinBeyondMarks(MarkCollections);
+
+Do not convert the existing independent `if` statements to `else if` or change another import format's behavior. At the end of this milestone, choosing the new radio button reaches the new service method (which may initially be a compile-safe stub only while the next milestone is in progress).
+
+### Milestone 3: Add deterministic Beyond parsing and materialization seams
+
+Create separate files under `src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/`:
+
+- `PangolinBeyondMarkRecord.cs`: an `internal` immutable record/record struct containing the parsed text, start time, and `System.Drawing.Color`.
+- `PangolinBeyondImportMode.cs`: an `internal enum` with `GroupByColor` and `SingleCollection` values.
+- `PangolinBeyondMarkParser.cs`: an `internal static` pure parser with a `TryParse`-style API accepting CSV text or lines and returning a complete record list plus an error description. It must not open dialogs, log, mutate collections, or create marks.
+- `PangolinBeyondMarkCollectionFactory.cs`: an `internal static` pure materializer accepting parsed records, an import mode, and the selected replacement color for one-collection mode. It returns detached `MarkCollection` instances and must not mutate the target observable collection.
+
+The parser must reject an empty file, a header that is not exactly `#,Name,Start,Color`, a row with anything other than four comma-separated columns, an invalid timestamp, and a color other than exactly six ASCII hexadecimal digits. Do not add CSV quoting/escaping behavior: Vixen's exporter removes commas from text, so precisely four direct comma fields is the supported contract. Preserve text verbatim from the second field, accept LF or CRLF input, and identify the failing line in the returned error description. Use `TimeSpan.TryParseExact` with invariant culture and exactly the format strings `mm\\:ss\\.fff` and `hh\\:mm\\:ss\\.fff`; do not accept locale separators, unpadded values, seconds-only values, or alternate fractions. Convert the color by parsing byte pairs in B, G, R order and return `Color.FromArgb(red, green, blue)`.
+
+The materializer's grouped mode must scan records in input order, collect every record sharing each source color into one collection, and return collections in first-color-occurrence order. Each returned collection is named `Beyond Marks - #RRGGBB` using normal RGB hexadecimal display, has `Decorator.Color` equal to its source color, sets `ShowMarkBar = true`, and calls `AddMarks` exactly once. Its single mode returns one `Beyond Marks` collection, applies the caller's replacement color to the decorator, sets `ShowMarkBar = true`, and builds marks from all parsed records in input order using that collection color. For every mark, construct `new Mark(record.StartTime) { Text = record.Text }`; do not assign `Duration`, so it retains the model's 450 ms default.
+
+Create `src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs`. Test these internals directly through the established friend-assembly access; no modal dialog test is required. Cover a valid two-row parse; the BGR `112233` to RGB `#332211` conversion; `mm:ss.fff` and `hh:mm:ss.fff` timestamps; header, column-count, time, and color failures; group mode's color grouping, input-first ordering, RGB names, source decorator colors, mark text/start time, 450 ms durations, and one `AddMarks`-equivalent result per collection; single mode's one name, one replacement color, and all marks; and materialization with an empty/invalid parse result only when parser contract permits it. Add a test around the service-level collection-append seam only if it can be exposed internally without UI, asserting unique suffixes and default behavior.
+
+### Milestone 4: Implement the legacy service workflow atomically
+
+Add `ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection> collections)` to `MarkImportExportService`. Follow existing open-dialog conventions: initialize from `_lastFolder`, filter `.csv` files plus all files, return on cancellation, and update `_lastFolder` only after a file is selected. Read the entire selected file using the default text reader behavior used by nearby imports, then call the pure parser before displaying any choice dialog or changing `collections`.
+
+If parsing fails, construct a specific NLog error containing the parser error and file path (include an exception only if one occurred), show `MessageBoxForm` with the title exactly `Pangolin Beyond Import Error`, and return. Do not add a collection, change an existing collection, set a default, or show the grouping question on this path. Also catch read/unexpected errors around this workflow, log them, show that same title, and preserve the same no-mutation guarantee.
+
+After a successful parse, ask with Yes/No/Cancel using the existing `MessageBoxForm`/WinForms dialog conventions and exact prompt text `Create a Mark Collection for each Beyond color?`. Map Yes to `PangolinBeyondImportMode.GroupByColor`. Map No to `SingleCollection`, then show the existing `ColorPicker`; if it returns anything other than `DialogResult.OK`, return without mutation. Convert its selected XYZ color with `picker.Color.ToRGB().ToArgb()`. Map Cancel, form-close, or any other result to an immediate no-mutation return. Dispose the ColorPicker with `using` so its message filter is removed.
+
+Only after a successful mode and, where required, color selection, call the materializer. Then append every fully constructed collection with `AddUniqueCollection(collections, collection)`, retaining the materializer order. Once all additions are complete, call `SetDefaultCollection(collections)` only if `collections.Any(x => x.IsDefault)` is false. This sequencing ensures failed parse, prompt cancellation, and picker cancellation cannot produce partial imports. Do not add a new dialog, do not move UI behavior out of the import service, and do not alter the existing Beyond export branch.
+
+Add or extend a narrow internal orchestration/helper seam if necessary to test append/default/cancellation state deterministically, but keep it `internal` and UI-free. Tests must demonstrate that mode cancellation leaves a pre-populated collection collection reference-identical and unchanged, that picker cancellation has the same result, that invalid input leaves it unchanged, and that successful additions use unique names if `Beyond Marks` or a grouped RGB name already exists. If keeping cancellation purely in the UI method makes a direct unit test impossible, test the no-mutation property by verifying parser failure and materializer non-execution, then manually verify the dialogs in Milestone 5; record that boundary in the Decision Log.
+
+### Milestone 5: Validate the user flow and close the tracker loop
+
+Use a small Vixen-exported CSV such as the following manual fixture (the first field is an identifier and is validated only by its column position; the export currently writes `M1`, `M2`, and so on):
+
+    #,Name,Start,Color
+    M1,Intro,00:01.250,112233
+    M2,Chorus,01:02:03.004,A0B0C0
+    M3,Again,00:03.500,112233
+
+Open a timed sequence, open the Marks Docker import action, choose `Pangolin Beyond`, and select the fixture. For Yes, observe two visible Marks Bar collections ordered `Beyond Marks - #332211` then `Beyond Marks - #C0B0A0`, with the first containing Intro and Again and colors matching their names. For No, select a visibly distinctive replacement color in the existing picker and observe one visible `Beyond Marks` collection with all three marks and that replacement color. In both cases, check that a mark duration remains 450 ms and an existing default collection stays default; when importing into a sequence with no default, exactly one default is assigned.
+
+Repeat with an invalid header, wrong column count, invalid timestamp, and invalid color. Each must log an error and show `Pangolin Beyond Import Error`; record the collection count before opening the dialog and confirm it is unchanged afterwards. Repeat the valid flow but choose Cancel at the Yes/No/Cancel prompt and Cancel in ColorPicker after choosing No; neither route may add anything. Finally, import a fixture into a sequence already holding `Beyond Marks` and a matching grouped name and confirm `AddUniqueCollection` supplies its standard unique suffixes.
+
+Build tests using full Visual Studio MSBuild, because the test graph contains C++/CLI dependencies. Then run the focused class and the whole test project without rebuilding, from `C:\Dev\Vixen`:
+
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PangolinBeyondMarkImportTests
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\"
+
+Expect each completed test command to report zero failed tests. Run `git diff --check` before handoff. Update VIX-3988's wording if implementation discoveries changed its requirements, then add a Jira comment containing actual build, focused-test, full-suite, and manual-validation results. Update this plan's Progress, Outcomes & Retrospective, Artifacts, and revision note with real evidence.
+
+## Concrete Steps
+
+All commands run from `C:\Dev\Vixen`.
+
+1. Before editing, read the project-specific documentation skill because this work changes the public `MarkCollectionImportDialog` API:
+
+       Get-Content -Raw .agents\skills\csharp-docs\SKILL.md
+
+2. Locate the current boundaries and ensure no unrelated work is overwritten:
+
+       git status --short
+       rg -n -C 4 "ImportCollection\(|ImportVixen3Beats|ExportMarkCollections|PangolinBeyond|AddUniqueCollection|SetDefaultCollection" src\Vixen.Modules\Editor\TimedSequenceEditor -g "*.cs"
+       rg -n "MarkCollectionNameService|InternalsVisibleTo" src\Vixen.Modules\Editor\TimedSequenceEditor src\Vixen.Tests -g "*.cs" -g "*.csproj"
+
+3. Complete Milestones 2 through 4 with tabs and LF line endings. Review only expected files:
+
+       git diff --check
+       git diff -- src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.cs src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.Designer.cs src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
+
+4. Run the Milestone 5 commands. A successful test summary contains:
+
+       Passed!  - Failed:     0, Passed:     <count>, Skipped:     0
+
+5. Record actual commands, counts, manual results, and Jira result in this plan rather than copying example results.
+
+## Validation and Acceptance
+
+The feature is accepted when the import dialog has a selectable Pangolin Beyond format and the user can import a Vixen-exported Beyond CSV through it. A file with the exact header and valid four-field rows must parse invariantly, preserve mark text and start time, translate BGR colors correctly, preserve the 450 ms default duration, and create visible collections.
+
+Yes must create one `Beyond Marks - #RRGGBB` collection for each source RGB color in first-occurrence order. No must show the existing ColorPicker and, after confirmation, create one `Beyond Marks` collection whose decorator is the selected replacement color. The collections must get unique names, marks must be bulk-added once per collection, and default selection must only be supplied when absent. Cancel at either decision point must leave collections untouched.
+
+For malformed headers, non-four-column rows, invalid timestamps, or invalid colors, the application must log an NLog error, display `Pangolin Beyond Import Error`, and make no collection/default changes. Automated tests must cover parsing, BGR conversion, both time forms, both materialization modes, grouping order, uniqueness/default append behavior where exposed, cancellation/no-mutation seams, and invalid-input atomicity. The focused and full `Vixen.Tests` commands must have zero failures, and the manual scenarios in Milestone 5 must pass.
+
+## Idempotence and Recovery
+
+Parser and materializer helpers are pure: rerunning them with the same input produces detached equivalent results and does not affect a sequence. The service mutates only after all parse and user decisions have succeeded. Retrying after a failed parse or a cancellation is safe because nothing was added. Retrying a successful import intentionally adds another import, but `AddUniqueCollection` prevents duplicate collection names.
+
+If implementation must be backed out, remove only the new dialog option, dispatch branch, service import entry point, Beyond helper files, and focused tests after confirming their exact paths with `git status --short`. Do not change or delete existing exports, other import formats, or user collections. If test build prerequisites are missing, leave source unchanged, capture the exact MSBuild failure, and retry on a machine with the Visual Studio C++ toolset rather than modifying project references.
+
+## Artifacts and Notes
+
+The fixed round-trip fixture is:
+
+    #,Name,Start,Color
+    M1,Intro,00:01.250,112233
+    M2,Chorus,01:02:03.004,A0B0C0
+    M3,Again,00:03.500,112233
+
+The expected grouped result is:
+
+    Beyond Marks - #332211, decorator RGB #332211, marks Intro at 00:01.250 and Again at 00:03.500
+    Beyond Marks - #C0B0A0, decorator RGB #C0B0A0, mark Chorus at 01:02:03.004
+
+Both imported collections set `ShowMarkBar = true`. Every listed mark has a 450 ms duration unless a future product requirement explicitly adds Beyond duration serialization.
+
+## Interfaces and Dependencies
+
+No package, solution, or project-reference change is expected. Use existing `System.Globalization.CultureInfo.InvariantCulture`, `System.Drawing.Color`, `System.Windows.Forms` dialogs, `NLog`, `VixenModules.App.Marks.Mark`, `MarkCollection`, `MarkCollectionNameService`, `MessageBoxForm`, and `Common.Controls.ColorManagement.ColorPicker.ColorPicker` dependencies.
+
+At completion, the externally reachable integration additions are limited to:
+
+    // MarkCollectionImportDialog.cs
+    public bool IsPangolinBeyondSelection => radioPangolinBeyond.Checked;
+
+    // MarkImportExportService.cs
+    public static void ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection> collections);
+
+The following must remain internal to `Module.Editor.TimedSequenceEditor` and exist in separate source files so `Vixen.Tests` can test them via the existing friend-assembly declaration:
+
+    internal record/record struct PangolinBeyondMarkRecord(string Text, TimeSpan StartTime, Color Color);
+    internal enum PangolinBeyondImportMode { GroupByColor, SingleCollection }
+    internal static class PangolinBeyondMarkParser { /* TryParse ... */ }
+    internal static class PangolinBeyondMarkCollectionFactory { /* CreateCollections ... */ }
+
+The exact helper signatures may be adjusted only to keep parsing and materialization pure and directly testable. They must not gain UI dependencies, mutate the destination collection, or become public. Preserve `MarkImportExportService.AddUniqueCollection` and `SetDefaultCollection` as the final append/default policy.
+
+## Revision Note
+
+2026-08-18: Initial ExecPlan created from the VIX-3988 handoff after source inspection of the existing import/export flow, WinForms selection dialog, Marks model, ColorPicker API, unique-name behavior, and test visibility. The plan resolves grouping order, parsing strictness, duration preservation, and no-mutation sequencing explicitly so implementation can proceed without relying on the handoff.
+
+2026-08-18: Completed Milestone 1 by updating VIX-3988 with a concise user-facing Summary, Scope, Acceptance Criteria, and Validation Plan. Detailed parser, UI, and test design remains in this repository-local ExecPlan.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -13,7 +13,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 - [x] (2026-08-18 15:49Z) Added the Pangolin Beyond dialog selection, Marks Docker dispatch, and documented compile-safe service entry point; the affected Release build succeeded.
 - [x] (2026-08-18 16:00Z) Added pure internal parser/materializer types and seven focused tests; the x64 test target build and `PangolinBeyondMarkImportTests` pass.
 - [x] (2026-08-18 16:20Z) Implemented the file, decision, color-picker, atomic error, unique-name, and default-selection workflow; the focused suite now passes 13 tests.
-- [ ] Build, run focused and full tests, perform a manual editor import check, and post validation results to VIX-3988.
+- [x] (2026-08-18 16:34Z) User confirmed the full build and full unit suite pass; verified Vixen Beyond export/import round trip and a Beyond-exported test file; posted the results to VIX-3988 comment 40367.
 
 ## Surprises & Discoveries
 
@@ -60,7 +60,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 ## Outcomes & Retrospective
 
-Milestones 1 through 4 are complete. The service now reads and fully parses the selected CSV before asking the user whether to group colors, uses the existing ColorPicker for a single replacement-color collection, and mutates collections only after all user decisions succeed. Invalid CSV and every cancellation route return before collection/default mutation. The legacy Yes button's `DialogResult.OK` is explicitly mapped to grouping. The x64 test target build succeeded and the focused suite passed 13 tests; both builds reported pre-existing warnings in dependent projects and no errors. At completion, record the actual full-suite count, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
+All milestones are complete. Users can import valid Pangolin Beyond CSV mark files into the Marks Docker either as collections grouped by source color or as one replacement-color collection. The import guards against malformed input and cancellation without changing a sequence. Automated focused coverage passes 13 tests; the user also confirmed the full build and full unit suite pass. Manual validation confirmed a Vixen Beyond export can be imported back into Vixen and a test file exported by Beyond imports successfully. VIX-3988 comment 40367 records the validation results. No remaining gaps are known.
 
 ## Context and Orientation
 
@@ -204,6 +204,14 @@ Milestone 3 validation evidence:
     dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PangolinBeyondMarkImportTests
     Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13.
 
+Milestone 5 validation evidence supplied by the user:
+
+    Full build: passed.
+    Full unit test suite: passed.
+    Manual: exported marks in Beyond format and re-imported the same file successfully.
+    Manual: imported a test file exported by Beyond successfully.
+    Jira: validation recorded in VIX-3988 comment 40367.
+
 ## Interfaces and Dependencies
 
 No package, solution, or project-reference change is expected. Use existing `System.Globalization.CultureInfo.InvariantCulture`, `System.Drawing.Color`, `System.Windows.Forms` dialogs, `NLog`, `VixenModules.App.Marks.Mark`, `MarkCollection`, `MarkCollectionNameService`, `MessageBoxForm`, and `Common.Controls.ColorManagement.ColorPicker.ColorPicker` dependencies.
@@ -238,3 +246,5 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Completed Milestone 4 by replacing the service placeholder with the legacy file/dialog workflow. It logs and displays the required error title for parse/read failures, maps Yes/No/other dialog results to grouping/single/cancellation behavior, uses the existing ColorPicker, and commits through an internal test seam after all decisions succeed. Added cancellation, unique-name/default-preservation, first-default, and legacy-dialog-result tests; the focused suite now has 13 passing tests.
 
 2026-08-18: Corrected grouped import after manual testing found that the legacy Yes button returns `DialogResult.OK`, not `DialogResult.Yes`. The service now maps both results to grouped import and has direct regression coverage for OK, Yes, No, and Cancel mappings.
+
+2026-08-18: Completed Milestone 5 with user-provided full-build, full-suite, and manual round-trip/import validation. Added the results to VIX-3988 comment 40367; no issue-description changes were needed.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -15,6 +15,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 - [x] (2026-08-18 16:20Z) Implemented the file, decision, color-picker, atomic error, unique-name, and default-selection workflow; the focused suite now passes 13 tests.
 - [x] (2026-08-18 16:34Z) User confirmed the full build and full unit suite pass; verified Vixen Beyond export/import round trip and a Beyond-exported test file; posted the results to VIX-3988 comment 40367.
 - [x] (2026-08-18 00:00Z) Updated the import flow so files with zero or one source color skip the grouping prompt and import directly with their source color; added focused decision coverage and revised the plan and VIX-3988 scope.
+- [x] (2026-08-18 00:00Z) User manually confirmed the updated zero/one-color prompt behavior.
 
 ## Surprises & Discoveries
 
@@ -65,7 +66,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 ## Outcomes & Retrospective
 
-All milestones are complete. Users can import valid Pangolin Beyond CSV mark files into the Marks Docker. Zero- or one-color files import directly as source-color collections, while multi-color files can be grouped by source color or combined into one replacement-color collection. The import guards against malformed input and cancellation without changing a sequence. The follow-up Release x64 test-target build, 17 focused tests, and 760-test full suite pass. Manual validation confirmed a Vixen Beyond export can be imported back into Vixen and a test file exported by Beyond imports successfully. VIX-3988 records the validation and amended scope. No remaining gaps are known.
+All milestones are complete. Users can import valid Pangolin Beyond CSV mark files into the Marks Docker. Zero- or one-color files import directly as source-color collections, while multi-color files can be grouped by source color or combined into one replacement-color collection. The import guards against malformed input and cancellation without changing a sequence. The follow-up Release x64 test-target build, 17 focused tests, and 760-test full suite pass. Manual validation confirmed Vixen Beyond export/import round trips, import of a Beyond-exported test file, and the updated zero/one-color prompt behavior. VIX-3988 records the validation and amended scope. No remaining gaps are known.
 
 ## Context and Orientation
 
@@ -257,3 +258,5 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Revised the scope after follow-up product feedback: files with zero or one distinct Beyond color now bypass the grouping prompt and import directly using their source color. The multi-color Yes/No/Cancel and replacement-color behavior remains unchanged. Added an internal decision seam and focused coverage for zero, one, and multiple colors; VIX-3988 was updated to reflect the user-visible requirement.
 
 2026-08-18: Follow-up validation passed with the Release x64 `Vixen_Tests` target build, 17 focused `PangolinBeyondMarkImportTests`, and the complete 760-test `Vixen.Tests` suite.
+
+2026-08-18: User manually confirmed that the updated zero/one-color import behavior works as intended.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -10,7 +10,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 - [x] (2026-08-18 00:00Z) Inspected the existing import dialog, import/export service, Marks Docker dispatch, mark model, unique-name helper use, ColorPicker use, and test-project visibility.
 - [x] (2026-08-18 15:46Z) Updated VIX-3988 with the user-facing Summary, Scope, Acceptance Criteria, and Validation Plan.
-- [ ] Add the Pangolin Beyond import choice and service dispatch.
+- [x] (2026-08-18 15:49Z) Added the Pangolin Beyond dialog selection, Marks Docker dispatch, and documented compile-safe service entry point; the affected Release build succeeded.
 - [ ] Add pure parser and materializer internals plus focused unit tests.
 - [ ] Implement the file, choice, color-picker, and collection-mutation workflow.
 - [ ] Build, run focused and full tests, perform a manual editor import check, and post validation results to VIX-3988.
@@ -46,7 +46,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 ## Outcomes & Retrospective
 
-Milestone 1 is complete: VIX-3988 now describes the import outcome, cancellation and invalid-file safeguards, and reviewable acceptance criteria. Implementation has not started. At completion, record the actual test counts, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
+Milestones 1 and 2 are complete. The UI now offers and routes the Pangolin Beyond selection, but its service entry point intentionally performs no import until the parser and workflow milestones are complete. The affected `TimedSequenceEditor` Release build succeeded; it reported pre-existing warnings in dependent projects and no errors. At completion, record the actual test counts, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
 
 ## Context and Orientation
 
@@ -208,3 +208,5 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Initial ExecPlan created from the VIX-3988 handoff after source inspection of the existing import/export flow, WinForms selection dialog, Marks model, ColorPicker API, unique-name behavior, and test visibility. The plan resolves grouping order, parsing strictness, duration preservation, and no-mutation sequencing explicitly so implementation can proceed without relying on the handoff.
 
 2026-08-18: Completed Milestone 1 by updating VIX-3988 with a concise user-facing Summary, Scope, Acceptance Criteria, and Validation Plan. Detailed parser, UI, and test design remains in this repository-local ExecPlan.
+
+2026-08-18: Completed Milestone 2 by adding the legacy dialog radio button and `IsPangolinBeyondSelection` property, routing it from Marks Docker, and adding the documented `ImportPangolinBeyondMarks` entry point. Verified with `msbuild src\\Vixen.Modules\\Editor\\TimedSequenceEditor\\TimedSequenceEditor.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -v:m`, which completed with zero errors.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -12,7 +12,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 - [x] (2026-08-18 15:46Z) Updated VIX-3988 with the user-facing Summary, Scope, Acceptance Criteria, and Validation Plan.
 - [x] (2026-08-18 15:49Z) Added the Pangolin Beyond dialog selection, Marks Docker dispatch, and documented compile-safe service entry point; the affected Release build succeeded.
 - [x] (2026-08-18 16:00Z) Added pure internal parser/materializer types and seven focused tests; the x64 test target build and `PangolinBeyondMarkImportTests` pass.
-- [ ] Implement the file, choice, color-picker, and collection-mutation workflow.
+- [x] (2026-08-18 16:20Z) Implemented the file, decision, color-picker, atomic error, unique-name, and default-selection workflow; the focused suite now passes 13 tests.
 - [ ] Build, run focused and full tests, perform a manual editor import check, and post validation results to VIX-3988.
 
 ## Surprises & Discoveries
@@ -28,6 +28,9 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 
 - Observation: `MarkCollection.AddMarks` enumerates its input once to assign parents and again to add it.
   Evidence: The initial focused factory test passed a lazy projection and observed two resulting marks with `Parent == null`; materializing the `Mark` list before the single `AddMarks` invocation made all seven focused tests pass.
+
+- Observation: `MessageBoxForm` presents its `OK` button as “YES” but retains `DialogResult.OK`.
+  Evidence: `MessageBoxForm.cs` changes `buttonOk.Text` for `YesNoCancel`, while its designer assigns `buttonOk.DialogResult = DialogResult.OK`; treating only `DialogResult.Yes` caused grouped imports to return without adding collections.
 
 ## Decision Log
 
@@ -47,9 +50,17 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
   Rationale: This guarantees invalid-file atomicity and avoids prompting the user for an import that cannot succeed.
   Date/Author: 2026-08-18 / Codex
 
+- Decision: Expose an internal append seam that accepts already parsed records and a nullable import mode.
+  Rationale: The WinForms dialogs must stay in the legacy service, but the nullable mode makes cancellation/no-mutation, unique-name insertion, and default-selection behavior directly testable without automating dialogs.
+  Date/Author: 2026-08-18 / Codex
+
+- Decision: Map the legacy dialog's `DialogResult.OK` to the grouped (Yes) import choice.
+  Rationale: The existing `MessageBoxForm` labels its OK button “YES” without changing its DialogResult. Accepting both `OK` and `Yes` keeps the user-visible choice correct and makes the mapping explicit in tests.
+  Date/Author: 2026-08-18 / Codex
+
 ## Outcomes & Retrospective
 
-Milestones 1 through 3 are complete. The UI now offers and routes the Pangolin Beyond selection, and pure internal parsing/materialization code validates Vixen's CSV shape, BGR colors, grouping order, and default durations. The service entry point intentionally performs no import until the file/dialog workflow milestone is complete. The x64 test target build succeeded and the focused suite passed 7 tests; both builds reported pre-existing warnings in dependent projects and no errors. At completion, record the actual full-suite count, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
+Milestones 1 through 4 are complete. The service now reads and fully parses the selected CSV before asking the user whether to group colors, uses the existing ColorPicker for a single replacement-color collection, and mutates collections only after all user decisions succeed. Invalid CSV and every cancellation route return before collection/default mutation. The legacy Yes button's `DialogResult.OK` is explicitly mapped to grouping. The x64 test target build succeeded and the focused suite passed 13 tests; both builds reported pre-existing warnings in dependent projects and no errors. At completion, record the actual full-suite count, manual import result, final tracker update, and any environment limitation here; compare them with the user-visible import behavior described above.
 
 ## Context and Orientation
 
@@ -191,7 +202,7 @@ Milestone 3 validation evidence:
     Build succeeded with zero errors.
 
     dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PangolinBeyondMarkImportTests
-    Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7.
+    Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13.
 
 ## Interfaces and Dependencies
 
@@ -223,3 +234,7 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Completed Milestone 2 by adding the legacy dialog radio button and `IsPangolinBeyondSelection` property, routing it from Marks Docker, and adding the documented `ImportPangolinBeyondMarks` entry point. Verified with `msbuild src\\Vixen.Modules\\Editor\\TimedSequenceEditor\\TimedSequenceEditor.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -v:m`, which completed with zero errors.
 
 2026-08-18: Completed Milestone 3 by adding separate internal record, mode, parser, and collection-factory files plus seven focused tests. The initial test exposed that `MarkCollection.AddMarks` re-enumerates its input, so the factory now materializes marks before its required single bulk-add call.
+
+2026-08-18: Completed Milestone 4 by replacing the service placeholder with the legacy file/dialog workflow. It logs and displays the required error title for parse/read failures, maps Yes/No/other dialog results to grouping/single/cancellation behavior, uses the existing ColorPicker, and commits through an internal test seam after all decisions succeed. Added cancellation, unique-name/default-preservation, first-default, and legacy-dialog-result tests; the focused suite now has 13 passing tests.
+
+2026-08-18: Corrected grouped import after manual testing found that the legacy Yes button returns `DialogResult.OK`, not `DialogResult.Yes`. The service now maps both results to grouped import and has direct regression coverage for OK, Yes, No, and Cancel mappings.

--- a/docs/plans/vix-3988-pangolin-beyond-mark-import.md
+++ b/docs/plans/vix-3988-pangolin-beyond-mark-import.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. Maintain its `Progress`, `Surprises & Discov
 
 ## Purpose / Big Picture
 
-Timed Sequence Editor users can already export mark collections in Pangolin Beyond's CSV shape, but cannot bring that CSV back into the Marks Docker. After this work, a user can choose `Pangolin Beyond` from the existing import-type dialog, select a CSV exported by Vixen, and either retain the source colors as separate mark collections or replace every source color with one selected color. The user can see the imported marks immediately in the Marks Bar; invalid files and cancelled choices leave the current sequence unchanged.
+Timed Sequence Editor users can already export mark collections in Pangolin Beyond's CSV shape, but cannot bring that CSV back into the Marks Docker. After this work, a user can choose `Pangolin Beyond` from the existing import-type dialog and select a CSV exported by Vixen. A file with zero or one source color imports directly as source-color collections; a multi-color file lets the user either retain source colors as separate mark collections or replace every source color with one selected color. The user can see the imported marks immediately in the Marks Bar; invalid files and cancelled choices leave the current sequence unchanged.
 
 ## Progress
 
@@ -14,6 +14,7 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
 - [x] (2026-08-18 16:00Z) Added pure internal parser/materializer types and seven focused tests; the x64 test target build and `PangolinBeyondMarkImportTests` pass.
 - [x] (2026-08-18 16:20Z) Implemented the file, decision, color-picker, atomic error, unique-name, and default-selection workflow; the focused suite now passes 13 tests.
 - [x] (2026-08-18 16:34Z) User confirmed the full build and full unit suite pass; verified Vixen Beyond export/import round trip and a Beyond-exported test file; posted the results to VIX-3988 comment 40367.
+- [x] (2026-08-18 00:00Z) Updated the import flow so files with zero or one source color skip the grouping prompt and import directly with their source color; added focused decision coverage and revised the plan and VIX-3988 scope.
 
 ## Surprises & Discoveries
 
@@ -58,9 +59,13 @@ Timed Sequence Editor users can already export mark collections in Pangolin Beyo
   Rationale: The existing `MessageBoxForm` labels its OK button “YES” without changing its DialogResult. Accepting both `OK` and `Yes` keeps the user-visible choice correct and makes the mapping explicit in tests.
   Date/Author: 2026-08-18 / Codex
 
+- Decision: Show the grouping and replacement-color choice only when parsed Beyond data contains more than one distinct source color.
+  Rationale: A zero- or one-color file has no grouping decision to make, so it imports directly using the source color and avoids an unnecessary prompt.
+  Date/Author: 2026-08-18 / Codex
+
 ## Outcomes & Retrospective
 
-All milestones are complete. Users can import valid Pangolin Beyond CSV mark files into the Marks Docker either as collections grouped by source color or as one replacement-color collection. The import guards against malformed input and cancellation without changing a sequence. Automated focused coverage passes 13 tests; the user also confirmed the full build and full unit suite pass. Manual validation confirmed a Vixen Beyond export can be imported back into Vixen and a test file exported by Beyond imports successfully. VIX-3988 comment 40367 records the validation results. No remaining gaps are known.
+All milestones are complete. Users can import valid Pangolin Beyond CSV mark files into the Marks Docker. Zero- or one-color files import directly as source-color collections, while multi-color files can be grouped by source color or combined into one replacement-color collection. The import guards against malformed input and cancellation without changing a sequence. The follow-up Release x64 test-target build, 17 focused tests, and 760-test full suite pass. Manual validation confirmed a Vixen Beyond export can be imported back into Vixen and a test file exported by Beyond imports successfully. VIX-3988 records the validation and amended scope. No remaining gaps are known.
 
 ## Context and Orientation
 
@@ -114,7 +119,7 @@ Add `ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection> collections
 
 If parsing fails, construct a specific NLog error containing the parser error and file path (include an exception only if one occurred), show `MessageBoxForm` with the title exactly `Pangolin Beyond Import Error`, and return. Do not add a collection, change an existing collection, set a default, or show the grouping question on this path. Also catch read/unexpected errors around this workflow, log them, show that same title, and preserve the same no-mutation guarantee.
 
-After a successful parse, ask with Yes/No/Cancel using the existing `MessageBoxForm`/WinForms dialog conventions and exact prompt text `Create a Mark Collection for each Beyond color?`. Map Yes to `PangolinBeyondImportMode.GroupByColor`. Map No to `SingleCollection`, then show the existing `ColorPicker`; if it returns anything other than `DialogResult.OK`, return without mutation. Convert its selected XYZ color with `picker.Color.ToRGB().ToArgb()`. Map Cancel, form-close, or any other result to an immediate no-mutation return. Dispose the ColorPicker with `using` so its message filter is removed.
+After a successful parse, count distinct source colors. For zero or one color, select `PangolinBeyondImportMode.GroupByColor` directly and do not show a choice dialog. For more than one color, ask with Yes/No/Cancel using the existing `MessageBoxForm`/WinForms dialog conventions and exact prompt text `Create a Mark Collection for each Beyond color?`. Map Yes to `PangolinBeyondImportMode.GroupByColor`. Map No to `SingleCollection`, then show the existing `ColorPicker`; if it returns anything other than `DialogResult.OK`, return without mutation. Convert its selected XYZ color with `picker.Color.ToRGB().ToArgb()`. Map Cancel, form-close, or any other result to an immediate no-mutation return. Dispose the ColorPicker with `using` so its message filter is removed.
 
 Only after a successful mode and, where required, color selection, call the materializer. Then append every fully constructed collection with `AddUniqueCollection(collections, collection)`, retaining the materializer order. Once all additions are complete, call `SetDefaultCollection(collections)` only if `collections.Any(x => x.IsDefault)` is false. This sequencing ensures failed parse, prompt cancellation, and picker cancellation cannot produce partial imports. Do not add a new dialog, do not move UI behavior out of the import service, and do not alter the existing Beyond export branch.
 
@@ -170,9 +175,9 @@ All commands run from `C:\Dev\Vixen`.
 
 The feature is accepted when the import dialog has a selectable Pangolin Beyond format and the user can import a Vixen-exported Beyond CSV through it. A file with the exact header and valid four-field rows must parse invariantly, preserve mark text and start time, translate BGR colors correctly, preserve the 450 ms default duration, and create visible collections.
 
-Yes must create one `Beyond Marks - #RRGGBB` collection for each source RGB color in first-occurrence order. No must show the existing ColorPicker and, after confirmation, create one `Beyond Marks` collection whose decorator is the selected replacement color. The collections must get unique names, marks must be bulk-added once per collection, and default selection must only be supplied when absent. Cancel at either decision point must leave collections untouched.
+A zero- or one-color file must import directly, without a grouping prompt, as one source-color `Beyond Marks - #RRGGBB` collection when records exist. For a multi-color file, Yes must create one `Beyond Marks - #RRGGBB` collection for each source RGB color in first-occurrence order. No must show the existing ColorPicker and, after confirmation, create one `Beyond Marks` collection whose decorator is the selected replacement color. The collections must get unique names, marks must be bulk-added once per collection, and default selection must only be supplied when absent. Cancel at either multi-color decision point must leave collections untouched.
 
-For malformed headers, non-four-column rows, invalid timestamps, or invalid colors, the application must log an NLog error, display `Pangolin Beyond Import Error`, and make no collection/default changes. Automated tests must cover parsing, BGR conversion, both time forms, both materialization modes, grouping order, uniqueness/default append behavior where exposed, cancellation/no-mutation seams, and invalid-input atomicity. The focused and full `Vixen.Tests` commands must have zero failures, and the manual scenarios in Milestone 5 must pass.
+For malformed headers, non-four-column rows, invalid timestamps, or invalid colors, the application must log an NLog error, display `Pangolin Beyond Import Error`, and make no collection/default changes. Automated tests must cover parsing, BGR conversion, both time forms, the zero/one/multiple-color prompt decision, both materialization modes, grouping order, uniqueness/default append behavior where exposed, cancellation/no-mutation seams, and invalid-input atomicity. The focused and full `Vixen.Tests` commands must have zero failures, and the manual scenarios in Milestone 5 must pass.
 
 ## Idempotence and Recovery
 
@@ -248,3 +253,7 @@ The exact helper signatures may be adjusted only to keep parsing and materializa
 2026-08-18: Corrected grouped import after manual testing found that the legacy Yes button returns `DialogResult.OK`, not `DialogResult.Yes`. The service now maps both results to grouped import and has direct regression coverage for OK, Yes, No, and Cancel mappings.
 
 2026-08-18: Completed Milestone 5 with user-provided full-build, full-suite, and manual round-trip/import validation. Added the results to VIX-3988 comment 40367; no issue-description changes were needed.
+
+2026-08-18: Revised the scope after follow-up product feedback: files with zero or one distinct Beyond color now bypass the grouping prompt and import directly using their source color. The multi-color Yes/No/Cancel and replacement-color behavior remains unchanged. Added an internal decision seam and focused coverage for zero, one, and multiple colors; VIX-3988 was updated to reflect the user-visible requirement.
+
+2026-08-18: Follow-up validation passed with the Release x64 `Vixen_Tests` target build, 17 focused `PangolinBeyondMarkImportTests`, and the complete 760-test `Vixen.Tests` suite.

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
@@ -25,11 +25,114 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
 		/// <summary>
 		/// Imports mark collections from a Pangolin Beyond CSV file.
 		/// </summary>
+		/// <remarks>
+		/// Parses the complete file before prompting for import options or changing <paramref name="collections" />.
+		/// Cancelling either import prompt leaves the collection set unchanged.
+		/// </remarks>
 		/// <param name="collections">The mark collections in the active timed sequence.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="collections" /> is <see langword="null" />.</exception>
 		public static void ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection> collections)
 		{
 			ArgumentNullException.ThrowIfNull(collections);
-			Logging.Debug("Pangolin Beyond mark import has not yet been implemented.");
+
+			using var openFileDialog = new OpenFileDialog
+			{
+				DefaultExt = ".csv",
+				Filter = @"Pangolin Beyond CSV (*.csv)|*.csv|All Files (*.*)|*.*",
+				FilterIndex = 0,
+				InitialDirectory = _lastFolder
+			};
+			if (openFileDialog.ShowDialog() != DialogResult.OK)
+			{
+				return;
+			}
+
+			_lastFolder = Path.GetDirectoryName(openFileDialog.FileName);
+			try
+			{
+				var csv = File.ReadAllText(openFileDialog.FileName);
+				if (!PangolinBeyondMarkParser.TryParse(csv, out var records, out var error))
+				{
+					Logging.Error("Unable to import Pangolin Beyond marks from {FileName}: {Error}", openFileDialog.FileName, error);
+					ShowPangolinBeyondImportError();
+					return;
+				}
+
+				using var choiceDialog = new MessageBoxForm(
+					"Create a Mark Collection for each Beyond color?",
+					"Pangolin Beyond Import",
+					MessageBoxButtons.YesNoCancel,
+					SystemIcons.Question);
+				var choice = choiceDialog.ShowDialog();
+				var importMode = GetPangolinBeyondImportMode(choice);
+				if (importMode is null)
+				{
+					return;
+				}
+
+				var replacementColor = Color.Empty;
+				if (importMode == PangolinBeyondImportMode.SingleCollection)
+				{
+					using var colorPicker = new Common.Controls.ColorManagement.ColorPicker.ColorPicker();
+					if (colorPicker.ShowDialog() != DialogResult.OK)
+					{
+						return;
+					}
+
+					replacementColor = colorPicker.Color.ToRGB().ToArgb();
+				}
+
+				TryAddPangolinBeyondMarks(collections, records, importMode, replacementColor);
+			}
+			catch (Exception ex)
+			{
+				Logging.Error(ex, "Unable to import Pangolin Beyond marks from {FileName}", openFileDialog.FileName);
+				ShowPangolinBeyondImportError();
+			}
+		}
+
+		internal static PangolinBeyondImportMode? GetPangolinBeyondImportMode(DialogResult dialogResult)
+		{
+			return dialogResult switch
+			{
+				DialogResult.OK or DialogResult.Yes => PangolinBeyondImportMode.GroupByColor,
+				DialogResult.No => PangolinBeyondImportMode.SingleCollection,
+				_ => null
+			};
+		}
+
+		internal static bool TryAddPangolinBeyondMarks(
+			ObservableCollection<IMarkCollection> collections,
+			IReadOnlyList<PangolinBeyondMarkRecord> records,
+			PangolinBeyondImportMode? importMode,
+			Color replacementColor)
+		{
+			ArgumentNullException.ThrowIfNull(collections);
+			ArgumentNullException.ThrowIfNull(records);
+			if (importMode is null)
+			{
+				return false;
+			}
+
+			var importedCollections = PangolinBeyondMarkCollectionFactory.CreateCollections(records, importMode.Value, replacementColor);
+			foreach (var importedCollection in importedCollections)
+			{
+				AddUniqueCollection(collections, importedCollection);
+			}
+
+			if (importedCollections.Count > 0 && !collections.Any(collection => collection.IsDefault))
+			{
+				SetDefaultCollection(collections);
+			}
+
+			return true;
+		}
+
+		private static void ShowPangolinBeyondImportError()
+		{
+			const string message = "There was an error importing the Pangolin Beyond marks.";
+			using var messageBox = new MessageBoxForm(message, "Pangolin Beyond Import Error", MessageBoxButtons.OK, SystemIcons.Error);
+			messageBox.ShowDialog();
 		}
 
 		//Vixen 3 Beat Mark Collection Import routine 2-7-2014 JMB

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
@@ -22,6 +22,15 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
 
 		private static string _lastFolder = Paths.DataRootPath;
 
+		/// <summary>
+		/// Imports mark collections from a Pangolin Beyond CSV file.
+		/// </summary>
+		/// <param name="collections">The mark collections in the active timed sequence.</param>
+		public static void ImportPangolinBeyondMarks(ObservableCollection<IMarkCollection> collections)
+		{
+			ArgumentNullException.ThrowIfNull(collections);
+			Logging.Debug("Pangolin Beyond mark import has not yet been implemented.");
+		}
 
 		//Vixen 3 Beat Mark Collection Import routine 2-7-2014 JMB
 		public static void ImportVixen3Beats(ObservableCollection<IMarkCollection> collections)

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/MarkImportExportService.cs
@@ -27,6 +27,8 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
 		/// </summary>
 		/// <remarks>
 		/// Parses the complete file before prompting for import options or changing <paramref name="collections" />.
+		/// Files with zero or one source color import directly with their source color; files with multiple source colors
+		/// prompt for the collection arrangement.
 		/// Cancelling either import prompt leaves the collection set unchanged.
 		/// </remarks>
 		/// <param name="collections">The mark collections in the active timed sequence.</param>
@@ -58,16 +60,21 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
 					return;
 				}
 
-				using var choiceDialog = new MessageBoxForm(
-					"Create a Mark Collection for each Beyond color?",
-					"Pangolin Beyond Import",
-					MessageBoxButtons.YesNoCancel,
-					SystemIcons.Question);
-				var choice = choiceDialog.ShowDialog();
-				var importMode = GetPangolinBeyondImportMode(choice);
-				if (importMode is null)
+				var importMode = PangolinBeyondImportMode.GroupByColor;
+				if (RequiresPangolinBeyondColorChoice(records))
 				{
-					return;
+					using var choiceDialog = new MessageBoxForm(
+						"Create a Mark Collection for each Beyond color?",
+						"Pangolin Beyond Import",
+						MessageBoxButtons.YesNoCancel,
+						SystemIcons.Question);
+					var choice = GetPangolinBeyondImportMode(choiceDialog.ShowDialog());
+					if (choice is null)
+					{
+						return;
+					}
+
+					importMode = choice.Value;
 				}
 
 				var replacementColor = Color.Empty;
@@ -99,6 +106,13 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
 				DialogResult.No => PangolinBeyondImportMode.SingleCollection,
 				_ => null
 			};
+		}
+
+		internal static bool RequiresPangolinBeyondColorChoice(IReadOnlyList<PangolinBeyondMarkRecord> records)
+		{
+			ArgumentNullException.ThrowIfNull(records);
+
+			return records.Select(record => record.Color).Distinct().Skip(1).Any();
 		}
 
 		internal static bool TryAddPangolinBeyondMarks(

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondImportMode.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondImportMode.cs
@@ -1,0 +1,8 @@
+namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
+{
+	internal enum PangolinBeyondImportMode
+	{
+		GroupByColor,
+		SingleCollection
+	}
+}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkCollectionFactory.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkCollectionFactory.cs
@@ -1,0 +1,57 @@
+using System.Drawing;
+using VixenModules.App.Marks;
+
+namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
+{
+	internal static class PangolinBeyondMarkCollectionFactory
+	{
+		internal static IReadOnlyList<MarkCollection> CreateCollections(
+			IReadOnlyList<PangolinBeyondMarkRecord> records,
+			PangolinBeyondImportMode importMode,
+			Color replacementColor)
+		{
+			ArgumentNullException.ThrowIfNull(records);
+
+			return importMode switch
+			{
+				PangolinBeyondImportMode.GroupByColor => CreateColorCollections(records),
+				PangolinBeyondImportMode.SingleCollection => [CreateCollection("Beyond Marks", replacementColor, records)],
+				_ => throw new ArgumentOutOfRangeException(nameof(importMode), importMode, @"Unsupported Pangolin Beyond import mode.")
+			};
+		}
+
+		private static IReadOnlyList<MarkCollection> CreateColorCollections(IReadOnlyList<PangolinBeyondMarkRecord> records)
+		{
+			var recordsByColor = new Dictionary<Color, List<PangolinBeyondMarkRecord>>();
+			var colorOrder = new List<Color>();
+			foreach (var record in records)
+			{
+				if (!recordsByColor.TryGetValue(record.Color, out var colorRecords))
+				{
+					colorRecords = [];
+					recordsByColor.Add(record.Color, colorRecords);
+					colorOrder.Add(record.Color);
+				}
+
+				colorRecords.Add(record);
+			}
+
+			return colorOrder
+				.Select(color => CreateCollection($"Beyond Marks - #{color.R:X2}{color.G:X2}{color.B:X2}", color, recordsByColor[color]))
+				.ToList();
+		}
+
+		private static MarkCollection CreateCollection(string name, Color color, IEnumerable<PangolinBeyondMarkRecord> records)
+		{
+			var marks = records.Select(record => new Mark(record.StartTime) { Text = record.Text }).ToList();
+			var collection = new MarkCollection
+			{
+				Name = name,
+				ShowMarkBar = true
+			};
+			collection.Decorator.Color = color;
+			collection.AddMarks(marks);
+			return collection;
+		}
+	}
+}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkParser.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkParser.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+
+namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
+{
+	internal static class PangolinBeyondMarkParser
+	{
+		private const string Header = "#,Name,Start,Color";
+		private static readonly string[] TimeFormats = [@"mm\:ss\.fff", @"hh\:mm\:ss\.fff"];
+
+		internal static bool TryParse(string csv, out IReadOnlyList<PangolinBeyondMarkRecord> marks, out string error)
+		{
+			marks = [];
+			error = string.Empty;
+
+			if (string.IsNullOrEmpty(csv))
+			{
+				error = "The Pangolin Beyond CSV file is empty.";
+				return false;
+			}
+
+			var lines = csv.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n').ToList();
+			if (lines[^1].Length == 0)
+			{
+				lines.RemoveAt(lines.Count - 1);
+			}
+
+			if (lines.Count == 0 || !string.Equals(lines[0], Header, StringComparison.Ordinal))
+			{
+				error = "Line 1 must be the Pangolin Beyond header '#,Name,Start,Color'.";
+				return false;
+			}
+
+			var parsedMarks = new List<PangolinBeyondMarkRecord>(lines.Count - 1);
+			for (var index = 1; index < lines.Count; index++)
+			{
+				var lineNumber = index + 1;
+				var fields = lines[index].Split(',');
+				if (fields.Length != 4)
+				{
+					error = $"Line {lineNumber} must contain exactly four comma-separated columns.";
+					return false;
+				}
+
+				if (!TimeSpan.TryParseExact(fields[2], TimeFormats, CultureInfo.InvariantCulture, out var startTime))
+				{
+					error = $"Line {lineNumber} has an invalid start time '{fields[2]}'.";
+					return false;
+				}
+
+				if (!TryParseBgrColor(fields[3], out var color))
+				{
+					error = $"Line {lineNumber} has an invalid BGR color '{fields[3]}'.";
+					return false;
+				}
+
+				parsedMarks.Add(new PangolinBeyondMarkRecord(fields[1], startTime, color));
+			}
+
+			marks = parsedMarks;
+			return true;
+		}
+
+		private static bool TryParseBgrColor(string value, out Color color)
+		{
+			color = Color.Empty;
+			if (value.Length != 6 || value.Any(character => !Uri.IsHexDigit(character)))
+			{
+				return false;
+			}
+
+			if (!byte.TryParse(value.AsSpan(0, 2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out var blue)
+				|| !byte.TryParse(value.AsSpan(2, 2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out var green)
+				|| !byte.TryParse(value.AsSpan(4, 2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out var red))
+			{
+				return false;
+			}
+
+			color = Color.FromArgb(red, green, blue);
+			return true;
+		}
+	}
+}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkRecord.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/Services/PangolinBeyondMarkRecord.cs
@@ -1,0 +1,6 @@
+using System.Drawing;
+
+namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services
+{
+	internal readonly record struct PangolinBeyondMarkRecord(string Text, TimeSpan StartTime, Color Color);
+}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkDockerViewModel.cs
@@ -137,6 +137,8 @@ namespace VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.ViewMode
 					MarkImportExportService.ImportPapagayoTracks(MarkCollections);
 				if(aDialog.IsTimingTrackBrowserSelection)
 					MarkImportExportService.ImportSingingFacesTracks(MarkCollections);
+				if (aDialog.IsPangolinBeyondSelection)
+					MarkImportExportService.ImportPangolinBeyondMarks(MarkCollections);
 			}
 		}
 

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.Designer.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.Designer.cs
@@ -37,6 +37,7 @@
             this.radioXTiming = new System.Windows.Forms.RadioButton();
             this.radioPapagayo = new System.Windows.Forms.RadioButton();
             this.radioTimingTrackBrowser = new System.Windows.Forms.RadioButton();
+            this.radioPangolinBeyond = new System.Windows.Forms.RadioButton();
             this.SuspendLayout();
             // 
             // radioVixen3Beats
@@ -84,7 +85,7 @@
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			btnCancel.Location = new Point(105, 205);
+			btnCancel.Location = new Point(105, 231);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(87, 27);
             this.btnCancel.TabIndex = 1;
@@ -94,7 +95,7 @@
             // btnOk
             // 
             this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-			btnOk.Location = new Point(12, 205);
+			btnOk.Location = new Point(12, 231);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(87, 27);
             this.btnOk.TabIndex = 2;
@@ -131,13 +132,24 @@
             this.radioTimingTrackBrowser.Text = "Singing Faces Lyric Browser";
             this.radioTimingTrackBrowser.UseVisualStyleBackColor = true;
             // 
+			// radioPangolinBeyond
+			//
+			this.radioPangolinBeyond.AutoSize = true;
+			radioPangolinBeyond.Location = new Point(12, 193);
+			this.radioPangolinBeyond.Name = "radioPangolinBeyond";
+			this.radioPangolinBeyond.Size = new System.Drawing.Size(117, 19);
+			this.radioPangolinBeyond.TabIndex = 7;
+			this.radioPangolinBeyond.Text = "Pangolin Beyond";
+			this.radioPangolinBeyond.UseVisualStyleBackColor = true;
+			//
             // MarkCollectionImportDialog
             // 
             this.AcceptButton = this.btnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-			ClientSize = new Size(207, 244);
+			ClientSize = new Size(207, 270);
+			this.Controls.Add(this.radioPangolinBeyond);
             this.Controls.Add(this.radioTimingTrackBrowser);
             this.Controls.Add(this.radioPapagayo);
             this.Controls.Add(this.radioXTiming);
@@ -150,7 +162,7 @@
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
 			this.MaximizeBox = false;
             this.MinimizeBox = false;
-			MinimumSize = new Size(150, 283);
+			MinimumSize = new Size(150, 309);
             this.Name = "MarkCollectionImportDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Import Type Selection";
@@ -170,5 +182,6 @@
 		private System.Windows.Forms.RadioButton radioXTiming;
 		private System.Windows.Forms.RadioButton radioPapagayo;
         private System.Windows.Forms.RadioButton radioTimingTrackBrowser;
+		private System.Windows.Forms.RadioButton radioPangolinBeyond;
     }
 }

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/MarkCollectionImportDialog.cs
@@ -43,6 +43,12 @@ namespace VixenModules.Editor.TimedSequenceEditor
 			}
 		}
 
+		/// <summary>
+		/// Gets a value that indicates whether Pangolin Beyond import is selected.
+		/// </summary>
+		/// <value><see langword="true" /> if Pangolin Beyond import is selected; otherwise, <see langword="false" />.</value>
+		public bool IsPangolinBeyondSelection => radioPangolinBeyond.Checked;
+
         public bool IsTimingTrackBrowserSelection => radioTimingTrackBrowser.Checked;
 
         public bool IsPapagayoSelection => radioPapagayo.Checked;

--- a/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
+++ b/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
@@ -116,6 +116,41 @@ public sealed class PangolinBeyondMarkImportTests
 		Assert.True(existingCollection.IsDefault);
 	}
 
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	[InlineData(2, true)]
+	public void RequiresPangolinBeyondColorChoice_ReturnsTrueOnlyForMultipleSourceColors(int colorCount, bool expected)
+	{
+		// Arrange
+		IReadOnlyList<PangolinBeyondMarkRecord> records = Enumerable.Range(0, colorCount)
+			.Select(index => new PangolinBeyondMarkRecord($"Mark {index}", TimeSpan.FromSeconds(index), Color.FromArgb(index, index, index)))
+			.ToList();
+
+		// Act
+		var requiresChoice = MarkImportExportService.RequiresPangolinBeyondColorChoice(records);
+
+		// Assert
+		Assert.Equal(expected, requiresChoice);
+	}
+
+	[Fact]
+	public void RequiresPangolinBeyondColorChoice_RepeatedSourceColor_ReturnsFalse()
+	{
+		// Arrange
+		IReadOnlyList<PangolinBeyondMarkRecord> records =
+		[
+			new("Intro", TimeSpan.FromSeconds(1), Color.Red),
+			new("Chorus", TimeSpan.FromSeconds(2), Color.Red)
+		];
+
+		// Act
+		var requiresChoice = MarkImportExportService.RequiresPangolinBeyondColorChoice(records);
+
+		// Assert
+		Assert.False(requiresChoice);
+	}
+
 	[Fact]
 	public void GetPangolinBeyondImportMode_LegacyYesChoice_ReturnsGroupByColor()
 	{

--- a/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
+++ b/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
@@ -1,4 +1,8 @@
 using System.Drawing;
+using System.Collections.ObjectModel;
+using System.Windows.Forms;
+using Vixen.Marks;
+using VixenModules.App.Marks;
 using VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services;
 using Xunit;
 
@@ -92,5 +96,94 @@ public sealed class PangolinBeyondMarkImportTests
 		Assert.Equal(replacementColor, collection.Decorator.Color);
 		Assert.Equal(["Intro", "Chorus"], collection.Marks.Select(mark => mark.Text));
 		Assert.All(collection.Marks, mark => Assert.Equal(TimeSpan.FromMilliseconds(450), mark.Duration));
+	}
+
+	[Fact]
+	public void TryAddPangolinBeyondMarks_Cancelled_DoesNotMutateCollections()
+	{
+		// Arrange
+		var existingCollection = new MarkCollection { Name = "Existing", IsDefault = true };
+		var collections = new ObservableCollection<IMarkCollection> { existingCollection };
+		IReadOnlyList<PangolinBeyondMarkRecord> records = [new("Intro", TimeSpan.FromSeconds(1), Color.Red)];
+
+		// Act
+		var imported = MarkImportExportService.TryAddPangolinBeyondMarks(collections, records, null, Color.Empty);
+
+		// Assert
+		Assert.False(imported);
+		var collection = Assert.Single(collections);
+		Assert.Same(existingCollection, collection);
+		Assert.True(existingCollection.IsDefault);
+	}
+
+	[Fact]
+	public void GetPangolinBeyondImportMode_LegacyYesChoice_ReturnsGroupByColor()
+	{
+		// Act
+		var importMode = MarkImportExportService.GetPangolinBeyondImportMode(DialogResult.OK);
+
+		// Assert
+		Assert.Equal(PangolinBeyondImportMode.GroupByColor, importMode);
+	}
+
+	[Fact]
+	public void GetPangolinBeyondImportMode_NoChoice_ReturnsSingleCollection()
+	{
+		// Act
+		var importMode = MarkImportExportService.GetPangolinBeyondImportMode(DialogResult.No);
+
+		// Assert
+		Assert.Equal(PangolinBeyondImportMode.SingleCollection, importMode);
+	}
+
+	[Fact]
+	public void GetPangolinBeyondImportMode_CancelledChoice_ReturnsNull()
+	{
+		// Act
+		var importMode = MarkImportExportService.GetPangolinBeyondImportMode(DialogResult.Cancel);
+
+		// Assert
+		Assert.Null(importMode);
+	}
+
+	[Fact]
+	public void TryAddPangolinBeyondMarks_Success_UsesUniqueNamesAndPreservesDefault()
+	{
+		// Arrange
+		var existingCollection = new MarkCollection { Name = "Beyond Marks", IsDefault = true };
+		var collections = new ObservableCollection<IMarkCollection> { existingCollection };
+		IReadOnlyList<PangolinBeyondMarkRecord> records = [new("Intro", TimeSpan.FromSeconds(1), Color.Red)];
+
+		// Act
+		var imported = MarkImportExportService.TryAddPangolinBeyondMarks(
+			collections,
+			records,
+			PangolinBeyondImportMode.SingleCollection,
+			Color.MediumPurple);
+
+		// Assert
+		Assert.True(imported);
+		Assert.Equal(["Beyond Marks", "Beyond Marks - 2"], collections.Select(collection => collection.Name));
+		Assert.True(existingCollection.IsDefault);
+		Assert.False(collections[1].IsDefault);
+	}
+
+	[Fact]
+	public void TryAddPangolinBeyondMarks_NoExistingDefault_SetsOneDefault()
+	{
+		// Arrange
+		var collections = new ObservableCollection<IMarkCollection>();
+		IReadOnlyList<PangolinBeyondMarkRecord> records = [new("Intro", TimeSpan.FromSeconds(1), Color.Red)];
+
+		// Act
+		var imported = MarkImportExportService.TryAddPangolinBeyondMarks(
+			collections,
+			records,
+			PangolinBeyondImportMode.SingleCollection,
+			Color.MediumPurple);
+
+		// Assert
+		Assert.True(imported);
+		Assert.True(Assert.Single(collections).IsDefault);
 	}
 }

--- a/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
+++ b/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
@@ -1,0 +1,96 @@
+using System.Drawing;
+using VixenModules.Editor.TimedSequenceEditor.Forms.WPF.MarksDocker.Services;
+using Xunit;
+
+namespace Vixen.Tests.Sequencer;
+
+public sealed class PangolinBeyondMarkImportTests
+{
+	[Fact]
+	public void TryParse_ValidRows_ParsesTextsTimesAndBgrColors()
+	{
+		// Arrange
+		const string csv = "#,Name,Start,Color\r\nM1,Intro,00:01.250,112233\r\nM2,Chorus,01:02:03.004,A0B0C0\r\n";
+
+		// Act
+		var result = PangolinBeyondMarkParser.TryParse(csv, out var marks, out var error);
+
+		// Assert
+		Assert.True(result);
+		Assert.Empty(error);
+		Assert.Equal(2, marks.Count);
+		Assert.Equal("Intro", marks[0].Text);
+		Assert.Equal(TimeSpan.FromSeconds(1.25), marks[0].StartTime);
+		Assert.Equal(Color.FromArgb(0x33, 0x22, 0x11), marks[0].Color);
+		Assert.Equal(TimeSpan.FromHours(1) + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(3.004), marks[1].StartTime);
+		Assert.Equal(Color.FromArgb(0xC0, 0xB0, 0xA0), marks[1].Color);
+	}
+
+	[Theory]
+	[InlineData("invalid header", "Line 1")]
+	[InlineData("#,Name,Start,Color\nM1,Intro,00:01.250", "Line 2")]
+	[InlineData("#,Name,Start,Color\nM1,Intro,1.25,112233", "Line 2")]
+	[InlineData("#,Name,Start,Color\nM1,Intro,00:01.250,GG2233", "Line 2")]
+	public void TryParse_InvalidCsv_ReturnsLineSpecificError(string csv, string expectedError)
+	{
+		// Act
+		var result = PangolinBeyondMarkParser.TryParse(csv, out var marks, out var error);
+
+		// Assert
+		Assert.False(result);
+		Assert.Empty(marks);
+		Assert.Contains(expectedError, error);
+	}
+
+	[Fact]
+	public void CreateCollections_GroupByColor_PreservesFirstColorOrderAndDefaultMarkDuration()
+	{
+		// Arrange
+		var firstColor = Color.FromArgb(0x33, 0x22, 0x11);
+		var secondColor = Color.FromArgb(0xC0, 0xB0, 0xA0);
+		IReadOnlyList<PangolinBeyondMarkRecord> records =
+		[
+			new("Intro", TimeSpan.FromSeconds(1), firstColor),
+			new("Chorus", TimeSpan.FromSeconds(2), secondColor),
+			new("Again", TimeSpan.FromSeconds(3), firstColor)
+		];
+
+		// Act
+		var collections = PangolinBeyondMarkCollectionFactory.CreateCollections(records, PangolinBeyondImportMode.GroupByColor, Color.Empty);
+
+		// Assert
+		Assert.Equal(["Beyond Marks - #332211", "Beyond Marks - #C0B0A0"], collections.Select(collection => collection.Name));
+		Assert.Equal(firstColor, collections[0].Decorator.Color);
+		Assert.Equal(secondColor, collections[1].Decorator.Color);
+		Assert.All(collections, collection => Assert.True(collection.ShowMarkBar));
+		Assert.Equal(["Intro", "Again"], collections[0].Marks.Select(mark => mark.Text));
+		Assert.All(collections[0].Marks, mark =>
+		{
+			Assert.Equal(TimeSpan.FromMilliseconds(450), mark.Duration);
+			Assert.Same(collections[0], mark.Parent);
+		});
+	}
+
+	[Fact]
+	public void CreateCollections_SingleCollection_UsesReplacementColorForAllMarks()
+	{
+		// Arrange
+		var replacementColor = Color.MediumPurple;
+		IReadOnlyList<PangolinBeyondMarkRecord> records =
+		[
+			new("Intro", TimeSpan.FromSeconds(1), Color.Red),
+			new("Chorus", TimeSpan.FromSeconds(2), Color.Blue)
+		];
+
+		// Act
+		var collections = PangolinBeyondMarkCollectionFactory.CreateCollections(records, PangolinBeyondImportMode.SingleCollection, replacementColor);
+
+		// Assert
+		var collection = Assert.Single(collections);
+		Assert.Equal("Beyond Marks", collection.Name);
+		Assert.True(collection.ShowMarkBar);
+		Assert.Equal(replacementColor, collection.Decorator.Color);
+		Assert.Equal(["Intro", "Chorus"], collection.Marks.Select(mark => mark.Text));
+		Assert.All(collection.Marks, mark => Assert.Equal(TimeSpan.FromMilliseconds(450), mark.Duration));
+	}
+}


### PR DESCRIPTION
## Summary

- Add Pangolin Beyond CSV import to the Timed Sequence Editor Marks Docker.
- Import zero- or one-color files directly using source colors.
- Offer grouped or replacement-color import for multi-color files.
- Reject malformed files without changing the sequence.
- Preserve unique collection names and existing default collection behavior.

## Validation

- Release x64 test-target build passed.
- Focused Beyond import tests: 17 passed.
- Full unit test suite: 760 passed.
- Manual validation confirmed Vixen export/import round trips, native Beyond file import, and streamlined zero/one-color behavior.