### PR TITLE
VIX-3989 Fix Pinwheel sizing constraints

### DIFF
--- a/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
+++ b/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
@@ -15,7 +15,7 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 - [x] (2026-08-21) Added the serialized Size Basis contract, documented property-grid setting, localized display/description resources, and generated resource accessors. The shared radius-basis calculation remains Milestone 3 work.
 - [x] (2026-08-21) Replaced the duplicated string/location radius selection with one private helper that selects the configured percentage basis and preserves the legacy absolute-offset corner-distance calculation.
 - [x] (2026-08-21) Added the PinWheel test-project reference and 17 focused compatibility, rendering, and browsability tests; the Release/x64 focused suite passes.
-- [ ] Run the focused and complete x64 test workflows, manually validate in the UI, update Jira, and record actual evidence here.
+- [x] (2026-08-21) User confirmed the full build and complete unit-test suite pass, and manually validated both the new wide-preview behavior and Height retention for existing effects. Recorded the results in Jira VIX-3989 comment 40372.
 
 ## Surprises & Discoveries
 
@@ -48,7 +48,7 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 
 ## Outcomes & Retrospective
 
-Implementation has not begun. The intended completed outcome is a localized, documented Size Basis setting with safe old-data behavior, parity between both PinWheel render paths, and automated evidence for serialization, cloning, buffer shapes, visibility, and legacy absolute offsets. Record actual results, remaining gaps, test counts, and manual validation here when the work finishes.
+All milestones are complete. PinWheel now provides a localized, documented Size Basis setting that defaults new effects to Largest Dimension while old serialized effects resolve to Height. The shared render helper keeps dense and location paths aligned and preserves absolute-offset behavior. Focused automated coverage verifies serialization, cloning, buffer shapes, visibility, render parity, unknown values, and legacy offsets; the user confirmed the full build, full unit suite, and manual behavior. No remaining gaps are known.
 
 ## Context and Orientation
 
@@ -228,6 +228,14 @@ Milestone 4 validation evidence:
     dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PinWheelSizeScaleBasisTests
     Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17.
 
+Milestone 5 validation evidence supplied by the user:
+
+    Full build: passed.
+    Complete unit-test suite: passed.
+    Manual: verified new wide-preview Size Basis behavior.
+    Manual: verified existing effects retain the Height setting and their prior appearance.
+    Jira: validation recorded in VIX-3989 comment 40372.
+
 ## Interfaces and Dependencies
 
 No package, descriptor-version, sequence migration, Catel/ViewModel, service, or solution-platform change is required. The only new production type is the public `VixenModules.Effect.PinWheel.PinWheelSizeScaleBasis` enum. The existing public `PinWheelData.SizeScaleBasis` and `PinWheel.SizeScaleBasis` properties expose it. Use the existing `System.Runtime.Serialization.DataContractSerializer`, `System.ComponentModel.TypeDescriptor`, provider-resource attributes, `PixelEffectBase`, `IPixelFrameBuffer`, and `PixelLocationFrameBuffer` dependencies; do not introduce a new library.
@@ -245,3 +253,5 @@ The private helper remains an implementation detail in `PinWheel.cs`; tests may 
 2026-08-21: Completed Milestone 3 by replacing the separate dense and location rendering radius-basis calculations with one private helper. It retains the absolute-offset bottom-right distance and selects Height, Width, or Largest Dimension for percentage offsets, with Height as the defensive fallback. The Release x64 PinWheel build completed with zero errors.
 
 2026-08-21: Completed Milestone 4 by adding the PinWheel module test reference and 17 focused tests. The tests cover constructor and old-XML defaults, data-contract round trips, cloning, property visibility, wide/tall/square buffer selection, string/location parity, unknown values, and unchanged absolute offsets. The Release x64 focused test run passed with zero failures.
+
+2026-08-21: Completed Milestone 5 with user-provided full-build, full-suite, and manual validation. The manual scenarios confirmed the corrected wide-preview behavior and Height retention for existing effects. Added the results to VIX-3989 comment 40372; no issue-description adjustment was required.

--- a/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
+++ b/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
@@ -1,0 +1,219 @@
+# VIX-3989: Add a compatibility-preserving PinWheel size scale basis
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. Maintain it in accordance with `.agents/PLANS.md` from the repository root.
+
+## Purpose / Big Picture
+
+PinWheel currently turns its percentage-based Size curve into a radius using only the virtual buffer height. On a wide preview rendered by element locations, this can leave the far-left and far-right props outside the effect even at a large Size value. After this change, newly created PinWheel effects will use the larger virtual-buffer dimension by default, while users can deliberately choose Height or Width when appropriate.
+
+Existing sequences and saved effect defaults must look exactly as they did before this change. An old serialized payload has no new size-basis member; it must therefore resolve to Height, the current behavior. A user can observe the feature in the PinWheel property grid: `Size Basis` appears beside `Size` only while percentage offsets are enabled, and a new PinWheel on a wide location-based group can cover locations that a height-scaled PinWheel cannot.
+
+## Progress
+
+- [x] (2026-08-21) Created this ExecPlan from the VIX-3989 handoff after inspecting `docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md`, the PinWheel effect/data code, the effect-editor resources, the current rendering-test seam, and the test project references.
+- [x] (2026-08-21 20:05Z) Updated Jira VIX-3989 with the user-facing summary, scope, and acceptance criteria for compatibility-preserving Size Basis behavior. Used the project `jira` skill.
+- [ ] Add the serialized compatibility strategy, documented property-grid setting, localized text, and shared radius-basis calculation.
+- [ ] Add focused PinWheel compatibility, rendering, and browsability tests and the required test-project reference.
+- [ ] Run the focused and complete x64 test workflows, manually validate in the UI, update Jira, and record actual evidence here.
+
+## Surprises & Discoveries
+
+- Observation: `PinWheel` currently calculates the same radius basis independently in both dense string rendering and location rendering.
+  Evidence: `src/Vixen.Modules/Effect/PinWheel/PinWheel.cs` uses `OffsetPercentage ? BufferHt : DistanceFromPoint(...)` in `RenderEffect` and again in `RenderEffectByLocation`.
+
+- Observation: The PinWheel module is already in `Vixen.sln`, but `src/Vixen.Tests/Vixen.Tests.csproj` does not reference `src/Vixen.Modules/Effect/PinWheel/PinWheel.csproj`.
+  Evidence: `Vixen.sln` contains the PinWheel project; the test project's reference list includes Spiral and other effects but no PinWheel reference.
+
+## Decision Log
+
+- Decision: Use a three-value public enum with `Height = 0`, `Width = 1`, and `LargestDimension = 2`.
+  Rationale: `DataContractSerializer` supplies the CLR default for an absent member without running the data class constructor. Reserving zero for Height makes old payloads retain the old height-based radius, while a constructor default can give genuinely new effects the corrected Largest Dimension behavior.
+  Date/Author: 2026-08-21 / Codex
+
+- Decision: Do not migrate data or assign `SizeScaleBasis` in `OnDeserialized`.
+  Rationale: Buffer dimensions are render-target-specific and unavailable during deserialization. More importantly, assigning the new-effect default on deserialization would destroy the missing-member compatibility discriminator.
+  Date/Author: 2026-08-21 / Codex
+
+- Decision: Centralize radius-basis selection in one private PinWheel helper and retain the absolute-offset branch byte-for-byte in meaning.
+  Rationale: Both render paths must remain behaviorally identical. The old non-percentage branch uses the distance from the calculated origin to the bottom-right buffer corner and is unrelated to this correction.
+  Date/Author: 2026-08-21 / Codex
+
+- Decision: Use a property-grid enum value rather than a hidden version flag or unconditional Largest Dimension behavior.
+  Rationale: It preserves old output, fixes the new-effect experience, and lets a user intentionally select an axis for a particular display without recreating an effect.
+  Date/Author: 2026-08-21 / Codex
+
+## Outcomes & Retrospective
+
+Implementation has not begun. The intended completed outcome is a localized, documented Size Basis setting with safe old-data behavior, parity between both PinWheel render paths, and automated evidence for serialization, cloning, buffer shapes, visibility, and legacy absolute offsets. Record actual results, remaining gaps, test counts, and manual validation here when the work finishes.
+
+## Context and Orientation
+
+`src/Vixen.Modules/Effect/PinWheel/PinWheel.cs` is the public effect implementation. Its Config properties are annotated with `Value`, `ProviderCategory`, `ProviderDisplayName`, `ProviderDescription`, and `PropertyOrder` so the Effect Editor property grid can display and edit them. `UpdateOffsetAttribute` controls dynamic browsability with `SetBrowsable`, and the `OffsetPercentage` setter refreshes that state. `RenderEffect` paints every cell in a normal pixel frame buffer; `RenderEffectByLocation` paints only actual element locations in a `PixelLocationFrameBuffer`. Both calculate a frame origin, a Size factor, and a maximum radius before entering their pixel/location loops.
+
+`src/Vixen.Modules/Effect/PinWheel/PinWheelData.cs` is the data contract serialized with each PinWheel effect. Its parameterless constructor establishes defaults only for genuinely newly constructed data. `DataContractSerializer` does not use that constructor when reading a serialized object; a `[DataMember]` absent from an older XML payload retains its CLR default. `OnDeserialized` is a legacy upgrade hook and must not touch the new member. `CreateInstanceForClone` explicitly makes independent copies of the existing data and is the place to preserve the selected enum value when an effect is cloned.
+
+The new enum belongs in `src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs`, in the `VixenModules.Effect.PinWheel` namespace. Because it is public, and because the new public `PinWheelData` and `PinWheel` properties are public APIs, their XML documentation must be added or updated in the same change.
+
+`src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx` and `EffectDescriptionDescriptors.resx` are the localized resource sources resolved by the provider attributes. Their matching `.Designer.cs` files are generated accessors and must be regenerated by the repository's established resource-generation process after adding the `SizeBasis` display and description resources. Do not hand-edit generated output unless the established project tooling itself does so.
+
+`src/Vixen.Tests/Effects/SpiralLocationRenderTests.cs` is the closest existing location-render test pattern. It sets private `PixelEffectBase` virtual-buffer fields through reflection, invokes protected rendering methods by reflection, and compares dense and location results. Add `PinWheel.csproj` to `src/Vixen.Tests/Vixen.Tests.csproj` using the repository's standard project-reference metadata, then create a focused `PinWheelSizeScaleBasisTests.cs` under `src/Vixen.Tests/Effects/` following that seam. Use a deterministic standard color, one arm, full thickness, fixed curves, and one frame so assertions do not depend on random colors or animation.
+
+`OffsetPercentage` has two meanings. When true, X/Y offsets are normalized to the virtual buffer and Size must use the selected scale basis. When false, offsets are legacy absolute values and radius must remain the current distance from the calculated origin to `(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt)`. `BufferWi` is the buffer width and `BufferHt` is the buffer height; Width chooses the former, Height chooses the latter, and Largest Dimension chooses `Math.Max(BufferWi, BufferHt)`.
+
+## Plan of Work
+
+### Milestone 1: Record the approved contract in Jira
+
+Before modifying source, use the repository `jira` skill to update VIX-3989. State the user-visible correction, the compatibility guarantee for payloads missing the new member, the exact enum values, the new-effect default, the `OffsetPercentage` visibility rule, the unchanged absolute-offset branch, the localization/XML documentation requirements, and the focused plus full validation plan from this ExecPlan. If Jira access is unavailable, capture the exact failure in `Surprises & Discoveries`, continue with local implementation, and leave the final tracker update pending.
+
+### Milestone 2: Add the data contract and property-grid contract
+
+Read the complete current `PinWheel.cs`, `PinWheelData.cs`, PinWheel project file, resource files, and generated-resource workflow before editing. Read `.agents/skills/csharp-docs/SKILL.md` because this milestone creates or modifies public APIs, and read `.agents/skills/dotnet-best-practices/SKILL.md` before writing the C# changes.
+
+Create `PinWheelSizeScaleBasis.cs` with a public documented enum. Assign values explicitly and in this exact order:
+
+    Height = 0
+    Width = 1
+    LargestDimension = 2
+
+Document that Height is the compatibility value for effects serialized before VIX-3989, Width scales by the virtual buffer width, and Largest Dimension scales by the larger buffer dimension. Do not reorder values or let an implicit future edit change Height's zero value.
+
+In `PinWheelData.cs`, add a documented `[DataMember] public PinWheelSizeScaleBasis SizeScaleBasis { get; set; }`. In the parameterless constructor explicitly assign `SizeScaleBasis = PinWheelSizeScaleBasis.LargestDimension;`. Do not add `EmitDefaultValue = false`; after an older effect is loaded and saved, serializing its resolved Height value makes its legacy intent durable. Do not set this property in `OnDeserialized`. Include `SizeScaleBasis = SizeScaleBasis` in the `CreateInstanceForClone` initializer so a clone retains the selected behavior rather than receiving the constructor default.
+
+In `PinWheel.cs`, add a documented `[Value]` Config property named `SizeScaleBasis` adjacent to `SizeCurve`, ordered immediately after it and shifting only later Config ordering as needed. It must get and set `_data.SizeScaleBasis`; the setter must set `IsDirty = true` and call `OnPropertyChanged()` like neighboring properties. Use `ProviderDisplayName("SizeBasis")` and `ProviderDescription("SizeBasis")`. The localized display value must be `Size Basis`; the description must explain that it chooses the preview dimension used to scale Size and that Largest Dimension is normally the best choice. Add those keys to the two resource `.resx` files and regenerate/update their strongly typed designer accessors through the established process.
+
+Modify `UpdateOffsetAttribute` so `SizeScaleBasis` is browsable only when `OffsetPercentage` is true. Keep the existing X/Y offset behavior: X/Y offsets are browsable only when `OffsetPercentage` is false. Use `nameof(OffsetPercentage)`, `nameof(SizeScaleBasis)`, `nameof(XOffsetCurve)`, and `nameof(YOffsetCurve)` for keys touched in this method, rather than new string literals. Preserve the refresh behavior: toggling `OffsetPercentage` must update visible properties immediately.
+
+### Milestone 3: Centralize and apply the radius-basis calculation
+
+In `PinWheel.cs`, replace only the duplicated local `xc` selection in `RenderEffect` and `RenderEffectByLocation` with a single private helper, for example `CalculateRadiusBasis(Point origin)`. Call it after calculating the origin and before calculating `maxRadius`; retain the existing Size factor and all pixel math. The helper must return a `double` or another type that preserves the existing multiplication behavior.
+
+Its first branch is non-negotiable:
+
+    if (!OffsetPercentage)
+        return DistanceFromPoint(origin, new Point(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt));
+
+For percentage offsets, use a `switch` over `SizeScaleBasis`: Height returns `BufferHt`; Width returns `BufferWi`; Largest Dimension returns `Math.Max(BufferWi, BufferHt)`; and the default/unknown enum value returns `BufferHt`. This defensive fallback preserves the legacy-safe dimension if corrupt or future data holds an unknown numeric enum value. Do not alter `CalculateSize`, curve ranges, origin calculations, offsets, center-hub handling, twist math, color behavior, descriptor version, sequence migration, Catel view models, commands, or services. Calculate once per rendered frame outside every pixel/location loop.
+
+### Milestone 4: Establish focused compatibility and rendering evidence
+
+Add the PinWheel project reference to `src/Vixen.Tests/Vixen.Tests.csproj`, following existing project-reference conventions: a project reference rather than a DLL, no new package, no duplicate reference, and the same copy/local asset behavior used by neighboring effect project references. Do not alter solution platform mappings because the project already exists in `Vixen.sln`.
+
+Create `src/Vixen.Tests/Effects/PinWheelSizeScaleBasisTests.cs` and use xUnit. Keep the test class narrowly focused on VIX-3989. Test data-contract behavior using `DataContractSerializer` with in-memory XML streams, not the application persistence service, so the missing-member rule is proved directly. Include the following independently meaningful tests:
+
+1. `new PinWheelData()` assigns `LargestDimension`.
+2. Deserialize a valid PinWheel XML payload produced without a `SizeScaleBasis` element and assert Height, proving old XML retains current output. Build the fixture from a baseline serialization or a concise valid contract fixture, removing only the new member; do not deserialize an incomplete object that bypasses ordinary contract requirements.
+3. For Height, Width, and Largest Dimension, serialize and deserialize then assert the exact selected enum survives. Also assert the serialized XML includes the member when it resolves to Height, so it is not accidentally suppressed.
+4. For each enum value, clone a configured `PinWheelData` through its normal clone API and assert the clone has the same enum value; also ensure the test does not mistake the constructor's Largest Dimension default for an actual copy.
+5. Verify the property grid with `TypeDescriptor.GetProperties(new PinWheel())`: `SizeScaleBasis` is browsable when `OffsetPercentage` is true and not browsable after setting it false. In the same test, assert the existing X/Y offset visibility remains inverse to prevent accidental regression.
+6. On a wide virtual buffer, prove Height reproduces the old height-based reach and that Width and Largest Dimension can light a location whose distance is beyond the height-scaled maximum but within the width-scaled maximum. Use an asymmetric rectangle and deterministic values that avoid a radius-boundary equality.
+7. On a tall buffer, prove Largest Dimension matches Height and differs from Width where expected. On a square buffer, prove Height, Width, and Largest Dimension produce identical results.
+8. For each basis on a dense rectangular grid, compare `RenderEffect` output with `RenderEffectByLocation` output at matching coordinates, applying PinWheel's existing Y inversion when reading the dense buffer. This verifies both paths use the same helper rather than separately drifting.
+9. With `OffsetPercentage = false`, use a noncentral origin and multiple distinct Size Basis values, then assert identical dense and location outputs. This characterizes the unchanged bottom-right-distance legacy branch.
+
+Use reflection only for the existing protected/private render seam: set the same `PixelEffectBase` buffer fields that the Spiral tests set, invoke `SetupRender` if required, invoke `RenderEffect(int, IPixelFrameBuffer)`, and invoke `RenderEffectByLocation(int, PixelLocationFrameBuffer)`. Correctly map the backing fields by their names, not by inferred width/height ordering. Build full grids of `ElementLocation` test nodes with a minimal `IElementNode`/`PropertyManager` setup as Spiral does. For every comparison, use a fixed standard color and compare RGB values or explicit lit/unlit state; do not use PinWheel random colors.
+
+### Milestone 5: Validate, inspect, and close the tracker loop
+
+First run the focused tests after building the Visual Studio/MSBuild x64 test target. The test graph has C++/CLI transitive dependencies, so `dotnet test` alone is insufficient to build it. From `C:\Dev\Vixen`, run:
+
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PinWheelSizeScaleBasisTests
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\"
+    git diff --check
+
+Expect the focused and full test commands to report zero failed tests. If an environmental C++ toolset/MSBuild failure prevents the first command, record the complete failure and retry on a Visual Studio-equipped machine; do not replace the required validation with `dotnet test` building from scratch.
+
+Manually create a location-positioned PinWheel on a deliberately wide group in Vixen. Confirm a newly added effect has `Size Basis = Largest Dimension`, its Size Basis property is visible while `OffsetPercentage` is enabled, and it can reach preview corners that height-only scaling misses. Change Size Basis to Height and confirm the prior limited reach returns; Width should match Largest Dimension for a wide buffer. Disable `OffsetPercentage` and confirm Size Basis is hidden, X/Y offset curves reappear, and changing the stored basis does not change the rendered result. Load an older sequence or compatible old serialized PinWheel fixture, confirm it resolves to Height with no visual change, then save and reload it to confirm Height persists.
+
+After validation, use the `jira` skill to update VIX-3989's description if discoveries changed requirements and add a comment containing the actual build command, focused/full test results, manual observations, and any known gap. Update all living-plan sections, including Progress, Outcomes & Retrospective, Artifacts, and the revision note, with evidence rather than this plan's examples.
+
+## Concrete Steps
+
+All commands run from `C:\Dev\Vixen`.
+
+1. Protect current user work and read the relevant contracts before changing files:
+
+       git status --short
+       git diff -- src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
+       Get-Content -Raw docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md
+       Get-Content -Raw src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
+       Get-Content -Raw src/Vixen.Modules/Effect/PinWheel/PinWheelData.cs
+       Get-Content -Raw .agents/skills/csharp-docs/SKILL.md
+       Get-Content -Raw .agents/skills/dotnet-best-practices/SKILL.md
+
+2. Locate resource and test conventions before creating the enum, resource entries, tests, and project reference:
+
+       rg -n -C 3 "OffsetPercentage|PinWheelRotation|<data name=\"Size\"" src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes -g "*.resx" -g "*.cs"
+       Get-Content -Raw src/Vixen.Tests/Effects/SpiralLocationRenderTests.cs
+       Get-Content -Raw src/Vixen.Tests/Vixen.Tests.csproj
+       Get-Content -Raw src/Vixen.Modules/Effect/PinWheel/PinWheel.csproj
+
+3. Complete Milestones 2 through 4 with tab indentation and LF line endings. Review only the expected change set:
+
+       git diff --check
+       git diff -- src/Vixen.Modules/Effect/PinWheel/PinWheel.cs src/Vixen.Modules/Effect/PinWheel/PinWheelData.cs src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx src/Vixen.Tests/Effects/PinWheelSizeScaleBasisTests.cs src/Vixen.Tests/Vixen.Tests.csproj
+
+4. Run the three Milestone 5 validation commands. A successful test summary contains a zero failure count, for example:
+
+       Passed!  - Failed:     0, Passed:     <count>, Skipped:     0
+
+5. Record the actual command output summary, test counts, Jira result, and manual scenario result in this document before handing work off.
+
+## Validation and Acceptance
+
+The change is accepted when a new PinWheel data object and a new PinWheel UI instance use Largest Dimension, while a valid pre-VIX-3989 XML payload that lacks `SizeScaleBasis` resolves to Height. Every enum choice must survive both data-contract serialization and normal cloning. The public enum and public properties must have accurate XML documentation, and the effect editor must display localized `Size Basis` text and an explanatory description.
+
+On a wide rectangle, Height must retain the old height-limited radius; Width and Largest Dimension must use the width and be able to illuminate a location beyond that old range. On a tall rectangle, Largest Dimension must equal Height; on a square rectangle all choices must agree. For equivalent grids, dense string rendering and location rendering must output the same pixels after accounting for the existing dense-buffer Y inversion. The private helper must retain the bottom-right-distance calculation when `OffsetPercentage` is false, and changing the enum in that mode must have no rendered effect.
+
+`SizeScaleBasis` must be browsable only when `OffsetPercentage` is true. Existing X/Y offset browsability must remain the inverse. The focused `PinWheelSizeScaleBasisTests` and the complete `Vixen.Tests` suite must pass with zero failures after the required Release/x64 MSBuild test-target build. The manual wide-preview and old-sequence scenarios in Milestone 5 must pass.
+
+## Idempotence and Recovery
+
+The planned source edits are additive and can be retried after a failed build. Data-contract tests operate only in memory and render tests use isolated buffers, so they do not alter sequences or effect defaults. Re-running an MSBuild restore/test is safe. Once an old payload is saved after implementation it will explicitly contain Height, which is intentional and preserves its historical rendering thereafter.
+
+If a source edit must be backed out, remove only the new enum, SizeScaleBasis data/UI/helper code, localized resource entries and generated accessors, PinWheel test file, and PinWheel test-project reference after confirming their exact paths with `git status --short`. Do not reset, checkout, delete, or broadly reformat `PinWheel.cs`. If resource designer generation is unavailable, identify the established project command before editing generated files and record the tooling limitation rather than leaving resources and designers out of sync.
+
+## Artifacts and Notes
+
+The required completed public contract is:
+
+    public enum PinWheelSizeScaleBasis
+    {
+        Height = 0,
+        Width = 1,
+        LargestDimension = 2
+    }
+
+    [DataMember]
+    public PinWheelSizeScaleBasis SizeScaleBasis { get; set; }
+
+    [Value]
+    public PinWheelSizeScaleBasis SizeScaleBasis { get; set; }
+
+The intended shared radius-basis logic is:
+
+    if (!OffsetPercentage)
+        return DistanceFromPoint(origin, new Point(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt));
+
+    return SizeScaleBasis switch
+    {
+        PinWheelSizeScaleBasis.Height => BufferHt,
+        PinWheelSizeScaleBasis.Width => BufferWi,
+        PinWheelSizeScaleBasis.LargestDimension => Math.Max(BufferWi, BufferHt),
+        _ => BufferHt
+    };
+
+This helper selects only the unscaled basis. Existing `CalculateSize(intervalPosFactor) / 100.0` remains the multiplier, so the maximum radius remains `basis * sizeFactor` and no Size curve is rewritten.
+
+## Interfaces and Dependencies
+
+No package, descriptor-version, sequence migration, Catel/ViewModel, service, or solution-platform change is required. The only new production type is the public `VixenModules.Effect.PinWheel.PinWheelSizeScaleBasis` enum. The existing public `PinWheelData.SizeScaleBasis` and `PinWheel.SizeScaleBasis` properties expose it. Use the existing `System.Runtime.Serialization.DataContractSerializer`, `System.ComponentModel.TypeDescriptor`, provider-resource attributes, `PixelEffectBase`, `IPixelFrameBuffer`, and `PixelLocationFrameBuffer` dependencies; do not introduce a new library.
+
+The private helper remains an implementation detail in `PinWheel.cs`; tests may reach the existing render methods and virtual-buffer state through reflection, as `SpiralLocationRenderTests` does, but should not make the helper public solely for testing. The final test project must reference the existing PinWheel module project so it can instantiate the effect and data contract directly.
+
+## Revision Note
+
+2026-08-21: Initial ExecPlan created from the VIX-3989 handoff and repository design note. It resolves serialization defaults, clone behavior, public documentation, resource keys, render helper behavior, location/string parity, legacy absolute offsets, required Jira lifecycle, and full x64 validation so implementation can proceed without relying on prior conversation context.
+
+2026-08-21: Completed Milestone 1 by updating VIX-3989 with a concise user-facing Summary, Scope, and Acceptance Criteria. Detailed design, compatibility constraints, and test steps remain in this repository-local ExecPlan.

--- a/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
+++ b/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
@@ -14,7 +14,7 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 - [x] (2026-08-21 20:05Z) Updated Jira VIX-3989 with the user-facing summary, scope, and acceptance criteria for compatibility-preserving Size Basis behavior. Used the project `jira` skill.
 - [x] (2026-08-21) Added the serialized Size Basis contract, documented property-grid setting, localized display/description resources, and generated resource accessors. The shared radius-basis calculation remains Milestone 3 work.
 - [x] (2026-08-21) Replaced the duplicated string/location radius selection with one private helper that selects the configured percentage basis and preserves the legacy absolute-offset corner-distance calculation.
-- [ ] Add focused PinWheel compatibility, rendering, and browsability tests and the required test-project reference.
+- [x] (2026-08-21) Added the PinWheel test-project reference and 17 focused compatibility, rendering, and browsability tests; the Release/x64 focused suite passes.
 - [ ] Run the focused and complete x64 test workflows, manually validate in the UI, update Jira, and record actual evidence here.
 
 ## Surprises & Discoveries
@@ -24,6 +24,9 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 
 - Observation: The PinWheel module is already in `Vixen.sln`, but `src/Vixen.Tests/Vixen.Tests.csproj` does not reference `src/Vixen.Modules/Effect/PinWheel/PinWheel.csproj`.
   Evidence: `Vixen.sln` contains the PinWheel project; the test project's reference list includes Spiral and other effects but no PinWheel reference.
+
+- Observation: Pixel frame buffers use `System.Drawing.Color` even though their source files also import the HSV color-model namespace.
+  Evidence: `src/Vixen.Modules/Effect/Effect/PixelFrameBuffer.cs` and `PixelLocationFrameBuffer.cs` expose `Color` values compatible with the existing `System.Drawing.Color` assertions in location-render tests.
 
 ## Decision Log
 
@@ -217,6 +220,14 @@ Milestone 3 validation evidence:
     msbuild src\Vixen.Modules\Effect\PinWheel\PinWheel.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -v:m
     Build succeeded with zero errors. The build reported existing warnings in Vixen.Core and FixtureGraphics.
 
+Milestone 4 validation evidence:
+
+    msbuild src\Vixen.Tests\Vixen.Tests.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:q
+    Build succeeded with zero errors.
+
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:\Dev\Vixen\\" --filter FullyQualifiedName~PinWheelSizeScaleBasisTests
+    Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17.
+
 ## Interfaces and Dependencies
 
 No package, descriptor-version, sequence migration, Catel/ViewModel, service, or solution-platform change is required. The only new production type is the public `VixenModules.Effect.PinWheel.PinWheelSizeScaleBasis` enum. The existing public `PinWheelData.SizeScaleBasis` and `PinWheel.SizeScaleBasis` properties expose it. Use the existing `System.Runtime.Serialization.DataContractSerializer`, `System.ComponentModel.TypeDescriptor`, provider-resource attributes, `PixelEffectBase`, `IPixelFrameBuffer`, and `PixelLocationFrameBuffer` dependencies; do not introduce a new library.
@@ -232,3 +243,5 @@ The private helper remains an implementation detail in `PinWheel.cs`; tests may 
 2026-08-21: Completed Milestone 2 by adding the documented public `PinWheelSizeScaleBasis` enum, serialized `SizeScaleBasis` storage with the Largest Dimension new-effect default and clone preservation, and a localized Config property shown only for percentage offsets. The Release x64 PinWheel build completed with zero errors.
 
 2026-08-21: Completed Milestone 3 by replacing the separate dense and location rendering radius-basis calculations with one private helper. It retains the absolute-offset bottom-right distance and selects Height, Width, or Largest Dimension for percentage offsets, with Height as the defensive fallback. The Release x64 PinWheel build completed with zero errors.
+
+2026-08-21: Completed Milestone 4 by adding the PinWheel module test reference and 17 focused tests. The tests cover constructor and old-XML defaults, data-contract round trips, cloning, property visibility, wide/tall/square buffer selection, string/location parity, unknown values, and unchanged absolute offsets. The Release x64 focused test run passed with zero failures.

--- a/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
+++ b/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
@@ -13,6 +13,7 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 - [x] (2026-08-21) Created this ExecPlan from the VIX-3989 handoff after inspecting `docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md`, the PinWheel effect/data code, the effect-editor resources, the current rendering-test seam, and the test project references.
 - [x] (2026-08-21 20:05Z) Updated Jira VIX-3989 with the user-facing summary, scope, and acceptance criteria for compatibility-preserving Size Basis behavior. Used the project `jira` skill.
 - [x] (2026-08-21) Added the serialized Size Basis contract, documented property-grid setting, localized display/description resources, and generated resource accessors. The shared radius-basis calculation remains Milestone 3 work.
+- [x] (2026-08-21) Replaced the duplicated string/location radius selection with one private helper that selects the configured percentage basis and preserves the legacy absolute-offset corner-distance calculation.
 - [ ] Add focused PinWheel compatibility, rendering, and browsability tests and the required test-project reference.
 - [ ] Run the focused and complete x64 test workflows, manually validate in the UI, update Jira, and record actual evidence here.
 
@@ -211,6 +212,11 @@ Milestone 2 validation evidence:
     msbuild src\Vixen.Modules\Effect\PinWheel\PinWheel.csproj -m -restore -t:Build -p:Configuration=Release -p:Platform=x64 -v:m
     Build succeeded with zero errors. The build reported existing warnings in Vixen.Core and FixtureGraphics.
 
+Milestone 3 validation evidence:
+
+    msbuild src\Vixen.Modules\Effect\PinWheel\PinWheel.csproj -m -t:Build -p:Configuration=Release -p:Platform=x64 -v:m
+    Build succeeded with zero errors. The build reported existing warnings in Vixen.Core and FixtureGraphics.
+
 ## Interfaces and Dependencies
 
 No package, descriptor-version, sequence migration, Catel/ViewModel, service, or solution-platform change is required. The only new production type is the public `VixenModules.Effect.PinWheel.PinWheelSizeScaleBasis` enum. The existing public `PinWheelData.SizeScaleBasis` and `PinWheel.SizeScaleBasis` properties expose it. Use the existing `System.Runtime.Serialization.DataContractSerializer`, `System.ComponentModel.TypeDescriptor`, provider-resource attributes, `PixelEffectBase`, `IPixelFrameBuffer`, and `PixelLocationFrameBuffer` dependencies; do not introduce a new library.
@@ -224,3 +230,5 @@ The private helper remains an implementation detail in `PinWheel.cs`; tests may 
 2026-08-21: Completed Milestone 1 by updating VIX-3989 with a concise user-facing Summary, Scope, and Acceptance Criteria. Detailed design, compatibility constraints, and test steps remain in this repository-local ExecPlan.
 
 2026-08-21: Completed Milestone 2 by adding the documented public `PinWheelSizeScaleBasis` enum, serialized `SizeScaleBasis` storage with the Largest Dimension new-effect default and clone preservation, and a localized Config property shown only for percentage offsets. The Release x64 PinWheel build completed with zero errors.
+
+2026-08-21: Completed Milestone 3 by replacing the separate dense and location rendering radius-basis calculations with one private helper. It retains the absolute-offset bottom-right distance and selects Height, Width, or Largest Dimension for percentage offsets, with Height as the defensive fallback. The Release x64 PinWheel build completed with zero errors.

--- a/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
+++ b/docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md
@@ -12,7 +12,7 @@ Existing sequences and saved effect defaults must look exactly as they did befor
 
 - [x] (2026-08-21) Created this ExecPlan from the VIX-3989 handoff after inspecting `docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md`, the PinWheel effect/data code, the effect-editor resources, the current rendering-test seam, and the test project references.
 - [x] (2026-08-21 20:05Z) Updated Jira VIX-3989 with the user-facing summary, scope, and acceptance criteria for compatibility-preserving Size Basis behavior. Used the project `jira` skill.
-- [ ] Add the serialized compatibility strategy, documented property-grid setting, localized text, and shared radius-basis calculation.
+- [x] (2026-08-21) Added the serialized Size Basis contract, documented property-grid setting, localized display/description resources, and generated resource accessors. The shared radius-basis calculation remains Milestone 3 work.
 - [ ] Add focused PinWheel compatibility, rendering, and browsability tests and the required test-project reference.
 - [ ] Run the focused and complete x64 test workflows, manually validate in the UI, update Jira, and record actual evidence here.
 
@@ -206,6 +206,11 @@ The intended shared radius-basis logic is:
 
 This helper selects only the unscaled basis. Existing `CalculateSize(intervalPosFactor) / 100.0` remains the multiplier, so the maximum radius remains `basis * sizeFactor` and no Size curve is rewritten.
 
+Milestone 2 validation evidence:
+
+    msbuild src\Vixen.Modules\Effect\PinWheel\PinWheel.csproj -m -restore -t:Build -p:Configuration=Release -p:Platform=x64 -v:m
+    Build succeeded with zero errors. The build reported existing warnings in Vixen.Core and FixtureGraphics.
+
 ## Interfaces and Dependencies
 
 No package, descriptor-version, sequence migration, Catel/ViewModel, service, or solution-platform change is required. The only new production type is the public `VixenModules.Effect.PinWheel.PinWheelSizeScaleBasis` enum. The existing public `PinWheelData.SizeScaleBasis` and `PinWheel.SizeScaleBasis` properties expose it. Use the existing `System.Runtime.Serialization.DataContractSerializer`, `System.ComponentModel.TypeDescriptor`, provider-resource attributes, `PixelEffectBase`, `IPixelFrameBuffer`, and `PixelLocationFrameBuffer` dependencies; do not introduce a new library.
@@ -217,3 +222,5 @@ The private helper remains an implementation detail in `PinWheel.cs`; tests may 
 2026-08-21: Initial ExecPlan created from the VIX-3989 handoff and repository design note. It resolves serialization defaults, clone behavior, public documentation, resource keys, render helper behavior, location/string parity, legacy absolute offsets, required Jira lifecycle, and full x64 validation so implementation can proceed without relying on prior conversation context.
 
 2026-08-21: Completed Milestone 1 by updating VIX-3989 with a concise user-facing Summary, Scope, and Acceptance Criteria. Detailed design, compatibility constraints, and test steps remain in this repository-local ExecPlan.
+
+2026-08-21: Completed Milestone 2 by adding the documented public `PinWheelSizeScaleBasis` enum, serialized `SizeScaleBasis` storage with the Largest Dimension new-effect default and clone preservation, and a localized Config property shown only for percentage offsets. The Release x64 PinWheel build completed with zero errors.

--- a/docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md
+++ b/docs/reviews/vix-3989-pinwheel-size-scale-basis-design.md
@@ -1,0 +1,209 @@
+# Architecture Design: VIX-3989 — Increase Pinwheel size when using location based rendering
+
+**Issue:** [VIX-3989](https://vixenlights.atlassian.net/browse/VIX-3989) — Bug, Normal priority, status *New Ticket*
+**Status:** Design complete, ready for specification and implementation
+**Target spec path:** `docs/plans/effects/vix-3989-pinwheel-size-scale-basis.md`
+
+## Purpose
+
+Pinwheel currently derives its percentage-based maximum radius from `BufferHt`. On a wide
+location-based preview, even the largest Size setting can therefore leave distant elements outside
+the effect. The corrected behavior must allow the radius to use the larger buffer dimension without
+changing the appearance of existing sequences.
+
+## Evidence and constraints
+
+- Both render paths calculate `xc` independently in `PinWheel.cs`: string rendering at lines
+  430-434 and location rendering at lines 476-482. When `OffsetPercentage` is true, both use
+  `BufferHt`.
+- `CalculateSize` maps the Size curve to 1-400, and the render path divides that value by 100. The
+  effective radius is therefore `basis * sizeFactor`, where `sizeFactor` ranges from 0.01 through
+  4.00.
+- `PixelEffectBase.ConfigureVirtualBuffer` determines `BufferWi`, `BufferHt`, and their offsets only
+  during pre-render. Sequence data migration and `PinWheelData.OnDeserialized` cannot safely know
+  which dimension will be larger.
+- Effect module data is read with `DataContractSerializer`. A member absent from an older payload
+  receives the CLR default; constructors are not used for deserialized instances. This provides a
+  compatibility discriminator without a sequence migration.
+- When `OffsetPercentage` is false, current behavior uses the distance from the origin to the
+  bottom-right buffer corner. VIX-3989 should not alter that legacy branch.
+- The working tree already contains a user-owned `Debug.WriteLine` change in `PinWheel.cs`; it is
+  unrelated to this design and must not be overwritten during implementation.
+
+## Ranked alternatives
+
+| Rank | Alternative | Existing effects | New-effect experience | Assessment |
+|---:|---|---|---|---|
+| 1 | Three-state Size Basis: Height, Width, Largest Dimension | Missing data resolves to Height and renders exactly as today | Defaults to Largest Dimension; Width and Height remain available for intentional axis-based sizing | Best balance of compatibility, discoverability, and correct out-of-box behavior |
+| 2 | Two-state X/Y selector, always defaulting to current Y/Height | Exact compatibility | Users must discover and change the setting on most wide previews; portrait previews require the opposite choice | Safe and simple, but the reported bug remains the default experience |
+| 3 | Hidden legacy flag: old effects use Height, new effects use Largest Dimension | Exact compatibility | Correct for new effects, but an existing effect cannot opt into the fix without recreation or another command | Low UI complexity, poor upgrade experience |
+| 4 | Automatically use Largest Dimension and compensate Size curves at first render | Attempts compatibility | Correct after conversion | Rejected: dimensions are target-dependent; lazy mutation during render creates dirty/undo problems, and animated curves plus clamping make compensation fragile |
+| 5 | Unconditionally replace Height with Largest Dimension | Existing wide effects visibly change | Correct and simple | Rejected as a breaking sequence change |
+
+## Core Strategy
+
+Use an explicit Strategy value in `PinWheelData` to select the dimension used by percentage-based
+Size scaling. The serialized value is an enum because the choices are closed, mutually exclusive,
+and meaningful to users. Centralize the basis calculation in one helper so string and location
+rendering cannot diverge.
+
+The compatibility behavior relies on two intentionally different defaults:
+
+1. `PinWheelSizeScaleBasis.Height` has numeric value zero. Older serialized effects do not contain
+   the new member, so `DataContractSerializer` gives them Height and preserves their output.
+2. `PinWheelData()` explicitly assigns `LargestDimension`. Effects newly created after VIX-3989
+   therefore get the corrected behavior without user intervention.
+
+This is not a data migration. It requires no buffer dimensions during deserialization and does not
+rewrite the Size curve. When an old sequence is next saved, its resolved Height value is serialized
+explicitly. Previously saved custom effect defaults also resolve to Height, preserving the user's
+chosen appearance; new built-in Pinwheel instances use Largest Dimension.
+
+## Data Model & Property Contracts
+
+### `PinWheelSizeScaleBasis`
+
+Add a public enum in its own `PinWheelSizeScaleBasis.cs` file:
+
+```text
+Height = 0              // compatibility value for data that predates VIX-3989
+Width = 1               // explicit horizontal-axis scaling
+LargestDimension = 2    // corrected automatic behavior
+```
+
+Suggested user descriptions:
+
+- `Height (Compatibility)`
+- `Width`
+- `Largest Dimension (Recommended)`
+
+The type and values require XML documentation because they are public API.
+
+### `PinWheelData.SizeScaleBasis`
+
+- Add a `[DataMember]` public property of type `PinWheelSizeScaleBasis`.
+- Set it to `LargestDimension` in `PinWheelData()`.
+- Do not assign it in `OnDeserialized`; doing so would erase the missing-member compatibility
+  behavior.
+- Copy it in `CreateInstanceForClone()`.
+- Do not use `EmitDefaultValue = false`; after an older effect is loaded and saved, explicitly
+  persisting Height makes its intent durable.
+- Add XML documentation to the public property.
+
+### `PinWheel.SizeScaleBasis`
+
+Expose the data value through a public effect property with the usual `[Value]`, Config category,
+display-name, description, and property-order attributes. Place it adjacent to Size in the property
+grid. Its setter must set `IsDirty`, call `OnPropertyChanged`, and otherwise follow neighboring
+Pinwheel properties.
+
+Use the display name `Size Basis`. The description should say that it chooses the preview dimension
+used to scale the Size curve and that Largest Dimension is normally the best choice.
+
+The setting has an effect only when `OffsetPercentage` is true. Extend `UpdateOffsetAttribute` so
+Size Basis is browsable in that mode and hidden when the older absolute-offset behavior is active.
+Use `nameof` for both property keys while touching this method. Add localized entries to the effect
+display-name and description resources and regenerate their designer files.
+
+The public effect property requires XML documentation.
+
+## Mathematical / Boundary Logic
+
+Extract the duplicated basis calculation to a private helper used by both render paths:
+
+```text
+CalculateRadiusBasis(origin):
+    if OffsetPercentage is false:
+        return DistanceFromPoint(
+            origin,
+            (BufferWiOffset + BufferWi, BufferHtOffset + BufferHt))
+
+    return SizeScaleBasis:
+        Height          => BufferHt
+        Width           => BufferWi
+        LargestDimension => max(BufferWi, BufferHt)
+        unknown         => BufferHt
+
+sizeFactor = CalculateSize(intervalPosition) / 100.0
+maxRadius = CalculateRadiusBasis(origin) * sizeFactor
+```
+
+The fallback for an unknown value is Height, favoring compatibility and safe rendering. Preserve the
+existing Size curve mapping, offset math, center-hub ratio, twist calculation, and radius comparison.
+The scope is the basis only; do not change the `OffsetPercentage == false` corner calculation as part
+of this issue.
+
+Apply the selected basis consistently to string and location rendering. Largest Dimension is
+orientation-invariant because swapping width and height does not change `max(BufferWi, BufferHt)`.
+For square buffers, all three modes are equivalent.
+
+## Subsystem Component Matrix
+
+| Component | Change | Behavioral responsibility |
+|---|---|---|
+| `PinWheelSizeScaleBasis.cs` | New public enum | Closed strategy choices with Height at zero for compatibility |
+| `PinWheelData.cs` | Add serialized property, new-instance default, clone copy | Persist user choice without a sequence migration |
+| `PinWheel.cs` | Add UI property and shared radius-basis helper; use helper in both render paths | Keep string/location results aligned and remove duplicated selection logic |
+| Effect descriptor `.resx` files | Add Size Basis name and description | Localizable, understandable property-grid text |
+| `PinWheelSizeScaleBasisTests.cs` or equivalent under `src/Vixen.Tests/Effects` | Add serialization, clone, UI, and render tests | Lock compatibility and corrected behavior |
+
+No descriptor version change, sequence content migrator, ViewModel, command, service, or dependency
+injection change is required. The property-grid attributes already provide the relevant editor UI;
+Catel-specific changes are not involved.
+
+## Validation and Acceptance
+
+Automated coverage must establish:
+
+1. `new PinWheelData()` defaults Size Basis to Largest Dimension.
+2. Deserializing pre-VIX-3989 Pinwheel XML with no Size Basis member yields Height.
+3. Height, Width, and Largest Dimension each survive DataContract round-trip and `Clone()`.
+4. On a wide virtual buffer, Height reproduces the old radius while Width and Largest Dimension can
+   illuminate a location beyond the old height-based maximum.
+5. On a tall virtual buffer, Largest Dimension selects height; on a square buffer all modes match.
+6. String and location render paths apply the same basis.
+7. With `OffsetPercentage == false`, changing Size Basis has no effect on rendered output.
+8. The Size Basis property is browsable only where it affects the percentage-based calculation.
+
+Follow the reflection-based render-test seam in `SpiralLocationRenderTests` unless a smaller
+internal pure-function seam is introduced without widening production API. Configure deterministic
+Pinwheel colors, one arm, full thickness, fixed curves, and a one-frame buffer so coverage assertions
+do not depend on animation or random colors.
+
+After the focused tests, build `Vixen_Tests` with full MSBuild and run the already-built x64 test
+project using the commands in `AGENTS.md`. Manual validation should load an older sequence containing
+a Pinwheel on a wide location group, confirm no visual change, switch Size Basis to Largest Dimension,
+and confirm that Size can cover the preview corners. A newly added Pinwheel should already use Largest
+Dimension.
+
+## Concurrency, Performance & Thread Safety
+
+The change adds one enum read and a constant-time `switch` per rendered frame. It allocates no new
+objects in the pixel loop. The helper reads instance-local effect data and the already configured
+buffer dimensions, so it introduces no shared state or synchronization requirement. Calculate the
+basis once per frame, outside the per-pixel loop, as the existing `xc` calculation does.
+
+## TERRA HAND-OFF CONTEXT
+
+VIX-3989 fixes Pinwheel radius scaling on wide location buffers. Current `PinWheel.cs` uses
+`OffsetPercentage ? BufferHt : DistanceFromPoint(origin, bottomRight)` in both `RenderEffect` and
+`RenderEffectByLocation`; Size maps to a factor of 0.01-4.00. Implement a new public enum in its own
+file: `PinWheelSizeScaleBasis { Height = 0, Width = 1, LargestDimension = 2 }`. Zero MUST remain Height:
+module data uses DataContractSerializer, whose missing members receive CLR defaults without running
+constructors, so old sequence/default payloads automatically remain height-based. Add
+`[DataMember] public PinWheelSizeScaleBasis SizeScaleBasis { get; set; }` to `PinWheelData`; explicitly set
+LargestDimension in the constructor for truly new effects; do not assign it in `OnDeserialized`; copy
+it in `CreateInstanceForClone`; do not suppress default-value serialization. Expose a documented
+`[Value]` Config property on `PinWheel`, next to Size, display name `Size Basis`, with setter dirty and
+property-changed behavior. Suggested enum labels: Height (Compatibility), Width, Largest Dimension
+(Recommended). Add localized display/description resources. Extend `UpdateOffsetAttribute` so Size
+Basis is shown only when `OffsetPercentage` is true, using `nameof`. Extract one private helper shared
+by both render paths: if `OffsetPercentage` is false, return the existing bottom-right distance
+unchanged; otherwise return BufferHt/BufferWi/Math.Max(BufferWi, BufferHt) per enum, falling back to
+BufferHt for unknown values. Keep all other math unchanged and calculate once per frame outside pixel
+loops. Add xUnit coverage under `src/Vixen.Tests/Effects` for constructor default Largest, old XML
+missing member => Height, DataContract round-trip, clone, wide/tall/square behavior, parity of string
+and location paths, unchanged false-OffsetPercentage branch, and property browsability. Public enum
+and properties need XML docs. Do not overwrite the pre-existing uncommitted Debug.WriteLine edit in
+PinWheel.cs. No sequence migration, descriptor version change, Catel/ViewModel change, or new service
+is needed.

--- a/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
@@ -448,11 +448,7 @@ namespace VixenModules.Effect.PinWheel
 
 			var origin = new Point(BufferWi / 2 + BufferWiOffset + CalculateXOffset(intervalPosFactor), BufferHt / 2 + BufferHtOffset + CalculateYOffset(intervalPosFactor));
 			
-			var xc = OffsetPercentage
-				? BufferHt
-				: DistanceFromPoint(origin, new Point(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt));
-
-			var maxRadius = xc * armsize;
+			var maxRadius = CalculateRadiusBasis(origin) * armsize;
 
 			var angleRange = CalculateThickness(intervalPosFactor) / 100.0f * degreesPerArm / 2.0f;
 
@@ -494,11 +490,7 @@ namespace VixenModules.Effect.PinWheel
 
 				var origin = new Point(BufferWi / 2 + BufferWiOffset + CalculateXOffset(intervalPosFactor), BufferHt / 2 + BufferHtOffset + CalculateYOffset(intervalPosFactor));
 				
-				var xc = OffsetPercentage
-					? BufferHt
-					: DistanceFromPoint(origin, new Point(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt));
-
-				var maxRadius = xc * armsize;
+				var maxRadius = CalculateRadiusBasis(origin) * armsize;
 
 				var angleRange = CalculateThickness(intervalPosFactor) / 100.0f * degreesPerArm / 2.0f;
 
@@ -523,6 +515,22 @@ namespace VixenModules.Effect.PinWheel
 			return OffsetPercentage
 				? (int) Math.Round(ScaleCurveToValue(YOffsetCurve.GetValue(intervalPos), -BufferHt, BufferHt))
 				: (int) Math.Round(ScaleCurveToValue(YOffsetCurve.GetValue(intervalPos), 100, -100));
+		}
+
+		private double CalculateRadiusBasis(Point origin)
+		{
+			if (!OffsetPercentage)
+			{
+				return DistanceFromPoint(origin, new Point(BufferWiOffset + BufferWi, BufferHtOffset + BufferHt));
+			}
+
+			return SizeScaleBasis switch
+			{
+				PinWheelSizeScaleBasis.Height => BufferHt,
+				PinWheelSizeScaleBasis.Width => BufferWi,
+				PinWheelSizeScaleBasis.LargestDimension => Math.Max(BufferWi, BufferHt),
+				_ => BufferHt
+			};
 		}
 
 		private double CalculateSpeed(double intervalPos)

--- a/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheel.cs
@@ -140,12 +140,34 @@ namespace VixenModules.Effect.PinWheel
 			}
 		}
 
+		/// <summary>
+		/// Gets or sets the virtual-buffer dimension used to scale the Size curve.
+		/// </summary>
+		/// <value>
+		/// One of the <see cref="PinWheelSizeScaleBasis"/> values that specifies the Size curve scale basis.
+		/// </value>
+		[Value]
+		[ProviderCategory(@"Config", 1)]
+		[ProviderDisplayName(@"SizeBasis")]
+		[ProviderDescription(@"SizeBasis")]
+		[PropertyOrder(5)]
+		public PinWheelSizeScaleBasis SizeScaleBasis
+		{
+			get { return _data.SizeScaleBasis; }
+			set
+			{
+				_data.SizeScaleBasis = value;
+				IsDirty = true;
+				OnPropertyChanged();
+			}
+		}
+
 		[Value]
 		[ProviderCategory(@"Config", 1)]
 		[ProviderDisplayName(@"Twist")]
 		[ProviderDescription(@"Twist")]
 		//[NumberRange(-500, 500, 1)] Keep for range reference
-		[PropertyOrder(5)]
+		[PropertyOrder(6)]
 		public Curve TwistCurve
 		{
 			get { return _data.TwistCurve; }
@@ -161,7 +183,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderCategory(@"Config", 1)]
 		[ProviderDisplayName(@"OffsetPercentage")]
 		[ProviderDescription(@"OffsetPercentage")]
-		[PropertyOrder(6)]
+		[PropertyOrder(7)]
 		public bool OffsetPercentage
 		{
 			get { return _data.OffsetPercentage; }
@@ -179,7 +201,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderDisplayName(@"XOffset")]
 		[ProviderDescription(@"XOffset")]
 		//[NumberRange(-100, 100, 1)]
-		[PropertyOrder(7)]
+		[PropertyOrder(8)]
 		public Curve XOffsetCurve
 		{
 			get { return _data.XOffsetCurve; }
@@ -196,7 +218,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderDisplayName(@"YOffset")]
 		[ProviderDescription(@"YOffset")]
 		//[NumberRange(-100, 100, 1)]
-		[PropertyOrder(8)]
+		[PropertyOrder(9)]
 		public Curve YOffsetCurve
 		{
 			get { return _data.YOffsetCurve; }
@@ -213,7 +235,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderDisplayName(@"Center Hub")]
 		[ProviderDescription(@"CenterHub")]
 		//[NumberRange(0, 100, 1)]
-		[PropertyOrder(9)]
+		[PropertyOrder(10)]
 		public Curve CenterHubCurve
 		{
 			get { return _data.CenterHubCurve; }
@@ -232,7 +254,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderCategory(@"Config", 1)]
 		[ProviderDisplayName(@"Rotation")]
 		[ProviderDescription(@"PinWheelRotation")]
-		[PropertyOrder(10)]
+		[PropertyOrder(11)]
 		public Curve RotationCurve
 		{
 			get { return _data.RotationCurve; }
@@ -248,7 +270,7 @@ namespace VixenModules.Effect.PinWheel
 		[ProviderCategory(@"Config", 1)]
 		[ProviderDisplayName(@"BladeType")]
 		[ProviderDescription(@"BladeType")]
-		[PropertyOrder(11)]
+		[PropertyOrder(12)]
 		public PinWheelBladeType PinWheelBladeType
 		{
 			get { return _data.PinWheelBladeType; }
@@ -328,11 +350,11 @@ namespace VixenModules.Effect.PinWheel
 			TypeDescriptor.Refresh(this);
 		}
 
-		//Used to hide Colors from user when Rainbow type is selected and unhides for the other types.
 		private void UpdateOffsetAttribute(bool refresh = true)
 		{
-			Dictionary<string, bool> propertyStates = new Dictionary<string, bool>(1);
-			propertyStates.Add("OffsetPercentage", !OffsetPercentage);
+			Dictionary<string, bool> propertyStates = new Dictionary<string, bool>(2);
+			propertyStates.Add(nameof(OffsetPercentage), !OffsetPercentage);
+			propertyStates.Add(nameof(SizeScaleBasis), OffsetPercentage);
 			SetBrowsable(propertyStates);
 			if (refresh)
 			{

--- a/src/Vixen.Modules/Effect/PinWheel/PinWheelData.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheelData.cs
@@ -31,6 +31,7 @@ namespace VixenModules.Effect.PinWheel
 			PinWheelBladeType = PinWheelBladeType.Flat; 
 			MovementType = MovementType.Iterations;
 			OffsetPercentage = true;
+			SizeScaleBasis = PinWheelSizeScaleBasis.LargestDimension;
 		}
 
 		[DataMember]
@@ -110,6 +111,15 @@ namespace VixenModules.Effect.PinWheel
 
 		[DataMember]
 		public bool OffsetPercentage { get; set; }
+
+		/// <summary>
+		/// Gets or sets the virtual-buffer dimension used to scale the Size curve.
+		/// </summary>
+		/// <value>
+		/// One of the <see cref="PinWheelSizeScaleBasis"/> values that specifies the Size curve scale basis. The default for newly created effects is <see cref="PinWheelSizeScaleBasis.LargestDimension"/>.
+		/// </value>
+		[DataMember]
+		public PinWheelSizeScaleBasis SizeScaleBasis { get; set; }
 
 		[OnDeserialized]
 		public void OnDeserialized(StreamingContext c)
@@ -202,7 +212,8 @@ namespace VixenModules.Effect.PinWheel
 				LevelCurve = new Curve(LevelCurve),
 				MovementType = MovementType,
 				PinWheelBladeType = PinWheelBladeType,
-				OffsetPercentage = OffsetPercentage
+				OffsetPercentage = OffsetPercentage,
+				SizeScaleBasis = SizeScaleBasis
 			};
 			return result;
 		}

--- a/src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace VixenModules.Effect.PinWheel
 {
 	/// <summary>
@@ -18,6 +20,7 @@ namespace VixenModules.Effect.PinWheel
 		/// <summary>
 		/// Scales size by the larger virtual-buffer dimension.
 		/// </summary>
+		[Description("Auto")]
 		LargestDimension = 2
 	}
 }

--- a/src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs
+++ b/src/Vixen.Modules/Effect/PinWheel/PinWheelSizeScaleBasis.cs
@@ -1,0 +1,23 @@
+namespace VixenModules.Effect.PinWheel
+{
+	/// <summary>
+	/// Specifies the virtual-buffer dimension used to scale a PinWheel's size.
+	/// </summary>
+	public enum PinWheelSizeScaleBasis
+	{
+		/// <summary>
+		/// Scales size by the virtual-buffer height. This is the compatibility value for effects serialized before VIX-3989.
+		/// </summary>
+		Height = 0,
+
+		/// <summary>
+		/// Scales size by the virtual-buffer width.
+		/// </summary>
+		Width = 1,
+
+		/// <summary>
+		/// Scales size by the larger virtual-buffer dimension.
+		/// </summary>
+		LargestDimension = 2
+	}
+}

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.Designer.cs
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.Designer.cs
@@ -2193,6 +2193,15 @@ namespace VixenModules.EffectEditor.EffectDescriptorAttributes {
                 return ResourceManager.GetString("Size", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Chooses the preview dimension used to scale Size. Largest Dimension is normally the best choice.
+        /// </summary>
+        internal static string SizeBasis {
+            get {
+                return ResourceManager.GetString("SizeBasis", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Enable increase/decrease of shape size based on size variation..

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -538,7 +538,7 @@
     <value>Size of the radial effect.</value>
   </data>
   <data name="SizeBasis" xml:space="preserve">
-    <value>Chooses the dimension used to scale Size. Largest Dimension is normally the best choice.</value>
+    <value>Chooses the dimension used to scale Size. Auto (Largest Dimension) is normally the best choice.</value>
   </data>
   <data name="VerticalOffset" xml:space="preserve">
     <value>Controls the center positioning of the effect in the vertical plane.</value>

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -537,6 +537,9 @@
   <data name="Size" xml:space="preserve">
     <value>Size of the radial effect.</value>
   </data>
+  <data name="SizeBasis" xml:space="preserve">
+    <value>Chooses the dimension used to scale Size. Largest Dimension is normally the best choice.</value>
+  </data>
   <data name="VerticalOffset" xml:space="preserve">
     <value>Controls the center positioning of the effect in the vertical plane.</value>
   </data>

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.Designer.cs
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.Designer.cs
@@ -2202,6 +2202,15 @@ namespace VixenModules.EffectEditor.EffectDescriptorAttributes {
                 return ResourceManager.GetString("Size", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Size Basis.
+        /// </summary>
+        internal static string SizeBasis {
+            get {
+                return ResourceManager.GetString("SizeBasis", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Size Change.

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
@@ -552,6 +552,9 @@
   <data name="Size" xml:space="preserve">
     <value>Size</value>
   </data>
+  <data name="SizeBasis" xml:space="preserve">
+    <value>Size Basis</value>
+  </data>
   <data name="VerticalOffset" xml:space="preserve">
     <value>Vertical Offset</value>
   </data>

--- a/src/Vixen.Tests/Effects/PinWheelSizeScaleBasisTests.cs
+++ b/src/Vixen.Tests/Effects/PinWheelSizeScaleBasisTests.cs
@@ -1,0 +1,356 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Xml.Linq;
+using Moq;
+using Vixen.Sys;
+using VixenModules.App.ColorGradients;
+using VixenModules.App.Curves;
+using VixenModules.Effect.Effect;
+using VixenModules.Effect.Effect.Location;
+using VixenModules.Effect.PinWheel;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+public sealed class PinWheelSizeScaleBasisTests
+{
+	private const int RenderFrame = 0;
+	private const int RenderFrameCount = 1;
+
+	[Fact]
+	public void PinWheelData_DefaultsSizeScaleBasisToLargestDimension()
+	{
+		// Arrange and Act
+		var data = new PinWheelData();
+
+		// Assert
+		Assert.Equal(PinWheelSizeScaleBasis.LargestDimension, data.SizeScaleBasis);
+	}
+
+	[Fact]
+	public void PinWheelData_OldSerializedPayloadDefaultsSizeScaleBasisToHeight()
+	{
+		// Arrange
+		var data = new PinWheelData { SizeScaleBasis = PinWheelSizeScaleBasis.LargestDimension };
+		var oldPayload = RemoveSizeScaleBasis(Serialize(data));
+
+		// Act
+		var deserialized = Deserialize(oldPayload);
+
+		// Assert
+		Assert.Equal(PinWheelSizeScaleBasis.Height, deserialized.SizeScaleBasis);
+	}
+
+	[Theory]
+	[InlineData(PinWheelSizeScaleBasis.Height)]
+	[InlineData(PinWheelSizeScaleBasis.Width)]
+	[InlineData(PinWheelSizeScaleBasis.LargestDimension)]
+	public void PinWheelData_RoundTripsSizeScaleBasis(PinWheelSizeScaleBasis sizeScaleBasis)
+	{
+		// Arrange
+		var data = new PinWheelData { SizeScaleBasis = sizeScaleBasis };
+
+		// Act
+		var payload = Serialize(data);
+		var deserialized = Deserialize(payload);
+
+		// Assert
+		Assert.Contains("SizeScaleBasis", payload);
+		Assert.Equal(sizeScaleBasis, deserialized.SizeScaleBasis);
+	}
+
+	[Theory]
+	[InlineData(PinWheelSizeScaleBasis.Height)]
+	[InlineData(PinWheelSizeScaleBasis.Width)]
+	[InlineData(PinWheelSizeScaleBasis.LargestDimension)]
+	public void PinWheelData_ClonePreservesSizeScaleBasis(PinWheelSizeScaleBasis sizeScaleBasis)
+	{
+		// Arrange
+		var data = new PinWheelData { SizeScaleBasis = sizeScaleBasis };
+
+		// Act
+		var clone = Assert.IsType<PinWheelData>(data.Clone());
+
+		// Assert
+		Assert.Equal(sizeScaleBasis, clone.SizeScaleBasis);
+	}
+
+	[Fact]
+	public void PinWheel_SizeScaleBasisIsBrowsableOnlyForPercentageOffsets()
+	{
+		// Arrange
+		var effect = new PinWheel();
+
+		// Act
+		var percentageProperty = TypeDescriptor.GetProperties(effect)[nameof(PinWheel.SizeScaleBasis)];
+		effect.OffsetPercentage = false;
+		var absoluteOffsetProperty = TypeDescriptor.GetProperties(effect)[nameof(PinWheel.SizeScaleBasis)];
+
+		// Assert
+		Assert.True(percentageProperty?.IsBrowsable);
+		Assert.False(absoluteOffsetProperty?.IsBrowsable);
+	}
+
+	[Fact]
+	public void PinWheel_WideBuffer_UsesConfiguredSizeScaleBasis()
+	{
+		// Arrange
+		const int width = 20;
+		const int height = 10;
+		var target = CreateElementLocation(19, 5);
+
+		// Act
+		var heightColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.Height).GetColorAt(target.X, target.Y);
+		var widthColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.Width).GetColorAt(target.X, target.Y);
+		var largestDimensionColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.LargestDimension).GetColorAt(target.X, target.Y);
+
+		// Assert
+		AssertUnlit(heightColor);
+		AssertLit(widthColor);
+		AssertLit(largestDimensionColor);
+	}
+
+	[Fact]
+	public void PinWheel_TallBuffer_UsesHeightForLargestDimension()
+	{
+		// Arrange
+		const int width = 10;
+		const int height = 20;
+		var target = CreateElementLocation(5, 19);
+
+		// Act
+		var heightColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.Height).GetColorAt(target.X, target.Y);
+		var widthColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.Width).GetColorAt(target.X, target.Y);
+		var largestDimensionColor = RenderLocation(width, height, [target], PinWheelSizeScaleBasis.LargestDimension).GetColorAt(target.X, target.Y);
+
+		// Assert
+		AssertLit(heightColor);
+		AssertUnlit(widthColor);
+		AssertLit(largestDimensionColor);
+	}
+
+	[Fact]
+	public void PinWheel_SquareBuffer_RendersIdenticallyForEverySizeScaleBasis()
+	{
+		// Arrange
+		const int dimension = 12;
+		var locations = CreateGridLocations(dimension, dimension);
+
+		// Act
+		var height = RenderLocation(dimension, dimension, locations, PinWheelSizeScaleBasis.Height);
+		var width = RenderLocation(dimension, dimension, locations, PinWheelSizeScaleBasis.Width);
+		var largestDimension = RenderLocation(dimension, dimension, locations, PinWheelSizeScaleBasis.LargestDimension);
+
+		// Assert
+		AssertSameLocationBuffer(locations, height, width);
+		AssertSameLocationBuffer(locations, height, largestDimension);
+	}
+
+	[Theory]
+	[InlineData(PinWheelSizeScaleBasis.Height)]
+	[InlineData(PinWheelSizeScaleBasis.Width)]
+	[InlineData(PinWheelSizeScaleBasis.LargestDimension)]
+	public void PinWheel_StringAndLocationRenderingUseTheSameSizeScaleBasis(PinWheelSizeScaleBasis sizeScaleBasis)
+	{
+		// Arrange
+		const int width = 13;
+		const int height = 7;
+		var locations = CreateGridLocations(width, height);
+		var stringEffect = CreateDeterministicPinWheel(sizeScaleBasis);
+		var locationEffect = CreateDeterministicPinWheel(sizeScaleBasis);
+		SetVirtualBuffer(stringEffect, width, height);
+		SetVirtualBuffer(locationEffect, width, height);
+		var stringBuffer = new PixelFrameBuffer(width, height);
+		var locationBuffer = new PixelLocationFrameBuffer(locations, RenderFrameCount);
+
+		// Act
+		InvokeRenderEffect(stringEffect, RenderFrame, stringBuffer);
+		InvokeRenderByLocation(locationEffect, RenderFrameCount, locationBuffer);
+
+		// Assert
+		foreach (var location in locations)
+		{
+			AssertSameRgb(stringBuffer.GetColorAt(location.X, height - 1 - location.Y), locationBuffer.GetColorAt(location.X, location.Y));
+		}
+	}
+
+	[Fact]
+	public void PinWheel_UnknownSizeScaleBasisFallsBackToHeight()
+	{
+		// Arrange
+		const int width = 20;
+		const int height = 10;
+		var locations = CreateGridLocations(width, height);
+
+		// Act
+		var heightBuffer = RenderLocation(width, height, locations, PinWheelSizeScaleBasis.Height);
+		var unknownBuffer = RenderLocation(width, height, locations, (PinWheelSizeScaleBasis)999);
+
+		// Assert
+		AssertSameLocationBuffer(locations, heightBuffer, unknownBuffer);
+	}
+
+	[Fact]
+	public void PinWheel_AbsoluteOffsetsIgnoreSizeScaleBasis()
+	{
+		// Arrange
+		const int width = 13;
+		const int height = 7;
+		var locations = CreateGridLocations(width, height);
+
+		// Act
+		var heightBuffer = RenderLocation(width, height, locations, PinWheelSizeScaleBasis.Height, offsetPercentage: false);
+		var widthBuffer = RenderLocation(width, height, locations, PinWheelSizeScaleBasis.Width, offsetPercentage: false);
+		var largestDimensionBuffer = RenderLocation(width, height, locations, PinWheelSizeScaleBasis.LargestDimension, offsetPercentage: false);
+
+		// Assert
+		AssertSameLocationBuffer(locations, heightBuffer, widthBuffer);
+		AssertSameLocationBuffer(locations, heightBuffer, largestDimensionBuffer);
+	}
+
+	private static PinWheel CreateDeterministicPinWheel(PinWheelSizeScaleBasis sizeScaleBasis, bool offsetPercentage = true)
+	{
+		return new PinWheel
+		{
+			TimeSpan = TimeSpan.FromMilliseconds(1000),
+			Arms = 1,
+			ColorType = PinWheelColorType.Standard,
+			Colors = [new GradientLevelPair(Color.Red, CurveType.Flat100)],
+			ThicknessCurve = new Curve(100),
+			SizeCurve = new Curve(20),
+			CenterHubCurve = new Curve(0d),
+			LevelCurve = new Curve(100),
+			RotationCurve = new Curve(50),
+			TwistCurve = new Curve(50),
+			SpeedCurve = new Curve(50),
+			XOffsetCurve = new Curve(50),
+			YOffsetCurve = new Curve(50),
+			SizeScaleBasis = sizeScaleBasis,
+			OffsetPercentage = offsetPercentage
+		};
+	}
+
+	private static PixelLocationFrameBuffer RenderLocation(int width, int height, List<ElementLocation> locations, PinWheelSizeScaleBasis sizeScaleBasis, bool offsetPercentage = true)
+	{
+		var effect = CreateDeterministicPinWheel(sizeScaleBasis, offsetPercentage);
+		SetVirtualBuffer(effect, width, height);
+		var buffer = new PixelLocationFrameBuffer(locations, RenderFrameCount);
+
+		InvokeRenderByLocation(effect, RenderFrameCount, buffer);
+
+		return buffer;
+	}
+
+	private static List<ElementLocation> CreateGridLocations(int width, int height)
+	{
+		var locations = new List<ElementLocation>();
+		for (var y = 0; y < height; y++)
+		{
+			for (var x = 0; x < width; x++)
+			{
+				locations.Add(CreateElementLocation(x, y));
+			}
+		}
+
+		return locations;
+	}
+
+	private static ElementLocation CreateElementLocation(int x, int y)
+	{
+		var node = new Mock<IElementNode>();
+		node.SetupGet(elementNode => elementNode.Properties).Returns(new PropertyManager(node.Object));
+		return new ElementLocation(node.Object)
+		{
+			X = x,
+			Y = y
+		};
+	}
+
+	private static void SetVirtualBuffer(PinWheel effect, int width, int height)
+	{
+		SetPixelEffectBaseField(effect, "_bufferHt", width);
+		SetPixelEffectBaseField(effect, "_bufferWi", height);
+		SetPixelEffectBaseField(effect, "_bufferHtOffset", 0);
+		SetPixelEffectBaseField(effect, "_bufferWiOffset", 0);
+	}
+
+	private static void SetPixelEffectBaseField(PinWheel effect, string fieldName, int value)
+	{
+		var field = typeof(PixelEffectBase).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(field);
+		field.SetValue(effect, value);
+	}
+
+	private static void InvokeRenderEffect(PinWheel effect, int frame, IPixelFrameBuffer frameBuffer)
+	{
+		var renderEffect = typeof(PinWheel).GetMethod(
+			"RenderEffect",
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[typeof(int), typeof(IPixelFrameBuffer)],
+			null);
+		Assert.NotNull(renderEffect);
+		renderEffect.Invoke(effect, [frame, frameBuffer]);
+	}
+
+	private static void InvokeRenderByLocation(PinWheel effect, int frameCount, PixelLocationFrameBuffer frameBuffer)
+	{
+		var renderByLocation = typeof(PinWheel).GetMethod(
+			"RenderEffectByLocation",
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[typeof(int), typeof(PixelLocationFrameBuffer)],
+			null);
+		Assert.NotNull(renderByLocation);
+		renderByLocation.Invoke(effect, [frameCount, frameBuffer]);
+	}
+
+	private static string Serialize(PinWheelData data)
+	{
+		var serializer = new DataContractSerializer(typeof(PinWheelData));
+		using var stream = new MemoryStream();
+		serializer.WriteObject(stream, data);
+		return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+	}
+
+	private static PinWheelData Deserialize(string payload)
+	{
+		var serializer = new DataContractSerializer(typeof(PinWheelData));
+		using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(payload));
+		return Assert.IsType<PinWheelData>(serializer.ReadObject(stream));
+	}
+
+	private static string RemoveSizeScaleBasis(string payload)
+	{
+		var document = XDocument.Parse(payload);
+		document.Descendants().Where(element => element.Name.LocalName == nameof(PinWheelData.SizeScaleBasis)).Remove();
+		return document.ToString(SaveOptions.DisableFormatting);
+	}
+
+	private static void AssertSameLocationBuffer(IEnumerable<ElementLocation> locations, PixelLocationFrameBuffer expected, PixelLocationFrameBuffer actual)
+	{
+		foreach (var location in locations)
+		{
+			AssertSameRgb(expected.GetColorAt(location.X, location.Y), actual.GetColorAt(location.X, location.Y));
+		}
+	}
+
+	private static void AssertLit(Color color)
+	{
+		Assert.NotEqual(Color.Black.ToArgb(), color.ToArgb());
+	}
+
+	private static void AssertUnlit(Color color)
+	{
+		Assert.Equal(Color.Black.ToArgb(), color.ToArgb());
+	}
+
+	private static void AssertSameRgb(Color expected, Color actual)
+	{
+		Assert.Equal(expected.R, actual.R);
+		Assert.Equal(expected.G, actual.G);
+		Assert.Equal(expected.B, actual.B);
+	}
+}

--- a/src/Vixen.Tests/Vixen.Tests.csproj
+++ b/src/Vixen.Tests/Vixen.Tests.csproj
@@ -32,6 +32,7 @@
 		<ProjectReference Include="..\Vixen.Modules\App\Marks\Marks.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Chase\Chase.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\LipSync\LipSync.csproj" />
+		<ProjectReference Include="..\Vixen.Modules\Effect\PinWheel\PinWheel.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Video\Video.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Property\State\State.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\State\State.csproj" />


### PR DESCRIPTION
## Summary

Fixes VIX-3989 by adding a configurable PinWheel Size Basis.

- New PinWheel effects default to `Largest Dimension`, allowing Size to cover wide location-based previews.
- Existing serialized effects retain the legacy `Height` basis and preserve their current appearance.
- Adds localized Size Basis UI, shared rendering logic for string/location paths, and focused compatibility/rendering coverage.

## Validation

- Full build passed.
- Complete unit-test suite passed.
- `PinWheelSizeScaleBasisTests`: 17 passed.
- Manual validation confirmed:
  - New wide-preview behavior works as intended.
  - Existing PinWheel effects retain the Height setting and prior appearance.