### PR TITLE
VIX-3991 Prevent stale loop restart callbacks

### DIFF
--- a/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
+++ b/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
@@ -13,7 +13,7 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 - [x] (2026-08-23 20:00Z) Investigated the reported stack trace, `SequenceExecutor`, `SequenceContext`, `ProgramExecutor`, and `HighResolutionTimer`; identified a queued loop-restart callback racing executor disposal.
 - [x] (2026-08-23 20:00Z) Read VIX-3991 and created this implementation plan without modifying production or test code.
 - [x] (2026-08-23 14:06Z) Updated VIX-3991 with the user-facing requirements, scope, acceptance criteria, and validation approach; added a progress comment.
-- [ ] Add deterministic executor lifecycle tests that reproduce a queued restart becoming stale.
+- [x] (2026-08-23 09:14-05:00) Added deterministic sequence-executor lifecycle tests and the `BaseSequence` test-project reference; the focused baseline reports 2 passed and 3 expected failures against the unfixed executor.
 - [ ] Implement restart invalidation and disposal-safe timer synchronization in `SequenceExecutor`.
 - [ ] Verify focused and full x64 test runs, then manually exercise the close/stop-at-loop-boundary scenario.
 - [ ] Align VIX-3991 with delivered behavior and add the final validation comment.
@@ -35,6 +35,9 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 - Observation: `SequenceContext.Dispose(bool)` disposes its sequence executor before `ContextBase.Dispose(bool)` has an opportunity to stop a running context.
   Evidence: `src/Vixen.Core/Execution/Context/SequenceContext.cs` lines 226-237 and `ContextBase.cs` lines 186-197. The normal `ContextManager` release route stops the context first, but direct disposal still needs a safe executor.
 
+- Observation: The queued-callback failure can be reproduced without UI timing or sleep-based polling by capturing the executor's synchronization-context posts, stopping its end-check timer, and invoking the existing natural-end boundary directly.
+  Evidence: `SequenceExecutorLifecycleTests` focused run reports 2 passed and 3 failures in 117 ms: stale dispatch after disposal throws `ArgumentNullException` at `_loopPlay`, stale dispatch after stop starts timing again, and a post-disposal end-check dispatch throws `NullReferenceException`.
+
 ## Decision Log
 
 - Decision: Solve the stale queued-work problem with an execution-generation token (a monotonically increasing value identifying one active play/loop run), not with only a null guard.
@@ -53,9 +56,17 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
   Rationale: `SequenceExecutor` is used both by sequence contexts and by `ProgramExecutor`; it is the common fault boundary. Correcting it there protects all callers and avoids relying on every owner to get cleanup order right.
   Date/Author: 2026-08-23 / Codex
 
+- Decision: Exercise the existing private timer and natural-end boundaries through reflection in the regression tests instead of adding a production-only test hook.
+  Rationale: The controlled synchronization context captures the actual production callback, and stopping the real timer before the direct boundary invocation removes scheduling variability. This preserves the public and internal production surface while matching the repository's existing reflection-based test convention.
+  Date/Author: 2026-08-23 / Codex
+
+- Decision: Do not add Jira comments after individual implementation milestones; update the issue description at the start and add one final validation comment at completion.
+  Rationale: The tracker should capture the agreed user-facing contract and final delivery evidence without milestone-by-milestone commentary.
+  Date/Author: 2026-08-23 / User
+
 ## Outcomes & Retrospective
 
-Milestone 1 is complete. VIX-3991 now defines the user-visible loop-boundary behavior and the required automated and manual validation before code changes begin. The intended implementation result remains a sequence executor whose posted loop restart is valid only for its originating active loop and whose disposal is safe while timer or UI work is in flight. Update this section with actual test counts, manual observations, remaining gaps, and the final VIX-3991 status when work is complete.
+Milestones 1 and 2 are complete. VIX-3991 now defines the user-visible loop-boundary behavior, and deterministic regression coverage proves the three unsafe current behaviors before implementation: stale restart after stop, stale restart after disposal, and timer work arriving after disposal. The intended implementation result remains a sequence executor whose posted loop restart is valid only for its originating active loop and whose disposal is safe while timer or UI work is in flight. Update this section with actual test counts, manual observations, remaining gaps, and the final VIX-3991 status when work is complete.
 
 ## Context and Orientation
 
@@ -77,7 +88,7 @@ Tests live in `src/Vixen.Tests`. The test project must be built with full Visual
 
 Before editing code, use `.agents/skills/jira/SKILL.md` and the configured Jira connection to update VIX-3991. Keep the description user-facing. Explain that Vixen must not crash, restart playback, or leave a sequence playing when a looping sequence ends while a user stops playback, closes the sequence/editor, changes playback context, or exits the application.
 
-Add acceptance criteria stating that normal looping continues to restart and report its restart event while the executor remains active; stopping or disposing at the loop boundary does not crash or restart; media and timing remain stopped after the stop; and existing non-loop end behavior remains unchanged. State that automated race-focused tests, the full x64 test suite, and a manual stop/close boundary scenario will validate the work. Add a concise progress comment after each implementation or validation milestone. If Jira is unavailable, record the failure in this plan and leave tracker actions pending; do not fabricate updates.
+Add acceptance criteria stating that normal looping continues to restart and report its restart event while the executor remains active; stopping or disposing at the loop boundary does not crash or restart; media and timing remain stopped after the stop; and existing non-loop end behavior remains unchanged. State that automated race-focused tests, the full x64 test suite, and a manual stop/close boundary scenario will validate the work. Do not add interim Jira comments; Milestone 4 adds the single final validation comment. If Jira is unavailable, record the failure in this plan and leave tracker actions pending; do not fabricate updates.
 
 ### Milestone 2: Establish deterministic stale-callback tests
 
@@ -176,3 +187,7 @@ Use existing .NET synchronization primitives (`lock`, `SynchronizationContext.Po
 Plan revision note (2026-08-23): Initial VIX-3991 ExecPlan created from the Jira report, the crash investigation, and `.agents/PLANS.md`. It requires the mandated initial and final Jira milestones, chooses generation-based stale-callback invalidation with immutable timer synchronization, and explicitly prohibits a null-guard-only fix.
 
 Plan revision note (2026-08-23): Completed Milestone 1. Updated VIX-3991 with a concise user-facing Summary, Scope, Acceptance Criteria, and validation approach, then added a progress comment. No production or test code was changed.
+
+Plan revision note (2026-08-23): Completed Milestone 2. Added the `BaseSequence` test-project reference, a non-parallel sequence-executor test collection, and five deterministic lifecycle tests using a captured synchronization context. The x64 test target builds successfully. The focused baseline has 2 passing tests and 3 expected failures that reproduce the bugs Milestone 3 must repair; no production behavior was changed.
+
+Plan revision note (2026-08-23): Updated the Jira communication policy at the user's direction. Keep the Milestone 1 description update and the Milestone 4 final validation comment, but do not add comments for individual implementation milestones.

--- a/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
+++ b/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
@@ -14,7 +14,7 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 - [x] (2026-08-23 20:00Z) Read VIX-3991 and created this implementation plan without modifying production or test code.
 - [x] (2026-08-23 14:06Z) Updated VIX-3991 with the user-facing requirements, scope, acceptance criteria, and validation approach; added a progress comment.
 - [x] (2026-08-23 09:14-05:00) Added deterministic sequence-executor lifecycle tests and the `BaseSequence` test-project reference; the focused baseline reports 2 passed and 3 expected failures against the unfixed executor.
-- [ ] Implement restart invalidation and disposal-safe timer synchronization in `SequenceExecutor`.
+- [x] (2026-08-23 09:20-05:00) Implemented generation-based stale-callback invalidation and disposal-safe timer synchronization in `SequenceExecutor`; the x64 test target builds and all 5 focused lifecycle tests pass.
 - [ ] Verify focused and full x64 test runs, then manually exercise the close/stop-at-loop-boundary scenario.
 - [ ] Align VIX-3991 with delivered behavior and add the final validation comment.
 
@@ -37,6 +37,9 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 
 - Observation: The queued-callback failure can be reproduced without UI timing or sleep-based polling by capturing the executor's synchronization-context posts, stopping its end-check timer, and invoking the existing natural-end boundary directly.
   Evidence: `SequenceExecutorLifecycleTests` focused run reports 2 passed and 3 failures in 117 ms: stale dispatch after disposal throws `ArgumentNullException` at `_loopPlay`, stale dispatch after stop starts timing again, and a post-disposal end-check dispatch throws `NullReferenceException`.
+
+- Observation: The repaired executor stops active timing and media as part of disposal, so direct context disposal no longer relies on a caller having stopped the context first.
+  Evidence: `SequenceExecutor.Dispose(bool)` captures and invalidates the timer under the lifecycle lock, then stops the captured timer, timing source, and media before raising the existing end event. The focused stale-disposal test passes without touching `SequenceContext`.
 
 ## Decision Log
 
@@ -64,9 +67,13 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
   Rationale: The tracker should capture the agreed user-facing contract and final delivery evidence without milestone-by-milestone commentary.
   Date/Author: 2026-08-23 / User
 
+- Decision: Do not change `SequenceContext.Dispose(bool)` in this delivery.
+  Rationale: The repaired `SequenceExecutor.Dispose(bool)` now performs terminal playback cleanup itself, which protects direct context disposal and every other executor owner. Changing context cleanup order would add redundant lifecycle behavior without evidence that it is necessary.
+  Date/Author: 2026-08-23 / Codex
+
 ## Outcomes & Retrospective
 
-Milestones 1 and 2 are complete. VIX-3991 now defines the user-visible loop-boundary behavior, and deterministic regression coverage proves the three unsafe current behaviors before implementation: stale restart after stop, stale restart after disposal, and timer work arriving after disposal. The intended implementation result remains a sequence executor whose posted loop restart is valid only for its originating active loop and whose disposal is safe while timer or UI work is in flight. Update this section with actual test counts, manual observations, remaining gaps, and the final VIX-3991 status when work is complete.
+Milestones 1 through 3 are complete. The executor now assigns each playback run a generation value, captures it with natural-end callbacks, and ignores a callback after stop or disposal has invalidated that run. Timer access uses one immutable lifecycle lock, and disposal stops active playback before releasing timer state. The x64 test target builds and the five focused lifecycle tests pass. Full-suite and manual validation remain for Milestone 4.
 
 ## Context and Orientation
 
@@ -191,3 +198,5 @@ Plan revision note (2026-08-23): Completed Milestone 1. Updated VIX-3991 with a 
 Plan revision note (2026-08-23): Completed Milestone 2. Added the `BaseSequence` test-project reference, a non-parallel sequence-executor test collection, and five deterministic lifecycle tests using a captured synchronization context. The x64 test target builds successfully. The focused baseline has 2 passing tests and 3 expected failures that reproduce the bugs Milestone 3 must repair; no production behavior was changed.
 
 Plan revision note (2026-08-23): Updated the Jira communication policy at the user's direction. Keep the Milestone 1 description update and the Milestone 4 final validation comment, but do not add comments for individual implementation milestones.
+
+Plan revision note (2026-08-23): Completed Milestone 3. `SequenceExecutor` now uses a lifecycle lock, a playback-generation value, and guarded queued callbacks to prevent stopped or disposed loops from restarting. Timer callbacks return after disposal, and disposal stops live timing/media before clearing timer state. The x64 test target built successfully and all five focused lifecycle tests passed. No `SequenceContext` change was required, and no interim Jira comment was added.

--- a/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
+++ b/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
@@ -1,0 +1,178 @@
+# VIX-3991: Prevent a disposed looping sequence from restarting
+
+This ExecPlan is a living document. Maintain its `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections as work proceeds. Follow `.agents/PLANS.md` from the repository root when revising this document.
+
+## Purpose / Big Picture
+
+When a looping sequence reaches its end at the same time that its playback context is stopped, released, or disposed, Vixen can terminate with a fatal `ArgumentNullException`. After this work, stopping or closing a looping sequence will reliably prevent any already-queued restart from touching its disposed playback resources. Users can verify the change by stopping or closing a looping sequence at its end without a crash, an unexpected restart, or continued media playback.
+
+VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve ordinary playback, looping, pause/resume behavior, `SequenceStarted`, `SequenceReStarted`, and `SequenceEnded` notifications for a live executor. It must not change sequence file data, timing-module contracts, or introduce a new UI implementation.
+
+## Progress
+
+- [x] (2026-08-23 20:00Z) Investigated the reported stack trace, `SequenceExecutor`, `SequenceContext`, `ProgramExecutor`, and `HighResolutionTimer`; identified a queued loop-restart callback racing executor disposal.
+- [x] (2026-08-23 20:00Z) Read VIX-3991 and created this implementation plan without modifying production or test code.
+- [x] (2026-08-23 14:06Z) Updated VIX-3991 with the user-facing requirements, scope, acceptance criteria, and validation approach; added a progress comment.
+- [ ] Add deterministic executor lifecycle tests that reproduce a queued restart becoming stale.
+- [ ] Implement restart invalidation and disposal-safe timer synchronization in `SequenceExecutor`.
+- [ ] Verify focused and full x64 test runs, then manually exercise the close/stop-at-loop-boundary scenario.
+- [ ] Align VIX-3991 with delivered behavior and add the final validation comment.
+
+## Surprises & Discoveries
+
+- Observation: The exact failing statement is `lock (_endCheckTimer)` in `BaseSequence.SequenceExecutor._loopPlay`.
+  Evidence: The report identifies `src/Vixen.Common/BaseSequence/SequenceExecutor.cs:line 216`; `lock` throws `ArgumentNullException` when its lock expression is null.
+
+- Observation: `SequenceExecutor.Dispose(bool)` detaches the timer event and assigns `_endCheckTimer = null`, while `_CheckForNaturalEnd` posts `_loopPlay` asynchronously to the synchronization context.
+  Evidence: `SequenceExecutor.cs` lines 386 and 411-423. The report's `System.Windows.Forms.Control.InvokeMarshaledCallbacks` frames prove the callback was queued to the WinForms UI message queue before it ran.
+
+- Observation: Stopping the timer cannot retract a callback already posted to the UI queue.
+  Evidence: `_CheckForNaturalEnd` calls `_syncContext.Post`, which has no cancellation handle. The current `_loopPlay` has no `IsRunning`, `_loop`, or disposal check before restarting timing and media state.
+
+- Observation: The timer field is also read and locked by `_EndCheckTimerElapsed`, so fixing only `_loopPlay` would leave another disposal-time null race.
+  Evidence: `SequenceExecutor.cs` lines 362-376 read `_endCheckTimer.IsRunning` and then lock `_endCheckTimer`.
+
+- Observation: `SequenceContext.Dispose(bool)` disposes its sequence executor before `ContextBase.Dispose(bool)` has an opportunity to stop a running context.
+  Evidence: `src/Vixen.Core/Execution/Context/SequenceContext.cs` lines 226-237 and `ContextBase.cs` lines 186-197. The normal `ContextManager` release route stops the context first, but direct disposal still needs a safe executor.
+
+## Decision Log
+
+- Decision: Solve the stale queued-work problem with an execution-generation token (a monotonically increasing value identifying one active play/loop run), not with only a null guard.
+  Rationale: A null guard avoids the immediate exception but leaves a stale callback capable of restarting a sequence after the user stopped it. A captured generation value lets the UI callback prove that it still belongs to the current live loop before it changes timing, media, or events.
+  Date/Author: 2026-08-23 / Codex
+
+- Decision: Use a dedicated private, readonly synchronization object for executor timer state rather than the mutable `_endCheckTimer` reference.
+  Rationale: A lock target must remain valid for the lifetime of the executor. The timer reference is deliberately cleared during disposal, so it is not a valid synchronization object.
+  Date/Author: 2026-08-23 / Codex
+
+- Decision: Make `Dispose` stop and invalidate a running executor before releasing timer-related references; each timer callback and UI-posted callback must harmlessly no-op after invalidation.
+  Rationale: Disposal is a terminal lifecycle operation and may race with the background high-resolution timer and the UI queue. The executor itself must be safe even when its caller did not explicitly call `Stop` first.
+  Date/Author: 2026-08-23 / Codex
+
+- Decision: Keep the change local to the executor unless tests prove a context-disposal ordering correction is needed for consistency.
+  Rationale: `SequenceExecutor` is used both by sequence contexts and by `ProgramExecutor`; it is the common fault boundary. Correcting it there protects all callers and avoids relying on every owner to get cleanup order right.
+  Date/Author: 2026-08-23 / Codex
+
+## Outcomes & Retrospective
+
+Milestone 1 is complete. VIX-3991 now defines the user-visible loop-boundary behavior and the required automated and manual validation before code changes begin. The intended implementation result remains a sequence executor whose posted loop restart is valid only for its originating active loop and whose disposal is safe while timer or UI work is in flight. Update this section with actual test counts, manual observations, remaining gaps, and the final VIX-3991 status when work is complete.
+
+## Context and Orientation
+
+`src/Vixen.Common/BaseSequence/SequenceExecutor.cs` is the shared playback implementation used by the Timed and Vixen 2.x sequence modules. It owns an `ITiming` source, media startup and shutdown, playback range state, and a `HighResolutionTimer` named `_endCheckTimer`. The timer runs its `Elapsed` event on a background thread every ten milliseconds to determine whether the timing position has reached the requested end time.
+
+For normal non-loop playback, `_CheckForNaturalEnd` posts `_Stop` to the synchronization context captured in the executor constructor. For loop playback, it posts `_loopPlay`. A synchronization context is the mechanism that transfers work from one thread to another; in the application it is the WinForms UI message queue. Posting work is asynchronous: the timer thread returns immediately, and the UI may execute the callback later. Consequently, a queued restart can exist after `Stop` or `Dispose` has completed.
+
+`_loopPlay` currently stops the timer, sets `TimingSource.Position` to `StartTime`, starts timing, raises `SequenceReStarted`, waits for movement, and starts the timer again. It locks on `_endCheckTimer`. `Dispose(bool)` removes the elapsed handler and clears both `_endCheckTimer` and `_syncContext`. This causes the reported failure if the UI dispatches a restart that was posted before disposal.
+
+`src/Vixen.Core/Execution/Context/SequenceContext.cs` creates the association between an execution context and an `ISequenceExecutor`, forwards start/pause/resume/stop calls, and disposes an executor when a context is replaced or disposed. `src/Vixen.Core/Execution/ProgramExecutor.cs` independently owns and disposes sequence executors for queued program playback. Neither owner can cancel a callback already placed on the synchronization context, so `SequenceExecutor` must reject stale callbacks itself.
+
+`src/Vixen.Core/Utility/HighResolutionTimer.cs` is a reusable, non-overlapping background timer. `Stop(false)` stops its loop but intentionally does not join its thread. Its event can therefore be at or near the dispatch boundary when executor state is being cleaned up. Do not alter this general-purpose utility for this bug unless investigation finds a defect independent of executor ownership.
+
+Tests live in `src/Vixen.Tests`. The test project must be built with full Visual Studio MSBuild before `dotnet test --no-build`, because two transitive C++/CLI projects require the Visual C++ toolset. `BaseSequence` currently has no dedicated executor lifecycle test. Add one in `src/Vixen.Tests/Sequencer/SequenceExecutorLifecycleTests.cs` and add the minimal project reference or test-access configuration required to use `BaseSequence.SequenceExecutor`; do not make test-only methods public.
+
+## Plan of Work
+
+### Milestone 1: Publish the VIX-3991 user contract
+
+Before editing code, use `.agents/skills/jira/SKILL.md` and the configured Jira connection to update VIX-3991. Keep the description user-facing. Explain that Vixen must not crash, restart playback, or leave a sequence playing when a looping sequence ends while a user stops playback, closes the sequence/editor, changes playback context, or exits the application.
+
+Add acceptance criteria stating that normal looping continues to restart and report its restart event while the executor remains active; stopping or disposing at the loop boundary does not crash or restart; media and timing remain stopped after the stop; and existing non-loop end behavior remains unchanged. State that automated race-focused tests, the full x64 test suite, and a manual stop/close boundary scenario will validate the work. Add a concise progress comment after each implementation or validation milestone. If Jira is unavailable, record the failure in this plan and leave tracker actions pending; do not fabricate updates.
+
+### Milestone 2: Establish deterministic stale-callback tests
+
+Read all of `SequenceExecutor.cs`, `HighResolutionTimer.cs`, `SequenceContext.cs`, `ProgramExecutor.cs`, `ISequenceExecutor.cs`, `IExecutor.cs`, and `ITiming.cs` immediately before editing. Then create `src/Vixen.Tests/Sequencer/SequenceExecutorLifecycleTests.cs` using xUnit v3 and Moq, consistent with the existing test project. Add the smallest appropriate reference from `Vixen.Tests` to `src/Vixen.Common/BaseSequence/BaseSequence.csproj`; follow repository project-reference conventions and do not add NuGet packages.
+
+The tests must use a deterministic synchronization context installed before constructing the executor. The context must capture `Post` callbacks without automatically running them, and expose a test-only method that runs the next captured callback on the test thread. Use a minimal fake or mock `ISequence` and `ITiming` that let playback begin, reach its requested end, and avoid real media. If the existing timing and sequence interfaces make that setup unwieldy, add a narrowly scoped internal test seam with friend-assembly access rather than depending on elapsed-time sleeps or reflection into private state. Any new internal seam must preserve the normal production constructor and have XML documentation only if it is public or protected.
+
+Cover these observable cases:
+
+- A live `PlayLoop` run reaches its end, dispatches the captured callback, restarts timing at `StartTime`, and raises exactly one `SequenceReStarted` event.
+- A loop restart is captured, then `Stop` is called before dispatch. Dispatching the stale callback does not throw, does not restart timing or media, and does not raise `SequenceReStarted`.
+- A loop restart is captured, then `Dispose` is called before dispatch. Dispatching the stale callback does not throw and does not access cleared executor state.
+- A completed non-loop run still queues and performs its normal stop behavior, including a single `SequenceEnded` notification.
+- Disposal while the end-check path is active does not throw from timer-state synchronization. Make this deterministic through the same test seam or controlled callback boundary; do not use a timing-sensitive stress test as the sole regression proof.
+
+Keep all test helpers private to the test file unless reuse genuinely requires a separate helper file. The tests must prove behavior before and after the posted-work boundary rather than merely asserting that fields are non-null.
+
+### Milestone 3: Invalidate stale runs and make executor cleanup safe
+
+In `src/Vixen.Common/BaseSequence/SequenceExecutor.cs`, introduce private executor lifecycle state that distinguishes a current active play run from stale work. Prefer a private integer or long generation value protected by one private readonly lock object. Increment or otherwise invalidate this value before any operation that makes queued work obsolete: beginning a new play request, stopping playback, and disposal. Capture the value at the point `_CheckForNaturalEnd` decides to post `_loopPlay` or `_Stop`; pass it as the `Post` state. In the UI callback, take the lifecycle lock and return before touching timing, media, events, or the timer unless all of these remain true: the executor is not disposed, it is still running, the run identifier matches, and the requested action is still applicable (`_loop` for restart).
+
+Retain valid behavior: a live loop callback resets to `StartTime`, starts the same timing source, raises `SequenceReStarted`, and resumes end checking. A valid non-loop natural-end callback still stops the sequence. Make the run-validation and timer transition atomic relative to `Stop` and `Dispose`, so a stop cannot interleave between a successful check and restart initialization. Do not hold the lifecycle lock while executing event subscribers or while the existing wait loop sleeps; snapshot only the required live references and release the lock before those operations if necessary. This prevents UI event handlers from deadlocking when they request playback changes.
+
+Replace every `lock (_endCheckTimer)` with the dedicated immutable lock object. Under that lock, copy `_endCheckTimer` to a local variable, verify it is non-null and the executor is live, and only then query, start, or stop it. Apply this consistently in `_loopPlay`, `_Stop`, `_EndCheckTimerElapsed`, and any other timer-access path discovered during review. Do not dereference `_syncContext` after disposal; before posting work, capture it in a local and verify it is non-null and the run is still valid.
+
+Update `Dispose(bool)` to be idempotent and terminal. While holding the lifecycle lock, mark the executor disposed, invalidate the current run, and capture the timer reference. Outside the lock, stop the captured timer and detach its event handler without relying on a mutable field. Preserve safe repeated disposal. Clear references only after no future executor path requires them; retaining a harmless reference is preferable to nulling a field that an asynchronous callback could observe. Do not change the public `ISequenceExecutor` API unless the implementation cannot be made testable otherwise. If any public or protected API changes, read and follow `.agents/skills/csharp-docs/SKILL.md` and update its XML documentation in the same change.
+
+Review `SequenceContext.Dispose(bool)` after the executor fix. If tests show direct context disposal can leave timing/media running before executor cleanup, make the smallest ordering correction so it calls `Stop` before `_DisposeSequenceExecutor`; preserve the normal `ContextManager` release behavior and avoid duplicate end events. Record the decision and test evidence in this plan. Do not alter `HighResolutionTimer` unless a focused test proves executor-side synchronization cannot address the race.
+
+### Milestone 4: Validate the repaired lifecycle and update the ticket
+
+From `C:\Dev\Vixen`, inspect the intentional diff and run the project-prescribed x64 test build. Run the new focused tests first, then the complete suite:
+
+    git diff --check
+    git diff -- src/Vixen.Common/BaseSequence/SequenceExecutor.cs src/Vixen.Core/Execution/Context/SequenceContext.cs src/Vixen.Tests/Vixen.Tests.csproj src/Vixen.Tests/Sequencer/SequenceExecutorLifecycleTests.cs docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:/Dev/Vixen/" --filter "FullyQualifiedName~SequenceExecutorLifecycleTests"
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="C:/Dev/Vixen/"
+
+Expect the MSBuild command to finish with zero errors and both test commands to report zero failures. Record actual test counts. If the full toolchain is unavailable or an unrelated existing test fails, preserve the complete failure output in this plan, run every remaining viable check, and do not modify dependencies or unrelated tests merely to obtain a green run.
+
+Manually open a short sequence with media in the Timed Sequence Editor. Configure or use the existing loop playback command over a short, non-zero range. Repeatedly let the range reach its end and immediately stop playback; repeat while closing the editor or application at the boundary. Also let the loop run through several normal restarts and run the same range without loop enabled. Observe that normal looping restarts cleanly, while stop/close prevents a restart, leaves audio/output stopped, and produces no application error. Include the exact manual scenario and observed result in this plan.
+
+Finally, revise VIX-3991 if implementation discoveries changed the user-facing requirements or acceptance criteria. Add a concise Jira comment with the focused test result, full-suite result, and manual validation result. Update every living-document section of this plan and append a dated revision note. When a completed milestone changes repository files, generate a proposed commit message using `.agents/skills/commit-msg/SKILL.md`; do not create a commit unless the user explicitly requests it.
+
+## Concrete Steps
+
+All commands run from `C:\Dev\Vixen`.
+
+1. Reconfirm the relevant asynchronous and disposal paths before changing them:
+
+       rg -n -C 8 "_loopPlay|_CheckForNaturalEnd|_EndCheckTimerElapsed|_Stop\(|Dispose\(|_endCheckTimer|_syncContext" src/Vixen.Common/BaseSequence/SequenceExecutor.cs src/Vixen.Core/Execution/Context/SequenceContext.cs src/Vixen.Core/Execution/ProgramExecutor.cs
+
+2. Complete Milestone 1's Jira description update, then add the focused lifecycle tests and run the focused command from Milestone 4. The stale-callback tests must fail against the original implementation by reaching the queued restart after disposal, then pass after the repair without relying on a real UI pump or a sleep-based race.
+
+3. Implement Milestone 3 in small edits. After each edit, rerun the focused test command. Review the final diff with `git diff --check` and confirm no unrelated formatting changed.
+
+4. Run the full build and test commands in Milestone 4, perform the manual loop-boundary exercise, and record concrete evidence in this plan and VIX-3991.
+
+## Validation and Acceptance
+
+The repair is accepted when a normal live looping sequence still restarts at the configured start time and raises one restart event per natural end, and a non-loop sequence still ends normally. A stop, context release, context disposal, editor close, or application exit that occurs after a loop restart has been queued but before it executes must cause the queued callback to do nothing. It must not throw, restart timing, restart media, raise `SequenceReStarted`, or start the end-check timer again.
+
+Automated acceptance requires deterministic tests for live restart, stale callback after stop, stale callback after disposal, non-loop completion, and timer/disposal synchronization, plus the complete `Vixen.Tests` suite after the x64 MSBuild test build. Manual acceptance requires repeatedly stopping or closing a looping short sequence at its end with no fatal error and no unexpected continued playback.
+
+## Idempotence and Recovery
+
+The implementation must make `Stop` and `Dispose` safe to call repeatedly. A stale callback is expected during normal queue timing and must return without logging an error or changing playback state. If a test intermittently depends on timer scheduling, replace elapsed-time waiting with the deterministic synchronization-context or timer-dispatch seam described above; do not increase sleeps or retry loops as a substitute for correctness.
+
+If a change prevents valid looping, inspect generation creation and invalidation points first: a generation must remain valid from `PlayLoop` until `Stop`, `Dispose`, or a new play request invalidates it. If shutdown deadlocks, identify whether a lock is held while event handlers, media operations, timing operations, or a thread join runs; reduce the protected region to state transition and local-reference capture. Revert only the intentional executor/context/test changes if necessary, retain the regression tests, and rework the synchronization approach.
+
+## Artifacts and Notes
+
+The reported failure is represented by this causal sequence:
+
+    timer thread detects end while _loop is true
+    -> _syncContext.Post(_loopPlay)
+    -> Stop or Dispose invalidates/releases executor state
+    -> WinForms UI queue invokes _loopPlay
+    -> current code executes lock(_endCheckTimer)
+    -> _endCheckTimer is null and ArgumentNullException terminates the application
+
+The post-dispatch guard must be semantic, not merely null-safe:
+
+    if (disposed || !IsRunning || !_loop || postedGeneration != currentGeneration)
+        return;
+
+The exact names and field types may vary with repository style, but the final implementation must preserve this behavior and use one immutable lock target for all timer/lifecycle transitions.
+
+## Interfaces and Dependencies
+
+Keep `Vixen.Execution.ISequenceExecutor`, `Vixen.Execution.IExecutor`, `Vixen.Module.Timing.ITiming`, and `Vixen.Utility.HighResolutionTimer` public contracts unchanged. `BaseSequence.SequenceExecutor` remains the owner of timer, timing, and media lifecycle. `Vixen.Execution.Context.SequenceContext` and `Vixen.Execution.ProgramExecutor` remain owners that request lifecycle transitions; they must not need knowledge of the synchronization-context implementation.
+
+Use existing .NET synchronization primitives (`lock`, `SynchronizationContext.Post`, and an integer generation value protected by the lifecycle lock) and existing xUnit/Moq packages. Do not add package dependencies, new threads, a polling cancellation worker, or a public cancellation API. Any test visibility required for deterministic tests must be internal and limited to the `Vixen.Tests` friend assembly, with production behavior exercised through the normal executor methods.
+
+Plan revision note (2026-08-23): Initial VIX-3991 ExecPlan created from the Jira report, the crash investigation, and `.agents/PLANS.md`. It requires the mandated initial and final Jira milestones, chooses generation-based stale-callback invalidation with immutable timer synchronization, and explicitly prohibits a null-guard-only fix.
+
+Plan revision note (2026-08-23): Completed Milestone 1. Updated VIX-3991 with a concise user-facing Summary, Scope, Acceptance Criteria, and validation approach, then added a progress comment. No production or test code was changed.

--- a/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
+++ b/docs/plans/sequencer/vix-3991-loop-play-disposal-race.md
@@ -15,8 +15,8 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 - [x] (2026-08-23 14:06Z) Updated VIX-3991 with the user-facing requirements, scope, acceptance criteria, and validation approach; added a progress comment.
 - [x] (2026-08-23 09:14-05:00) Added deterministic sequence-executor lifecycle tests and the `BaseSequence` test-project reference; the focused baseline reports 2 passed and 3 expected failures against the unfixed executor.
 - [x] (2026-08-23 09:20-05:00) Implemented generation-based stale-callback invalidation and disposal-safe timer synchronization in `SequenceExecutor`; the x64 test target builds and all 5 focused lifecycle tests pass.
-- [ ] Verify focused and full x64 test runs, then manually exercise the close/stop-at-loop-boundary scenario.
-- [ ] Align VIX-3991 with delivered behavior and add the final validation comment.
+- [x] (2026-08-23 09:54-05:00) Verified the full build and unit-test suite pass; manual loop-boundary testing could not recreate the crash, and normal loop playback was validated.
+- [x] (2026-08-23 09:54-05:00) Added the final VIX-3991 validation comment; the issue description remains aligned with delivered behavior.
 
 ## Surprises & Discoveries
 
@@ -40,6 +40,9 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 
 - Observation: The repaired executor stops active timing and media as part of disposal, so direct context disposal no longer relies on a caller having stopped the context first.
   Evidence: `SequenceExecutor.Dispose(bool)` captures and invalidates the timer under the lifecycle lock, then stops the captured timer, timing source, and media before raising the existing end event. The focused stale-disposal test passes without touching `SequenceContext`.
+
+- Observation: The complete application build, full unit-test suite, and manual loop playback validation pass after the executor repair.
+  Evidence: User validation on 2026-08-23 reports that the full build and unit tests pass, the reported crash could not be recreated through manual testing, and normal loop playback was validated.
 
 ## Decision Log
 
@@ -73,7 +76,7 @@ VIX-3991 concerns only the shared sequence-executor lifecycle. It must preserve 
 
 ## Outcomes & Retrospective
 
-Milestones 1 through 3 are complete. The executor now assigns each playback run a generation value, captures it with natural-end callbacks, and ignores a callback after stop or disposal has invalidated that run. Timer access uses one immutable lifecycle lock, and disposal stops active playback before releasing timer state. The x64 test target builds and the five focused lifecycle tests pass. Full-suite and manual validation remain for Milestone 4.
+VIX-3991 is complete. The executor assigns each playback run a generation value, captures it with natural-end callbacks, and ignores a callback after stop or disposal has invalidated that run. Timer access uses one immutable lifecycle lock, and disposal stops active playback before releasing timer state. The focused lifecycle suite, full build, full unit-test suite, and manual loop-boundary validation all pass. The reported fatal crash could not be recreated, while ordinary loop playback continues to work.
 
 ## Context and Orientation
 
@@ -200,3 +203,5 @@ Plan revision note (2026-08-23): Completed Milestone 2. Added the `BaseSequence`
 Plan revision note (2026-08-23): Updated the Jira communication policy at the user's direction. Keep the Milestone 1 description update and the Milestone 4 final validation comment, but do not add comments for individual implementation milestones.
 
 Plan revision note (2026-08-23): Completed Milestone 3. `SequenceExecutor` now uses a lifecycle lock, a playback-generation value, and guarded queued callbacks to prevent stopped or disposed loops from restarting. Timer callbacks return after disposal, and disposal stops live timing/media before clearing timer state. The x64 test target built successfully and all five focused lifecycle tests passed. No `SequenceContext` change was required, and no interim Jira comment was added.
+
+Plan revision note (2026-08-23): Completed Milestone 4 with user-provided full-build, full-unit-test, and manual-validation evidence. The crash could not be recreated, and normal loop playback was confirmed. Added the single final VIX-3991 validation comment; no Jira description change was necessary.

--- a/src/Vixen.Common/BaseSequence/SequenceExecutor.cs
+++ b/src/Vixen.Common/BaseSequence/SequenceExecutor.cs
@@ -11,11 +11,14 @@ namespace BaseSequence
 {
 	public class SequenceExecutor : ISequenceExecutor
 	{
+		private readonly Lock _lifecycleLock = new();
 		private HighResolutionTimer _endCheckTimer;
 		private SynchronizationContext _syncContext;
 		private bool _isRunning;
 		private bool _isPaused;
 		private bool _loop;
+		private bool _isDisposed;
+		private long _executionGeneration;
 
 		public event EventHandler<SequenceStartedEventArgs> SequenceStarted;
 		public event EventHandler<SequenceStartedEventArgs> SequenceReStarted;
@@ -69,13 +72,21 @@ namespace BaseSequence
 
 		public void Play(TimeSpan startTime, TimeSpan endTime)
 		{
-			_loop = false;
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed) return;
+				_loop = false;
+			}
 			_Play(startTime, endTime);
 		}
 
 		public void PlayLoop(TimeSpan startTime, TimeSpan endTime)
 		{
-			_loop = true;
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed) return;
+				_loop = true;
+			}
 			_Play(startTime, endTime);
 		}
 
@@ -171,8 +182,12 @@ namespace BaseSequence
 
 		private void _Play(TimeSpan startTime, TimeSpan endTime)
 		{
-			if (IsRunning) return;
-			if (Sequence == null) return;
+			long executionGeneration;
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed || IsRunning || Sequence == null) return;
+				executionGeneration = ++_executionGeneration;
+			}
 
 			// Only hook the input stream during execution.
 			// Hook before starting the behaviors.
@@ -186,7 +201,7 @@ namespace BaseSequence
 			if (StartTime == EndTime)
 			{
 				//We are done before we get started
-				_syncContext.Post(x => _Stop(), null);
+				_PostNaturalEnd(executionGeneration, false);
 			}
 
 			TimingSource = Sequence.GetTiming() ?? _GetDefaultTimingSource();
@@ -206,29 +221,43 @@ namespace BaseSequence
 				Thread.Sleep(1); //Give the train a chance to get out of the station.
 			}
 
-			_endCheckTimer.Start();
+			_StartEndCheckTimer(executionGeneration);
 
 		}
 
-		private void _loopPlay()
+		private void _loopPlay(long executionGeneration)
 		{
-			// Stop whatever is driving this crazy train.
-			lock (_endCheckTimer)
+			ITiming timingSource;
+			ISequence sequence;
+			TimeSpan startTime;
+			TimeSpan endTime;
+
+			lock (_lifecycleLock)
 			{
-				_endCheckTimer.Stop(false);
+				if (!_IsCurrentLoopExecution(executionGeneration)) return;
+
+				var endCheckTimer = _endCheckTimer;
+				if (endCheckTimer == null) return;
+
+				endCheckTimer.Stop(false);
+				timingSource = TimingSource;
+				sequence = Sequence;
+				startTime = StartTime;
+				endTime = EndTime;
+
+				//Reset our position. No need to stop the source, we will just reset its position.
+				timingSource.Position = startTime;
+				timingSource.Start();
 			}
+
+			OnSequenceReStarted(new SequenceStartedEventArgs(sequence, timingSource, startTime, endTime));
 			
-			//Reset our position. No need to stop the source, we will just reset its position.
-			TimingSource.Position = StartTime;
-			TimingSource.Start();
-			OnSequenceReStarted(new SequenceStartedEventArgs(Sequence, TimingSource, StartTime, EndTime));
-			
-			while (TimingSource.Position == StartTime)
+			while (_IsCurrentExecution(executionGeneration) && timingSource.Position == startTime)
 			{
 				Thread.Sleep(1); //Give the train a chance to get out of the station.
 			}
 
-			_endCheckTimer.Start();
+			_StartEndCheckTimer(executionGeneration);
 		}
 
 		protected virtual void _HookDataListener()
@@ -303,41 +332,51 @@ namespace BaseSequence
 
 		private void _Pause()
 		{
-			if (!IsRunning || IsPaused) return;
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed || !IsRunning || IsPaused) return;
 
-			if (_endCheckTimer.IsRunning) {
+				var endCheckTimer = _endCheckTimer;
+				if (endCheckTimer == null || !endCheckTimer.IsRunning) return;
+
 				IsPaused = true;
 
 				TimingSource.Pause();
 
 				_PauseMedia();
 
-				_endCheckTimer.Stop(false);
+				endCheckTimer.Stop(false);
 			}
 		}
 
 		private void _Resume()
 		{
-			if (!IsPaused) return;
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed || !IsPaused) return;
 
-			if (!_endCheckTimer.IsRunning && Sequence != null) {
+				var endCheckTimer = _endCheckTimer;
+				if (endCheckTimer == null || endCheckTimer.IsRunning || Sequence == null) return;
+
 				IsPaused = false;
 
 				TimingSource.Resume();
 
 				_ResumeMedia();
 
-				_endCheckTimer.Start();
+				endCheckTimer.Start();
 			}
 		}
 
 		private void _Stop()
 		{
-			if (!IsRunning) return;
+			lock (_lifecycleLock)
+			{
+				if (!IsRunning) return;
+				_executionGeneration++;
 
-			// Stop whatever is driving this crazy train.
-			lock (_endCheckTimer) {
-				_endCheckTimer.Stop(false);
+				var endCheckTimer = _endCheckTimer;
+				endCheckTimer?.Stop(false);
 			}
 
 			// Release the hook before the behaviors are shut down so that
@@ -365,33 +404,77 @@ namespace BaseSequence
 			// To catch events that may trail after the timer's been disabled
 			// due to it being a threaded timer and Stop being called between the
 			// timer message being posted and acted upon.
-			if (!_endCheckTimer.IsRunning) return;
-
-			lock (_endCheckTimer)
+			lock (_lifecycleLock)
 			{
+				if (_isDisposed) return;
+
+				var endCheckTimer = _endCheckTimer;
+				if (endCheckTimer == null || !endCheckTimer.IsRunning) return;
 
 				if (_CheckForNaturalEnd() || !IsRunning)
 				{
-					_endCheckTimer.Stop(false);
+					endCheckTimer.Stop(false);
 				}
 			}
 		}
 
 		private bool _CheckForNaturalEnd()
 		{
-			bool isEnd = _IsEndOfSequence();
-			if (isEnd) {
-				if (_loop)
-				{
-					_syncContext.Post(x => _loopPlay(), null);
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed || !IsRunning) return false;
+
+				bool isEnd = _IsEndOfSequence();
+				if (isEnd) {
+					_PostNaturalEnd(_executionGeneration, _loop);
 				}
-				else
-				{
-					_syncContext.Post(x => _Stop(), null);	
-				}
-				
+				return isEnd;
 			}
-			return isEnd;
+		}
+
+		private void _PostNaturalEnd(long executionGeneration, bool loop)
+		{
+			var syncContext = _syncContext;
+			if (_isDisposed || syncContext == null) return;
+
+			if (loop)
+			{
+				syncContext.Post(x => _loopPlay((long)x), executionGeneration);
+			}
+			else
+			{
+				syncContext.Post(x => _stopAfterNaturalEnd((long)x), executionGeneration);
+			}
+		}
+
+		private void _stopAfterNaturalEnd(long executionGeneration)
+		{
+			lock (_lifecycleLock)
+			{
+				if (!_IsCurrentExecution(executionGeneration)) return;
+			}
+
+			_Stop();
+		}
+
+		private void _StartEndCheckTimer(long executionGeneration)
+		{
+			lock (_lifecycleLock)
+			{
+				if (!_IsCurrentExecution(executionGeneration)) return;
+
+				_endCheckTimer?.Start();
+			}
+		}
+
+		private bool _IsCurrentLoopExecution(long executionGeneration)
+		{
+			return _loop && _IsCurrentExecution(executionGeneration);
+		}
+
+		private bool _IsCurrentExecution(long executionGeneration)
+		{
+			return !_isDisposed && IsRunning && executionGeneration == _executionGeneration;
 		}
 
 		private bool _IsEndOfSequence()
@@ -414,17 +497,34 @@ namespace BaseSequence
 
 		protected virtual void Dispose(bool disposing)
 		{
+			HighResolutionTimer endCheckTimer;
+			bool wasRunning;
+
+			lock (_lifecycleLock)
+			{
+				if (_isDisposed) return;
+
+				_isDisposed = true;
+				_executionGeneration++;
+				wasRunning = IsRunning;
+				endCheckTimer = _endCheckTimer;
+				_endCheckTimer = null;
+				_syncContext = null;
+			}
+
 			if (disposing)
 			{
-				if (_endCheckTimer != null)
-				{
-					_endCheckTimer.Elapsed -= _EndCheckTimerElapsed;
-					_endCheckTimer = null;
+				endCheckTimer?.Stop();
+				endCheckTimer?.Elapsed -= _EndCheckTimerElapsed;
 
-				}	
+				if (wasRunning)
+				{
+					TimingSource?.Stop();
+					_StopMedia();
+					IsRunning = false;
+					IsPaused = false;
+				}
 			}
-			_endCheckTimer = null;
-			_syncContext = null;
 		}
 
 		#endregion

--- a/src/Vixen.Tests/Sequencer/SequenceExecutorLifecycleTests.cs
+++ b/src/Vixen.Tests/Sequencer/SequenceExecutorLifecycleTests.cs
@@ -1,0 +1,236 @@
+using System.ComponentModel;
+using System.Reflection;
+using BaseSequence;
+using Moq;
+using Vixen.Module.Media;
+using Vixen.Module.Timing;
+using Vixen.Sys;
+using Vixen.Utility;
+using Xunit;
+
+namespace Vixen.Tests.Sequencer;
+
+/// <summary>
+/// Verifies sequence-executor behavior at the boundary between a timer-posted completion callback and lifecycle cleanup.
+/// </summary>
+[Collection(SequenceExecutorTestCollection.Name)]
+public sealed class SequenceExecutorLifecycleTests
+{
+	private static readonly TimeSpan EndTime = TimeSpan.FromSeconds(1);
+
+	/// <summary>
+	/// Verifies that a live looping sequence restarts when its queued natural-end callback is dispatched.
+	/// </summary>
+	[Fact]
+	public void PlayLoop_WhenNaturalEndCallbackIsDispatched_RestartsAndRaisesRestartedEvent()
+	{
+		WithExecutor((executor, timing, synchronizationContext) =>
+		{
+			var restartCount = 0;
+			executor.SequenceReStarted += (_, _) => restartCount++;
+
+			StartAndQueueNaturalEnd(executor, timing);
+			synchronizationContext.DispatchSingle();
+
+			Assert.Equal(2, timing.StartCount);
+			Assert.Equal(TimeSpan.FromMilliseconds(1), timing.Position);
+			Assert.Equal(1, restartCount);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that stopping playback invalidates a queued loop restart.
+	/// </summary>
+	[Fact]
+	public void PlayLoop_WhenStoppedBeforeNaturalEndCallbackDispatch_DoesNotRestartOrRaiseRestartedEvent()
+	{
+		WithExecutor((executor, timing, synchronizationContext) =>
+		{
+			var restartCount = 0;
+			executor.SequenceReStarted += (_, _) => restartCount++;
+
+			StartAndQueueNaturalEnd(executor, timing);
+			executor.Stop();
+			var startCountAfterStop = timing.StartCount;
+
+			var exception = Record.Exception(synchronizationContext.DispatchSingle);
+
+			Assert.Null(exception);
+			Assert.Equal(startCountAfterStop, timing.StartCount);
+			Assert.Equal(0, restartCount);
+			Assert.False(executor.IsRunning);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that disposing playback invalidates a queued loop restart without accessing released state.
+	/// </summary>
+	[Fact]
+	public void PlayLoop_WhenDisposedBeforeNaturalEndCallbackDispatch_DoesNotThrowOrRestart()
+	{
+		WithExecutor((executor, timing, synchronizationContext) =>
+		{
+			var restartCount = 0;
+			executor.SequenceReStarted += (_, _) => restartCount++;
+
+			StartAndQueueNaturalEnd(executor, timing);
+			executor.Dispose();
+			var startCountAfterDispose = timing.StartCount;
+
+			var exception = Record.Exception(synchronizationContext.DispatchSingle);
+
+			Assert.Null(exception);
+			Assert.Equal(startCountAfterDispose, timing.StartCount);
+			Assert.Equal(0, restartCount);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that a queued non-loop natural-end callback stops playback and raises one end event.
+	/// </summary>
+	[Fact]
+	public void Play_WhenNaturalEndCallbackIsDispatched_StopsAndRaisesEndedEvent()
+	{
+		WithExecutor((executor, timing, synchronizationContext) =>
+		{
+			var endedCount = 0;
+			executor.SequenceEnded += (_, _) => endedCount++;
+
+			executor.Play(TimeSpan.Zero, EndTime);
+			StopEndCheckTimer(executor);
+			timing.Position = EndTime;
+			Assert.True(CheckForNaturalEnd(executor));
+
+			synchronizationContext.DispatchSingle();
+
+			Assert.Equal(1, timing.StopCount);
+			Assert.Equal(1, endedCount);
+			Assert.False(executor.IsRunning);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that a timer callback arriving after disposal does not access released timer state.
+	/// </summary>
+	[Fact]
+	public void EndCheckTimerElapsed_WhenExecutorIsDisposed_DoesNotThrow()
+	{
+		WithExecutor((executor, _, _) =>
+		{
+			executor.PlayLoop(TimeSpan.Zero, EndTime);
+			StopEndCheckTimer(executor);
+			executor.Dispose();
+
+			var exception = Record.Exception(() => InvokeEndCheckTimerElapsed(executor));
+
+			Assert.Null(exception);
+		});
+	}
+
+	private static void WithExecutor(Action<SequenceExecutor, TestTiming, QueuedSynchronizationContext> test)
+	{
+		var originalSynchronizationContext = AsyncOperationManager.SynchronizationContext;
+		var synchronizationContext = new QueuedSynchronizationContext();
+		AsyncOperationManager.SynchronizationContext = synchronizationContext;
+
+		try
+		{
+			var timing = new TestTiming();
+			var sequence = new Mock<ISequence>();
+			sequence.SetupGet(x => x.Length).Returns(EndTime);
+			sequence.Setup(x => x.GetTiming()).Returns(timing);
+			sequence.Setup(x => x.GetAllMedia()).Returns(Enumerable.Empty<IMediaModuleInstance>());
+
+			using var executor = new SequenceExecutor { Sequence = sequence.Object };
+			test(executor, timing, synchronizationContext);
+		}
+		finally
+		{
+			AsyncOperationManager.SynchronizationContext = originalSynchronizationContext;
+		}
+	}
+
+	private static void StartAndQueueNaturalEnd(SequenceExecutor executor, TestTiming timing)
+	{
+		executor.PlayLoop(TimeSpan.Zero, EndTime);
+		StopEndCheckTimer(executor);
+		timing.Position = EndTime;
+		Assert.True(CheckForNaturalEnd(executor));
+	}
+
+	private static bool CheckForNaturalEnd(SequenceExecutor executor)
+	{
+		var method = typeof(SequenceExecutor).GetMethod("_CheckForNaturalEnd", BindingFlags.Instance | BindingFlags.NonPublic)!;
+		return (bool) method.Invoke(executor, null)!;
+	}
+
+	private static void StopEndCheckTimer(SequenceExecutor executor)
+	{
+		var timer = (HighResolutionTimer) GetField(executor, "_endCheckTimer");
+		timer.Stop();
+	}
+
+	private static void InvokeEndCheckTimerElapsed(SequenceExecutor executor)
+	{
+		var method = typeof(SequenceExecutor).GetMethod("_EndCheckTimerElapsed", BindingFlags.Instance | BindingFlags.NonPublic)!;
+		method.Invoke(executor, [null, null]);
+	}
+
+	private static object GetField(object target, string fieldName)
+	{
+		var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+		return field.GetValue(target)!;
+	}
+
+	private sealed class QueuedSynchronizationContext : SynchronizationContext
+	{
+		private readonly Queue<(SendOrPostCallback Callback, object? State)> _callbacks = [];
+
+		public override void Post(SendOrPostCallback callback, object? state)
+		{
+			_callbacks.Enqueue((callback, state));
+		}
+
+		public void DispatchSingle()
+		{
+			if (!_callbacks.TryDequeue(out var callback))
+			{
+				throw new InvalidOperationException("No callback was queued for dispatch.");
+			}
+
+			callback.Callback(callback.State);
+		}
+	}
+
+	private sealed class TestTiming : ITiming
+	{
+		public TimeSpan Position { get; set; }
+		public bool SupportsVariableSpeeds => false;
+		public float Speed { get; set; }
+		public int StartCount { get; private set; }
+		public int StopCount { get; private set; }
+
+		public void Start()
+		{
+			StartCount++;
+			if (Position == TimeSpan.Zero)
+			{
+				Position = TimeSpan.FromMilliseconds(1);
+			}
+		}
+
+		public void Stop()
+		{
+			StopCount++;
+		}
+
+		public void Pause()
+		{
+		}
+
+		public void Resume()
+		{
+		}
+	}
+
+}

--- a/src/Vixen.Tests/Sequencer/SequenceExecutorTestCollection.cs
+++ b/src/Vixen.Tests/Sequencer/SequenceExecutorTestCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Vixen.Tests.Sequencer;
+
+/// <summary>
+/// Defines the non-parallel collection for tests that replace the process-wide asynchronous-operation synchronization context.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SequenceExecutorTestCollection
+{
+	/// <summary>
+	/// Identifies the collection that serializes sequence-executor lifecycle tests.
+	/// </summary>
+	public const string Name = "Sequence executor lifecycle tests";
+}

--- a/src/Vixen.Tests/Vixen.Tests.csproj
+++ b/src/Vixen.Tests/Vixen.Tests.csproj
@@ -19,6 +19,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Vixen.Application\Vixen.Application.csproj" />
+		<ProjectReference Include="..\Vixen.Common\BaseSequence\BaseSequence.csproj" />
 		<ProjectReference Include="..\Vixen.Common\Broadcast\Broadcast.csproj" />
 		<ProjectReference Include="..\Vixen.Common\Controls\Controls.csproj" />
 		<ProjectReference Include="..\Vixen.Common\Messages\Messages.csproj" />


### PR DESCRIPTION
## Summary

Fixes a fatal crash when a loop restart callback runs after sequence playback has been stopped or disposed.

- Ignore queued loop/end callbacks that no longer belong to the active playback run.
- Synchronize timer cleanup with a stable lifecycle lock.
- Stop active timing and media during executor disposal.
- Add deterministic regression coverage for loop restart, stop, disposal, and delayed timer callbacks.

## Validation

- Full build passed.
- Full unit-test suite passed.
- Focused sequence executor lifecycle tests passed (5/5).
- Manual loop-boundary testing could not recreate the crash.
- Normal loop playback was validated.

## Risk

Low. The change is isolated to sequence-executor lifecycle handling and preserves normal loop and non-loop completion behavior.