### PR TITLE
VIX-3991 Fix unstarted timer shutdown

### DIFF
--- a/src/Vixen.Core/Utility/HighResolutionTimer.cs
+++ b/src/Vixen.Core/Utility/HighResolutionTimer.cs
@@ -127,11 +127,12 @@ namespace Vixen.Utility
 		{
 			_isRunning = false;
 
-			// Even if _thread.Join may take time it is guaranteed that 
+			// Even if _thread.Join may take time, it is guaranteed that
 			// Elapsed event is never called overlapped with different threads
-			if (joinThread && Thread.CurrentThread != _thread)
+			var thread = _thread;
+			if (joinThread && thread is not null && Thread.CurrentThread != thread)
 			{
-				_thread.Join();
+				thread.Join();
 			}
 		}
 

--- a/src/Vixen.Tests/Utility/HighResolutionTimerTests.cs
+++ b/src/Vixen.Tests/Utility/HighResolutionTimerTests.cs
@@ -1,0 +1,21 @@
+using Vixen.Utility;
+using Xunit;
+
+namespace Vixen.Tests.Utility;
+
+public sealed class HighResolutionTimerTests
+{
+	[Fact]
+	public void Stop_WhenTimerHasNotStarted_DoesNotThrow()
+	{
+		// Arrange
+		var timer = new HighResolutionTimer();
+
+		// Act
+		var exception = Record.Exception(() => timer.Stop());
+
+		// Assert
+		Assert.Null(exception);
+		Assert.False(timer.IsRunning);
+	}
+}


### PR DESCRIPTION
VIX-3991 disposal now stops the end-check timer even when a sequence has never played. That timer has no worker thread yet, causing a fatal NullReferenceException while closing the editor.

Guard the timer join against an unstarted worker thread and add a regression test for stopping a newly created timer.