### PR TITLE
VIX-1119 Add location rendering to Fire

### DIFF
--- a/docs/effects/vix-1119-fire-location-support.md
+++ b/docs/effects/vix-1119-fire-location-support.md
@@ -1,0 +1,505 @@
+# VIX-1119 Fire Location Rendering Specification
+
+## Purpose
+
+The Fire effect currently renders only against the target element string structure. This makes the effect useful on a matrix,
+tree, or similarly ordered prop, but it does not support whole-display or multi-prop layouts where the fire should use each
+element's preview location. VIX-1119 adds location rendering so a user can apply Fire to a group of props and see one continuous
+fire simulation across their combined preview-space coordinates.
+
+This specification follows the same user, compatibility, coordinate, performance, test, and delivery considerations as
+`docs/effects/vix-3386-spiral-location-support.md`. Fire requires a different rendering strategy from Spiral because a Fire cell
+depends on neighboring cells in the preceding simulation row. Missing preview elements therefore cannot simply be omitted from
+the simulation without changing how heat propagates.
+
+The Jira connector and authenticated issue page were unavailable during this analysis. The issue contract below is based on the
+user-supplied VIX-1119 scope, the current repository, and the completed VIX-3386 design and implementation. No unavailable old
+patch is assumed.
+
+This document is a detailed implementation specification. It is intended to be converted into an ExecPlan under `docs/plans/`
+before coding begins. The ExecPlan must follow `.agents/PLANS.md`.
+
+## Current Behavior
+
+`src/Vixen.Modules/Effect/Fire/Fire.cs` inherits from `PixelEffectBase` and implements only the string rendering path:
+
+- The constructor creates `FireData` but does not call `EnableTargetPositioning(true, true)`, so the inherited
+  `TargetPositioning` setup property remains hidden.
+- `SetupRender()` allocates one dense integer heat buffer with `BufferWi * BufferHt` cells.
+- `RenderEffect(int frame, IPixelFrameBuffer frameBuffer)` generates a random source row, propagates heat through every cell of
+  the dense rectangle, maps the simulation to the selected `FireDirection`, converts heat indexes through `FirePalette`, and
+  writes the colors to the string frame buffer.
+- `FireDirection.Left` and `FireDirection.Right` swap the simulation width and height before propagation.
+- There is no `RenderEffectByLocation(int numFrames, PixelLocationFrameBuffer frameBuffer)` override. If location mode were only
+  exposed, `PixelEffectBase.RenderNodeByLocation` would call the base implementation and throw `NotImplementedException`.
+
+The current propagation intentionally samples the previous row at `x - 1`, `x + 1`, `x`, and `x` again. The duplicated center
+sample weights the center cell twice. This is existing Fire behavior and must not be "cleaned up" as part of location support.
+
+`src/Vixen.Modules/Effect/Fire/FireData.cs` already inherits from `EffectTypeModuleData`, which contains the serialized
+`TargetPositioning` property and preserves it during cloning. No new serialized data member is required.
+
+The existing public setting named `Location` is a `FireDirection` and means the edge from which flames originate: `Bottom`,
+`Top`, `Left`, or `Right`. It is separate from the inherited `TargetPositioning` setting, whose values are `Strings` and
+`Locations`. Both settings must remain available and retain their current names for compatibility.
+
+## Repository Context
+
+The shared target-positioning behavior lives in `src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs`.
+
+`PixelEffectBase.TargetPositioning` has two modes:
+
+- `Strings`: render by the target element hierarchy. This is Fire's current behavior.
+- `Locations`: collect all leaf target elements, read their Location property, create a virtual coordinate rectangle enclosing
+  those elements, and render against preview coordinates.
+
+When `TargetPositioning` is `Locations`, `PixelEffectBase.ConfigureVirtualBuffer()` computes:
+
+- `ElementLocations`: one `ElementLocation` per target leaf element.
+- `BufferWi`, `BufferHt`: the logical width and height of the orientation-normalized virtual rectangle.
+- `BufferWiOffset`, `BufferHtOffset`: the absolute preview-coordinate offsets used to map into that rectangle.
+
+`PixelLocationFrameBuffer` in `src/Vixen.Modules/Effect/Effect/Location/PixelLocationFrameBuffer.cs` stores output only for actual
+element locations. Duplicate preview coordinates share the same sparse output cell.
+
+Relevant precedents are:
+
+- `src/Vixen.Modules/Effect/Spiral/Spiral.cs`, which enables target positioning, performs the standard absolute-to-local
+  coordinate conversion, and writes only actual locations.
+- `src/Vixen.Modules/Effect/Spiral/Spiral.cs` and `src/Vixen.Tests/Effects/SpiralLocationRenderTests.cs`, which establish
+  rectangular-grid parity, sparse sampling, property enablement, control coverage, and performance measurement as expectations.
+- `src/Vixen.Modules/Effect/Wave/Wave/Wave.cs`, `Whirlpool/Whirlpool/Whirlpool.cs`, and `Morph/Morph/Morph.cs`, which show the
+  repository's dense virtual-render-then-sample option. That option is correct but would duplicate Fire's already-dense heat
+  storage with a second dense color buffer.
+
+The design was reviewed using the project `dotnet-best-practices`, `dotnet-design-pattern-review`, and `catel-mvvm` guidance.
+The change stays inside the effect module and its tests; it adds no service, dependency injection, view model, view, command, or
+code-behind responsibility.
+
+## Required User Behavior
+
+After implementation, Fire must expose the same inherited `TargetPositioning` setup option as other location-aware pixel
+effects. A user must be able to select `Locations`, place Fire on a group containing elements from multiple props, and see one
+continuous fire simulation over the combined preview-space bounding rectangle.
+
+Location mode must preserve the existing Fire controls:
+
+- `Location` (`FireDirection.Bottom`, `Top`, `Left`, or `Right`)
+- `Height`
+- `HueShiftCurve`
+- `LevelCurve`
+
+On a regular rectangular location grid, location output must match string output for the same simulated heat frame and
+orientation. On a sparse layout, the result must appear as though Fire were simulated across the entire virtual rectangle and
+then sampled only at actual element coordinates. A gap between props must still participate in heat propagation even though it
+has no output element.
+
+Switching an existing effect between `Strings` and `Locations` must not reset or reinterpret the existing controls. Existing
+serialized effects must continue to default to `Strings` unless they already contain a different inherited
+`TargetPositioning` value.
+
+## Design Alternatives
+
+### Direct Per-Location Simulation
+
+This is not suitable for Fire. Spiral can calculate a color independently for any coordinate, but Fire cannot: a cell depends
+on adjacent cells from the preceding simulation row. Simulating only actual element locations would treat gaps as missing heat,
+break propagation across props, and produce a different effect from a dense virtual rectangle.
+
+### Dense Color Buffer Then Sparse Sampling
+
+Location mode could allocate a `PixelFrameBuffer`, call the existing `RenderEffect`, and copy colors at each
+`ElementLocation`. This is a valid low-code fallback and follows Wave and Whirlpool, but it retains Fire's dense integer heat
+buffer and adds a dense `Color` buffer of the same virtual dimensions. Whole-display layouts are the case most likely to have a
+large, sparse bounding rectangle, so the additional allocation and dense HSV-to-RGB conversion are avoidable.
+
+### Dense Heat Simulation With Sparse Projection
+
+This is the preferred design. Continue to simulate every heat cell in `_fireBuffer`, preserving neighborhood behavior, random
+call order, and gaps between props. After the heat field is complete, location mode converts and writes colors only for
+`frameBuffer.ElementLocations`. String mode projects the same heat field to every logical output coordinate.
+
+This strategy uses the minimum state compatible with Fire's existing algorithm:
+
+- Dense simulation cost: `O(BufferWi * BufferHt)` per frame.
+- Location projection cost: `O(elementCount)` per frame.
+- Persistent simulation allocation: one `int[BufferWi * BufferHt]` per effect render.
+- No additional dense `PixelFrameBuffer` in the normal location path.
+
+## Proposed Design
+
+### Target Positioning Enablement
+
+In `Fire.Fire()`, after `_data` is initialized, call:
+
+    EnableTargetPositioning(true, true);
+
+Initialize the orientation attribute state so `StringOrientation` is visible for `Strings` and hidden for `Locations`. Apply the
+same attribute refresh when `ModuleData` is replaced during deserialization. A small private helper such as
+`InitAllAttributes()` may call `UpdateStringOrientationAttributes(true)` and be used by both the constructor and the
+`ModuleData` setter.
+
+Do not add a second target-positioning property and do not rename the existing `Location` direction setting.
+
+### Shared Simulation and Projection Responsibilities
+
+Refactor `RenderEffect` into three focused private responsibilities while preserving its formulas and iteration order:
+
+1. `CreateFireFrameState(int frame)` calculates frame values that do not vary by cell:
+   - effect interval position factor;
+   - brightness level;
+   - hue shift;
+   - simulation width and height after applying `FireDirection`;
+   - clamped effective height;
+   - heat adjustment step.
+2. `GenerateFireHeat(FireFrameState state)` fills `_fireBuffer` for exactly one frame.
+3. A projection helper reads a heat index at a logical output coordinate, converts it through `FirePalette`, applies hue and
+   level, and returns whether the coordinate is lit.
+
+Exact private names may vary. A private readonly record struct is acceptable for immutable per-frame state if it fits the local
+code style; no public data transfer type is needed.
+
+`GenerateFireHeat` must preserve the existing random sequence and calculations:
+
+    for simulationX in 0 .. simulationWidth - 1:
+        heat[simulationX] = simulationX is even
+            ? 190 + Rand() % 10
+            : 100 + Rand() % 50
+
+    effectiveHeight = max((int)Height.GetValue(intervalPositionFactor), 1)
+    step = 255 * 100 / simulationHeight / effectiveHeight
+
+    for simulationY in 1 .. simulationHeight - 1:
+        for simulationX in 0 .. simulationWidth - 1:
+            neighbors = valid values from:
+                (simulationX - 1, simulationY - 1)
+                (simulationX + 1, simulationY - 1)
+                (simulationX,     simulationY - 1)
+                (simulationX,     simulationY - 1)  // intentional duplicate
+            newIndex = integer average of neighbors, or zero when none exist
+            if newIndex > 0:
+                newIndex += Rand() % 100 < 20 ? step : -step
+                clamp newIndex to [0, FirePalette.Count() - 1]
+            heat[simulationY * simulationWidth + simulationX] = newIndex
+
+Do not parallelize this loop. It has row dependencies, and changing evaluation order would also change the sequence of random
+values and therefore the effect's visual character.
+
+### Output Coordinate to Simulation Coordinate Mapping
+
+Projection should work from a logical output coordinate `(outputX, outputY)` in the standard `PixelFrameBuffer` coordinate
+system, where `(0, 0)` is the lower-left corner. Convert that coordinate to the heat simulation using this inverse mapping:
+
+| `FireDirection` | Simulation width | Simulation height | `simulationX` | `simulationY` |
+|---|---:|---:|---:|---:|
+| `Bottom` | `BufferWi` | `BufferHt` | `outputX` | `outputY` |
+| `Top` | `BufferWi` | `BufferHt` | `outputX` | `BufferHt - outputY - 1` |
+| `Left` | `BufferHt` | `BufferWi` | `outputY` | `outputX` |
+| `Right` | `BufferHt` | `BufferWi` | `outputY` | `BufferWi - outputX - 1` |
+
+This is the exact inverse of the current forward transformation in `RenderEffect`. It ensures the source row appears on the
+bottom, top, left, or right edge respectively without duplicating four render loops.
+
+The pixel evaluator should then:
+
+    colorIndex = GetFireBuffer(simulationX, simulationY, simulationWidth, simulationHeight)
+    if colorIndex == 0:
+        return false
+
+    hsv = FirePalette.GetColor(colorIndex)
+    if hueShift > 0:
+        hsv.H += hueShift / 100.0f
+    hsv.V *= level
+    return true
+
+Keep the current `hueShift > 0` behavior and the current palette semantics. Corrections to negative hue shifts, palette bounds,
+or palette construction are separate issues unless characterization tests show location support cannot be implemented safely
+without them.
+
+### String Mode Preservation
+
+`RenderEffect(int frame, IPixelFrameBuffer frameBuffer)` should create the frame state, generate the heat field once, iterate all
+logical output coordinates, evaluate each coordinate with the shared inverse mapping, and set lit pixels on the supplied dense
+frame buffer.
+
+Refactoring the current forward projection to the inverse evaluator is acceptable only after characterization tests cover all
+four directions. Setting pixels in a different order does not change the completed heat field, but heat generation loop order
+and random call count must remain unchanged.
+
+If the inverse projection refactor cannot be proven equivalent, retain the existing string projection loop and use a separate
+inverse mapping only for location sampling. Do not duplicate the heat generation algorithm.
+
+### Location Coordinate Conversion
+
+Add:
+
+    protected override void RenderEffectByLocation(int numFrames, PixelLocationFrameBuffer frameBuffer)
+
+and import `VixenModules.Effect.Effect.Location` in `Fire.cs`.
+
+For each absolute `ElementLocation`, first convert preview coordinates into the logical output coordinates used by string-mode
+effect math:
+
+    int outputY = Math.Abs((BufferHtOffset - elementLocation.Y) +
+                           (BufferHt - 1 + BufferHtOffset));
+    outputY -= BufferHtOffset;
+    int outputX = elementLocation.X - BufferWiOffset;
+
+For locations inside the configured virtual rectangle this is equivalent to:
+
+    outputX = elementLocation.X - previewXMin;
+    outputY = previewYMax - elementLocation.Y;
+
+Use the table above to map `(outputX, outputY)` to the heat buffer. Write any resulting color back with the original absolute
+preview coordinate:
+
+    frameBuffer.SetPixel(elementLocation.X, elementLocation.Y, hsv);
+
+This retains the sparse buffer's keys and matches the Y inversion used by Spiral and other location-aware effects.
+
+### Location Render Loop
+
+The location override should:
+
+1. Return without rendering if `numFrames <= 0`, `BufferWi <= 0`, or `BufferHt <= 0`.
+2. Loop frames from `0` through `numFrames - 1` in order.
+3. Set `frameBuffer.CurrentFrame` for each frame.
+4. Create one frame state and generate the complete dense heat field once.
+5. Iterate `frameBuffer.ElementLocations` once.
+6. Convert each absolute preview location to logical output coordinates.
+7. Evaluate the corresponding heat cell using the selected `FireDirection`.
+8. Set only lit locations. Unset cells retain the sparse frame buffer's black/transparent default.
+
+`SetupRender()` continues to allocate `_fireBuffer` once for the full virtual rectangle, and `CleanUpRender()` continues to
+release it after rendering. The allocation product is unchanged by left/right direction because those directions only swap
+width and height.
+
+### Serialized Data and Compatibility
+
+No changes are required in `FireData`, `FireDirection`, `FirePalette`, or `FireDescriptor` for the feature contract.
+`EffectTypeModuleData.TargetPositioning` already supplies serialization and clone behavior.
+
+Existing effects remain in `Strings` because `EffectTypeModuleData` defaults `TargetPositioning` to `Strings`. The existing
+`FireData` defaults and `OnDeserialized` hue-shift migration remain unchanged.
+
+No new public or protected C# API is expected beyond the required protected override already defined by `PixelEffectBase`. If
+implementation adds or changes another public or protected member, use the project `csharp-docs` skill and update XML comments
+in the same change.
+
+## Mathematical and Boundary Rules
+
+The implementation must preserve or safely handle these cases:
+
+- `BufferWi == 0` or `BufferHt == 0`: return before allocation, division, or rendering. `PixelEffectBase` normally prevents this,
+  but helpers should not rely exclusively on the caller.
+- `Height <= 0`: clamp the effective height to `1`, matching current behavior.
+- Large `Height`: preserve integer division in the current `step` calculation, including a possible `step` of zero.
+- `FireDirection.Left` and `Right`: swap simulation dimensions but not the logical output dimensions.
+- Heat index zero: do not set an output pixel, matching the current rendering optimization and black result.
+- Sparse gaps: calculate their heat values even though no output is written for them.
+- Duplicate preview coordinates: allow `PixelLocationFrameBuffer` to share one sampled color; do not attempt per-element
+  differentiation at the same coordinate.
+- Missing Location properties: follow the shared `ElementLocation` behavior; do not special-case Fire.
+- Hue and level curves: evaluate once per frame, then apply to every sampled lit location exactly as string mode does.
+- Randomness: preserve the source-row and propagation random call count and order for a given buffer size and frame sequence.
+- Repeated renders: allocate a fresh zeroed heat buffer in `SetupRender()` and do not retain heat between effect render passes.
+- Integer allocation size: calculate or validate the cell count before allocating if implementation introduces new dimension
+  arithmetic. Do not add an arbitrary preview-size cap without measured evidence and a separately agreed user behavior.
+
+## Concurrency, Performance, and Thread Safety
+
+Each Fire effect instance owns `_fireBuffer`, so no synchronization is required around the heat field. `FirePalette` is
+initialized once and read thereafter. `Rand()` uses the existing thread-local random source.
+
+Location rendering must remain sequential per effect instance. Parallel row generation is invalid because each row depends on
+the previous row. Parallel cell generation would change random assignment even within a row. The design adds no static mutable
+state, tasks, locks, or UI-thread work.
+
+The normal location path must not allocate a dense `PixelFrameBuffer` or convert every virtual heat cell to RGB. It is expected
+to retain one dense integer heat field because exact sparse virtual-rectangle semantics require the cells between actual
+elements.
+
+The future ExecPlan should measure at least these scenarios in Release configuration:
+
+- Dense matrix: 50 x 50 virtual rectangle, 2,500 elements, 100 frames.
+- Medium sparse display: 5,000 elements over a 1,000 x 500 virtual rectangle, 20 frames.
+- Large sparse display: 20,000 elements over a 2,000 x 1,000 virtual rectangle, 3 frames.
+
+Measure elapsed time and allocated bytes for:
+
+1. Dense heat simulation with sparse projection, the proposed implementation.
+2. Dense heat plus dense `PixelFrameBuffer` rendering and sparse sampling, as a comparison prototype if practical.
+3. A dependency-pruned heat simulation only if the proposed implementation is materially too slow. Such an optimization must
+   reproduce dense results and random behavior before adoption; it is not part of the initial design.
+
+Record evidence in the ExecPlan. Unlike Spiral, Fire cannot be expected to scale only with element count because its simulation
+is spatially dependent. Acceptance should focus on avoiding unnecessary second dense buffers and conversions while preserving
+the effect.
+
+## Test Specification
+
+Add focused xUnit tests in `src/Vixen.Tests/Effects/FireLocationRenderTests.cs`. Add a project reference from
+`src/Vixen.Tests/Vixen.Tests.csproj` to `..\Vixen.Modules\Effect\Fire\Fire.csproj`; do not add a new test project or solution
+folder.
+
+Fire uses randomness, so exact string/location parity must compare two projections of the same deterministic heat field or use a
+small deterministic random seam. Do not write flaky assertions against unrelated `ThreadSafeRandom` sequences. Prefer private
+helpers exercised through the existing reflection style in `SpiralLocationRenderTests`; use an `internal` seam only if it makes
+the production design clearer and does not affect the hot loop.
+
+Recommended tests:
+
+1. `Fire_DefaultConstructor_EnablesTargetPositioning`
+
+   Verify `TargetPositioning` is browsable and can be set to `TargetPositioningType.Locations`. Also verify
+   `StringOrientation` hides in location mode and is restored in string mode.
+
+2. `Fire_RenderEffectByLocation_DoesNotThrow`
+
+   Configure a non-empty virtual rectangle and location buffer, invoke the location override, and verify it completes.
+
+3. `Fire_LocationProjection_RectangularGridMatchesStringProjection`
+
+   Generate one deterministic heat frame, project it to a dense string buffer and a complete location grid, and compare RGB at
+   every corresponding coordinate after preview Y inversion. Run this theory for Bottom, Top, Left, and Right.
+
+4. `Fire_LocationRender_OriginatesAtSelectedEdge`
+
+   With deterministic source values, verify the source row maps to the bottom, top, left, and right logical output edge for the
+   corresponding direction.
+
+5. `Fire_LocationRender_SparseCoordinatesSampleDenseHeatField`
+
+   Use non-contiguous located elements with offsets. Verify only actual coordinates are stored while their values come from the
+   same dense heat field used for a complete grid. Include a location whose heat depends on an intermediate coordinate that has
+   no element, proving gaps still participate in propagation.
+
+6. `Fire_LocationRender_AppliesHeightHueAndLevel`
+
+   Use deterministic heat generation to verify Height changes propagation, `HueShiftCurve` changes the sampled hue, and
+   `LevelCurve` scales value. A zero level is a stable assertion for fully dark output.
+
+7. `Fire_LocationRender_MultipleFramesAdvanceAndStayInBounds`
+
+   Render multiple frames and verify every source and propagation access remains in range for narrow shapes such as 1 x N and
+   N x 1 in all directions.
+
+8. `Fire_ModuleData_PreservesLocationAttributeState`
+
+   Replace `ModuleData` with data whose inherited target positioning is `Locations` and verify the setup property state is
+   refreshed, especially that `StringOrientation` remains hidden.
+
+If tests expose an existing Fire defect unrelated to location support, document it and scope it separately unless it blocks
+safe implementation. Characterize the duplicated center sample, current hue condition, and integer step behavior rather than
+silently changing them.
+
+## Manual Validation
+
+After implementation, manually validate in Vixen:
+
+1. Create or open a profile with at least two props that have preview locations and a visible gap between them.
+2. Group those props under one target group.
+3. Add Fire to the group in the sequencer.
+4. Set `TargetPositioning` to `Locations` and confirm `StringOrientation` is hidden.
+5. Set `Location` to `Bottom`, use visible Height, Hue Shift, and Brightness curves, and scrub the timeline.
+6. Confirm flames form one simulation across both props rather than restarting per prop.
+7. Repeat with `Top`, `Left`, and `Right`, confirming flames originate at the selected preview edge.
+8. Change Height, Hue Shift, and Brightness and confirm each control affects location rendering.
+9. Switch to `Strings` and confirm the previous string-based behavior and orientation setting still work.
+10. Save, reopen, and confirm both target positioning and fire direction persist independently.
+
+## Acceptance Criteria
+
+VIX-1119 is complete when all of the following are true:
+
+- Fire exposes `TargetPositioning` and supports both `Strings` and `Locations`.
+- Choosing `Locations` renders without `NotImplementedException`.
+- Location mode renders one continuous fire simulation over the virtual rectangle containing all target preview coordinates.
+- Sparse gaps participate in propagation but allocate no output pixels beyond actual element locations.
+- Bottom, Top, Left, and Right originate from the matching preview edge.
+- Height, Hue Shift, and Brightness behave in location mode as they do in string mode.
+- Regular-grid location projection matches string projection for the same deterministic heat frame.
+- Existing string-mode output is unchanged for representative settings and all four directions.
+- Location mode does not allocate a second dense color frame buffer in its normal path.
+- Automated tests cover property enablement, direction mapping, parity, sparse sampling, controls, frame progression, and module
+  data attribute refresh.
+- Focused and full-suite automated validation plus manual UI results are recorded in the future ExecPlan.
+- VIX-1119 is updated with the final user-facing requirements, acceptance criteria, and validation outcome when Jira access is
+  available.
+
+## Jira Update Draft
+
+Use this user-facing content to update VIX-1119 before implementation begins, following the project `jira` skill.
+
+### Summary
+
+Add preview-location rendering to the Fire effect.
+
+### Scope
+
+- Allow Fire to render as one continuous effect across a group of located props.
+- Preserve the existing choice of bottom, top, left, or right flame origin.
+- Preserve Height, Hue Shift, Brightness, and existing string-based behavior.
+- Ensure gaps between props behave as part of the same virtual display area.
+
+### Acceptance Criteria
+
+- Given a group containing multiple located props, when Fire uses location positioning, then one continuous fire pattern spans
+  the group instead of restarting for each prop.
+- Given any flame origin, when Fire is rendered by location, then flames originate from the matching preview edge.
+- Given existing Fire controls, when their values change, then location output responds consistently with string output.
+- Given an existing sequence using Fire, when it is opened after the change, then it retains string positioning and its existing
+  appearance unless the user selects location positioning.
+
+## ExecPlan Notes
+
+The future ExecPlan should be saved under `docs/plans/effects/vix-1119-fire-location-support.md` and include these milestones:
+
+1. Restore authenticated Jira access if available and update VIX-1119 with the user-facing scope and acceptance criteria.
+2. Add baseline tests showing target positioning is hidden and the location render path is absent.
+3. Enable target positioning and refresh orientation property attributes during construction and module-data replacement.
+4. Extract shared heat generation and color projection without changing string output.
+5. Implement dense-heat/sparse-output location rendering and all four direction mappings.
+6. Complete deterministic parity, sparse-gap, control, boundary, and persistence tests.
+7. Measure CPU and allocation behavior for dense and sparse virtual rectangles; optimize only with evidence.
+8. Run focused and full automated validation, perform manual UI validation, and update Jira with the outcome.
+
+Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` current as required by
+`.agents/PLANS.md`.
+
+## Architecture Design: VIX-1119 Fire Location Support
+
+- **Core Strategy:** Enable the inherited target-positioning choice and separate Fire into dense heat simulation plus output
+  projection. Keep the heat field dense because neighbor propagation crosses sparse gaps; project only actual locations to the
+  sparse frame buffer. This applies the Strategy-like separation and compatibility focus from the active .NET design-review
+  skills without adding public abstractions.
+- **Data Model & Property Contracts:** Reuse inherited serialized `TargetPositioning`; retain `Fire.Location` as the independent
+  flame-origin direction; add no serialized fields. Refresh `StringOrientation` visibility after construction, target-mode
+  changes, and module-data replacement.
+- **Mathematical / Boundary Logic:** Convert absolute preview coordinates to lower-left logical coordinates, then invert the
+  existing direction mapping using the table in this specification. Preserve dense row propagation, the duplicated center
+  sample, integer averaging and step calculation, palette clamping, hue condition, brightness scaling, and random call order.
+- **Subsystem Component Matrix:** Modify `Fire.cs` for enablement, shared simulation/projection helpers, and the location
+  override; add `FireLocationRenderTests.cs`; add one Fire project reference to `Vixen.Tests.csproj`. No changes are expected in
+  Fire data, direction, palette, descriptor, shared pixel infrastructure, views, or view models.
+- **Concurrency, Performance & Thread Safety:** Keep sequential per-instance rendering. Allocate one dense integer heat field
+  per render, no dense color field in location mode, and write only actual element coordinates. Benchmark virtual-area cost and
+  allocations before considering dependency-pruned simulation.
+
+## TERRA HAND-OFF CONTEXT
+
+VIX-1119 adds `TargetPositioning=Locations` to `VixenModules.Effect.Fire.Fire`. Jira details could not be authenticated, so use
+the user-supplied scope and `docs/effects/vix-1119-fire-location-support.md` as the contract. Fire differs from Spiral: heat at
+`(x,y)` depends on `(x-1,y-1)`, `(x+1,y-1)`, and `(x,y-1)` twice, so sparse per-element calculation is invalid. Required design:
+call `EnableTargetPositioning(true,true)`; refresh `StringOrientation` attributes in constructor and `ModuleData` setter; retain
+inherited serialized `EffectTypeModuleData.TargetPositioning` and existing `Fire.Location` direction; split current render into
+per-frame state, dense heat generation, and color projection; preserve random call order, duplicate-center weighting, integer
+step, palette clamp, hue condition, and level scaling. Location rendering keeps `_fireBuffer` dense but does not allocate a
+dense `PixelFrameBuffer`; per frame generate heat once, iterate `PixelLocationFrameBuffer.ElementLocations`, convert absolute
+preview `(X,Y)` to logical `outputX=X-BufferWiOffset`, `outputY=previewYMax-Y`, then map to simulation coordinates: Bottom
+`(outputX,outputY)`, Top `(outputX,BufferHt-outputY-1)`, Left `(outputY,outputX)`, Right
+`(outputY,BufferWi-outputX-1)`. Write colors at original absolute coordinates. Add Fire project reference and deterministic tests
+for property visibility, no-throw, regular-grid projection parity for all directions, origin edges, sparse gaps participating in
+dense propagation, Height/Hue/Level, multi-frame narrow buffers, and module-data attribute refresh. Benchmark dense 50x50,
+sparse 5k over 1000x500, and sparse 20k over 2000x1000. Do not change FireData, FireDirection, FirePalette, FireDescriptor,
+PixelEffectBase, UI/MVVM, or public APIs unless implementation evidence forces a separately documented decision.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -16,7 +16,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 - [x] (2026-08-24) Updated Jira VIX-1119 with the user-facing preview-location scope, compatibility commitments, validation plan, and acceptance criteria. The issue is in progress; no implementation completion was claimed.
 - [x] (2026-08-24) Added `FireLocationRenderTests` and the Fire module project reference. The Release-focused baseline builds successfully; four string-direction characterizations pass while the target-positioning and location-render tests fail as expected against current Fire.
 - [x] (2026-08-24) Enabled Fire's inherited target-positioning setup property and refreshed `StringOrientation` metadata after construction and `ModuleData` replacement. Added mode-toggle and replacement tests; all Milestone 3 tests pass.
-- [ ] Separate Fire's dense heat generation from its string and sparse-location output projections without changing existing string output.
+- [x] (2026-08-24) Extracted private simulation-dimension, frame-state, dense heat-generation, and color-evaluation helpers while retaining Fire's forward string projection. Added full-grid same-frame characterization for all four directions; string behavior remains covered before location projection is added.
 - [ ] Add location projection, deterministic behavioral coverage, and boundary coverage.
 - [ ] Record Release performance and allocation evidence for all required layouts.
 - [ ] Run focused and full automated validation, complete manual UI validation, update Jira with outcomes, and complete this plan's retrospective.
@@ -37,6 +37,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: `dotnet test src\\Vixen.Tests\\Vixen.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~FireLocation` on 2026-08-24 reported 6 total tests: 4 passed and 2 failed. The failures are `TargetPositioning` not browsable and the base `RenderEffectByLocation` throwing `NotImplementedException`.
 - Observation: enabling target positioning and refreshing attributes resolves the two setup-property failures without affecting string-direction characterization.
   Evidence: after Milestone 3, the same focused Release run reported 8 total tests: 7 passed, including target-positioning visibility, mode toggling, module-data replacement, and all four string directions. The only failure remains `RenderEffectByLocation` inheriting the base `NotImplementedException`.
+- Observation: the Milestone 4 refactor preserves the established string projection for every lit heat cell in every direction.
+  Evidence: after the extraction, the focused Release run reported 12 total tests: 11 passed, including source-edge and full-grid same-frame projection theories for Bottom, Top, Left, and Right. The only failure remains the intentionally unimplemented location override.
 
 ## Decision Log
 
@@ -54,6 +56,9 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Date/Author: 2026-08-24 / Codex
 - Decision: Use test-only reflection to inspect Fire's completed dense heat field for the initial string-direction characterization.
   Rationale: Fire currently has no deterministic random-source seam. Comparing output to the exact heat field produced during the same render proves direction projection without asserting unrelated thread-local random values or modifying production APIs before the location-rendering design is implemented.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Retain Fire's existing forward string projection while extracting generation and color evaluation.
+  Rationale: this minimizes string-mode regression risk and retains the original output ordering. The extracted dense generator preserves source-row X order, propagation Y/X order, duplicate center sample, and all random-call sites; Milestone 5 can use the shared dense field with a separate inverse location mapper.
   Date/Author: 2026-08-24 / Codex
 
 ## Outcomes & Retrospective
@@ -226,3 +231,5 @@ Revision note (2026-08-24): Retried Milestone 1 after VIX-1119 became visible. U
 Revision note (2026-08-24): Completed Milestone 2. Added Fire location characterization tests and the Fire project reference without modifying production code. Recorded the expected two failures and four passing string-direction characterizations from the Release-focused baseline.
 
 Revision note (2026-08-24): Completed Milestone 3. Enabled inherited target positioning, refreshed StringOrientation attributes after construction and module-data replacement, added focused setup-property tests, and preserved all existing string-direction characterizations.
+
+Revision note (2026-08-24): Completed Milestone 4. Separated private frame state, dense heat generation, and color evaluation from the retained forward string projection. Added full-grid same-frame string characterization for all four directions and preserved the existing random traversal structure.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -15,7 +15,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 - [x] (2026-08-24) Created this ExecPlan from the implementation contract after reading the current Fire renderer, `PixelEffectBase`, `PixelLocationFrameBuffer`, the existing Spiral location tests, and the completed VIX-3386 ExecPlan. No production code or tests have been changed.
 - [x] (2026-08-24) Updated Jira VIX-1119 with the user-facing preview-location scope, compatibility commitments, validation plan, and acceptance criteria. The issue is in progress; no implementation completion was claimed.
 - [x] (2026-08-24) Added `FireLocationRenderTests` and the Fire module project reference. The Release-focused baseline builds successfully; four string-direction characterizations pass while the target-positioning and location-render tests fail as expected against current Fire.
-- [ ] Expose inherited target positioning and correctly refresh Fire setup-property visibility.
+- [x] (2026-08-24) Enabled Fire's inherited target-positioning setup property and refreshed `StringOrientation` metadata after construction and `ModuleData` replacement. Added mode-toggle and replacement tests; all Milestone 3 tests pass.
 - [ ] Separate Fire's dense heat generation from its string and sparse-location output projections without changing existing string output.
 - [ ] Add location projection, deterministic behavioral coverage, and boundary coverage.
 - [ ] Record Release performance and allocation evidence for all required layouts.
@@ -35,6 +35,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: the initial `getJiraIssue(VIX-1119)` call on 2026-08-24 returned “Issue does not exist or you do not have permission to see it.” A retry returned issue 15583 and `editJiraIssue` saved the planned description at 2026-08-24T15:08:11-05:00.
 - Observation: the Milestone 2 focused baseline has four passing string-direction characterizations and two expected failures.
   Evidence: `dotnet test src\\Vixen.Tests\\Vixen.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~FireLocation` on 2026-08-24 reported 6 total tests: 4 passed and 2 failed. The failures are `TargetPositioning` not browsable and the base `RenderEffectByLocation` throwing `NotImplementedException`.
+- Observation: enabling target positioning and refreshing attributes resolves the two setup-property failures without affecting string-direction characterization.
+  Evidence: after Milestone 3, the same focused Release run reported 8 total tests: 7 passed, including target-positioning visibility, mode toggling, module-data replacement, and all four string directions. The only failure remains `RenderEffectByLocation` inheriting the base `NotImplementedException`.
 
 ## Decision Log
 
@@ -222,3 +224,5 @@ Revision note (2026-08-24): Attempted Milestone 1. The Jira connection and VIX p
 Revision note (2026-08-24): Retried Milestone 1 after VIX-1119 became visible. Updated the Jira description with the user-facing scope and acceptance criteria, marked the milestone complete, and retained the earlier temporary-access observation for traceability.
 
 Revision note (2026-08-24): Completed Milestone 2. Added Fire location characterization tests and the Fire project reference without modifying production code. Recorded the expected two failures and four passing string-direction characterizations from the Release-focused baseline.
+
+Revision note (2026-08-24): Completed Milestone 3. Enabled inherited target positioning, refreshed StringOrientation attributes after construction and module-data replacement, added focused setup-property tests, and preserved all existing string-direction characterizations.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -17,7 +17,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 - [x] (2026-08-24) Added `FireLocationRenderTests` and the Fire module project reference. The Release-focused baseline builds successfully; four string-direction characterizations pass while the target-positioning and location-render tests fail as expected against current Fire.
 - [x] (2026-08-24) Enabled Fire's inherited target-positioning setup property and refreshed `StringOrientation` metadata after construction and `ModuleData` replacement. Added mode-toggle and replacement tests; all Milestone 3 tests pass.
 - [x] (2026-08-24) Extracted private simulation-dimension, frame-state, dense heat-generation, and color-evaluation helpers while retaining Fire's forward string projection. Added full-grid same-frame characterization for all four directions; string behavior remains covered before location projection is added.
-- [ ] Add location projection, deterministic behavioral coverage, and boundary coverage.
+- [x] (2026-08-24) Implemented sparse preview-location projection over a single dense heat field per frame. Added offset-aware deterministic coverage for all directions, source edges, sparse gaps, controls, multi-frame narrow rectangles, and duplicate locations; the focused Release run passes 26 tests.
 - [ ] Record Release performance and allocation evidence for all required layouts.
 - [ ] Run focused and full automated validation, complete manual UI validation, update Jira with outcomes, and complete this plan's retrospective.
 
@@ -39,6 +39,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: after Milestone 3, the same focused Release run reported 8 total tests: 7 passed, including target-positioning visibility, mode toggling, module-data replacement, and all four string directions. The only failure remains `RenderEffectByLocation` inheriting the base `NotImplementedException`.
 - Observation: the Milestone 4 refactor preserves the established string projection for every lit heat cell in every direction.
   Evidence: after the extraction, the focused Release run reported 12 total tests: 11 passed, including source-edge and full-grid same-frame projection theories for Bottom, Top, Left, and Right. The only failure remains the intentionally unimplemented location override.
+- Observation: the sparse location buffer stores output only at supplied preview coordinates, while Fire must still simulate the complete virtual rectangle.
+  Evidence: `Fire.RenderEffectByLocation` generates `_fireBuffer` once per frame, then makes one pass through `PixelLocationFrameBuffer.ElementLocations`; `Fire_LocationRender_SparseCoordinatesSampleDenseHeatField` validates an offset, noncontiguous layout and confirms a missing coordinate has no sparse entry. The Release-focused run on 2026-08-24 passed all 26 Fire location tests.
 
 ## Decision Log
 
@@ -59,6 +61,9 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Date/Author: 2026-08-24 / Codex
 - Decision: Retain Fire's existing forward string projection while extracting generation and color evaluation.
   Rationale: this minimizes string-mode regression risk and retains the original output ordering. The extracted dense generator preserves source-row X order, propagation Y/X order, duplicate center sample, and all random-call sites; Milestone 5 can use the shared dense field with a separate inverse location mapper.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Implement location sampling through one private inverse mapper and preserve the documented base-class absolute-coordinate conversion formula.
+  Rationale: a single mapper covers all four origin directions without duplicating the generator, and the offset-aware tests detect swapped X/Y offsets or an omitted preview-Y inversion. The protected override is the existing extension point, so no new public API is required.
   Date/Author: 2026-08-24 / Codex
 
 ## Outcomes & Retrospective
@@ -233,3 +238,5 @@ Revision note (2026-08-24): Completed Milestone 2. Added Fire location character
 Revision note (2026-08-24): Completed Milestone 3. Enabled inherited target positioning, refreshed StringOrientation attributes after construction and module-data replacement, added focused setup-property tests, and preserved all existing string-direction characterizations.
 
 Revision note (2026-08-24): Completed Milestone 4. Separated private frame state, dense heat generation, and color evaluation from the retained forward string projection. Added full-grid same-frame string characterization for all four directions and preserved the existing random traversal structure.
+
+Revision note (2026-08-24): Completed Milestone 5. Added Fire's protected location-rendering override with a dense heat field generated once per frame and sparse absolute-coordinate output. Added deterministic offset, direction, source-edge, sparse-gap, control, multi-frame, narrow-buffer, and duplicate-location coverage; the focused Release run passed 26 tests.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -19,7 +19,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 - [x] (2026-08-24) Extracted private simulation-dimension, frame-state, dense heat-generation, and color-evaluation helpers while retaining Fire's forward string projection. Added full-grid same-frame characterization for all four directions; string behavior remains covered before location projection is added.
 - [x] (2026-08-24) Implemented sparse preview-location projection over a single dense heat field per frame. Added offset-aware deterministic coverage for all directions, source edges, sparse gaps, controls, multi-frame narrow rectangles, and duplicate locations; the focused Release run passes 26 tests.
 - [x] (2026-08-24) Added a Release benchmark harness and measured all required layouts with one warm-up and three measured runs. The dense-heat/sparse-projection implementation remains selected; no production optimization or dense-color buffer was introduced.
-- [ ] Run focused and full automated validation, complete manual UI validation, update Jira with outcomes, and complete this plan's retrospective.
+- [x] (2026-08-24) Full Release build and all 836 unit tests passed. Manual testing confirmed location-mode rendering and all tested functions behaved as expected. Added the final validation comment to Jira VIX-1119 and completed this ExecPlan.
 
 ## Surprises & Discoveries
 
@@ -43,6 +43,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: `Fire.RenderEffectByLocation` generates `_fireBuffer` once per frame, then makes one pass through `PixelLocationFrameBuffer.ElementLocations`; `Fire_LocationRender_SparseCoordinatesSampleDenseHeatField` validates an offset, noncontiguous layout and confirms a missing coordinate has no sparse entry. The Release-focused run on 2026-08-24 passed all 26 Fire location tests.
 - Observation: Release performance scales with both the dense simulation rectangle and the count of actual sparse outputs, without requiring a second dense color frame.
   Evidence: `FireLocationBenchmark_*` uses one warm-up plus three measured runs of Fire setup and location rendering, excluding sparse-buffer construction. On an AMD Ryzen 7 8845HS (8 cores/16 logical processors), 64 GB RAM, Windows 10.0.26200.0, and the .NET 10.0.8 test runtime: 50x50/2,500/100 averaged 177.2 ms and 81,555,901 bytes; 1000x500/5,000/20 averaged 99.1 ms and 30,055,035 bytes; 2000x1000/20,000/3 averaged 120.2 ms and 25,162,152 bytes.
+- Observation: end-to-end validation completed without a user-visible regression.
+  Evidence: the user reported a successful full Release build, all 836 unit tests passing, and manual testing of location mode and all tested functions producing expected results. Jira VIX-1119 received completion comment 40384 on 2026-08-24.
 
 ## Decision Log
 
@@ -73,7 +75,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 
 ## Outcomes & Retrospective
 
-Planning is complete; implementation has not started. When implementation completes, replace this paragraph with the observed location-rendering behavior, focused/full test results, benchmark results, manual-validation result, Jira status, remaining gaps, and lessons learned compared with the Purpose section.
+Fire now renders a single continuous simulation over preview locations while keeping the independent flame-origin direction and existing string behavior. Deterministic focused validation passed 29 Fire tests, including the benchmark harness. The user confirmed the full Release build and all 836 unit tests passed, then manually verified location mode and all tested functions. The required Release performance evidence is recorded above. Jira VIX-1119 remains in progress with completion comment 40384; no remaining implementation gaps are known, and no production changes were required after the performance evidence.
 
 ## Context and Orientation
 
@@ -248,3 +250,5 @@ Revision note (2026-08-24): Completed Milestone 4. Separated private frame state
 Revision note (2026-08-24): Completed Milestone 5. Added Fire's protected location-rendering override with a dense heat field generated once per frame and sparse absolute-coordinate output. Added deterministic offset, direction, source-edge, sparse-gap, control, multi-frame, narrow-buffer, and duplicate-location coverage; the focused Release run passed 26 tests.
 
 Revision note (2026-08-24): Completed Milestone 6. Added focused Release benchmark tests using one warm-up and three measured runs for all required dense and sparse layouts. Recorded machine/runtime context, timing, and setup-plus-render allocations; retained the production dense-heat/sparse-projection design without a dense-color prototype or optimization.
+
+Revision note (2026-08-24): Completed Milestone 7. Recorded the user-reported successful full Release build, all 836 passing unit tests, and manual location-mode validation. Added the final Jira validation comment (40384) and completed the ExecPlan retrospective.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -1,0 +1,217 @@
+# Add Preview-Location Rendering to the Fire Effect
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository contains `.agents/PLANS.md`; maintain this document according to that file. The implementation contract for this work is `docs/effects/vix-1119-fire-location-support.md`. That contract takes precedence if this plan is revised.
+
+## Purpose / Big Picture
+
+After this change, a Vixen user can apply Fire to a group of props, select `TargetPositioning = Locations`, and see one continuous fire simulation across the bounding rectangle of those props' preview coordinates. Today Fire only uses the string structure of its target, so it restarts or cannot render as a display-wide preview-space effect.
+
+The existing setting named `Location` will continue to mean the flame-origin edge (`Bottom`, `Top`, `Left`, or `Right`). It is independent from the inherited `TargetPositioning` setting (`Strings` or `Locations`). A user will be able to change either setting without changing the meaning or saved value of the other. The behavior is demonstrable through deterministic projection tests, performance measurements, and manual sequencer validation with separated props.
+
+## Progress
+
+- [x] (2026-08-24) Created this ExecPlan from the implementation contract after reading the current Fire renderer, `PixelEffectBase`, `PixelLocationFrameBuffer`, the existing Spiral location tests, and the completed VIX-3386 ExecPlan. No production code or tests have been changed.
+- [x] (2026-08-24) Updated Jira VIX-1119 with the user-facing preview-location scope, compatibility commitments, validation plan, and acceptance criteria. The issue is in progress; no implementation completion was claimed.
+- [ ] Add failing characterization tests and the Fire project reference.
+- [ ] Expose inherited target positioning and correctly refresh Fire setup-property visibility.
+- [ ] Separate Fire's dense heat generation from its string and sparse-location output projections without changing existing string output.
+- [ ] Add location projection, deterministic behavioral coverage, and boundary coverage.
+- [ ] Record Release performance and allocation evidence for all required layouts.
+- [ ] Run focused and full automated validation, complete manual UI validation, update Jira with outcomes, and complete this plan's retrospective.
+
+## Surprises & Discoveries
+
+- Observation: Fire has the required inherited serialized storage already, but does not currently expose it or implement location rendering.
+  Evidence: `FireData` inherits `EffectTypeModuleData`; `Fire.Fire()` only creates `FireData`; `PixelEffectBase.RenderEffectByLocation` throws `NotImplementedException` unless a derived effect overrides it.
+- Observation: Fire cannot compute only the actual element locations when the preview layout has gaps.
+  Evidence: each heat cell reads the preceding-row left neighbor, right neighbor, and the center neighbor twice. Omitting a virtual coordinate changes later heat values and therefore changes the visible simulation.
+- Observation: `PixelLocationFrameBuffer` is sparse but accepts a virtual location list and deduplicates equal preview coordinates.
+  Evidence: its constructor stores `ElementLocations = elementLocations.Distinct()` and creates data only at supplied X/Y keys. `SetPixel` silently writes only a stored coordinate.
+- Observation: the virtual-buffer width/height names are orientation-normalized by `PixelEffectBase`; Fire's standard default orientation is vertical.
+  Evidence: `ConfigureVirtualBuffer()` assigns raw preview Y extent to `_bufferWi` and X extent to `_bufferHt`; the public protected accessors swap them only when `StringOrientation` is horizontal. Tests must set or construct dimensions through the same orientation assumptions as production code.
+- Observation: VIX-1119 was temporarily unavailable to the connected Jira account but was retrievable and editable on retry.
+  Evidence: the initial `getJiraIssue(VIX-1119)` call on 2026-08-24 returned “Issue does not exist or you do not have permission to see it.” A retry returned issue 15583 and `editJiraIssue` saved the planned description at 2026-08-24T15:08:11-05:00.
+
+## Decision Log
+
+- Decision: Treat `docs/effects/vix-1119-fire-location-support.md` as the implementation contract and do not infer requirements from an unavailable Jira page.
+  Rationale: the contract explicitly records that Jira access was unavailable during analysis and gives complete behavior, test, compatibility, and performance requirements.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Preserve one dense integer heat field and make output projection sparse in location mode.
+  Rationale: Fire's row-to-row neighbor dependency requires every virtual coordinate to participate, but converting every virtual coordinate to RGB or allocating a dense color buffer is unnecessary when only actual elements receive output.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Preserve Fire's existing random source-row and propagation loop ordering exactly; share or refactor projection only after all four direction parity tests characterize string behavior.
+  Rationale: random-call order is observable output for this effect. A mathematically similar heat loop with a changed traversal order can produce a different animation.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Make no changes to `FireData`, `FireDirection`, `FirePalette`, `FireDescriptor`, `PixelEffectBase`, UI/MVVM code, serialized data, or public APIs unless implementation evidence establishes a separate documented need.
+  Rationale: inherited target-positioning storage and the required protected virtual override already exist, so expanding the scope would add compatibility risk without serving VIX-1119.
+  Date/Author: 2026-08-24 / Codex
+
+## Outcomes & Retrospective
+
+Planning is complete; implementation has not started. When implementation completes, replace this paragraph with the observed location-rendering behavior, focused/full test results, benchmark results, manual-validation result, Jira status, remaining gaps, and lessons learned compared with the Purpose section.
+
+## Context and Orientation
+
+Vixen is a WPF application for sequencing animated lights. Effects are modules under `src/Vixen.Modules/Effect`. A pixel effect first renders a two-dimensional field of colors, then Vixen creates lighting intents for the selected elements.
+
+`src/Vixen.Modules/Effect/Fire/Fire.cs` contains `VixenModules.Effect.Fire.Fire`, the runtime Fire effect. Its current `SetupRender()` allocates `_fireBuffer`, an integer heat field. For each string-rendered frame, `RenderEffect(int, IPixelFrameBuffer)` first fills row zero with randomized source heat, then builds every later row from the previous row. The neighbor calculation intentionally samples the center cell twice. It selects the heat field dimensions from `BufferWi`/`BufferHt`, swapping simulation width and height for `Left` and `Right`, then performs a forward projection to the output buffer. It evaluates `Height`, `HueShiftCurve`, and `LevelCurve` once per frame. `CleanUpRender()` releases the heat buffer.
+
+`src/Vixen.Modules/Effect/Fire/FireData.cs` holds Fire settings. It inherits `EffectTypeModuleData`, which already serializes and clones `TargetPositioning`. `FireData.Location` is Fire's flame-edge direction; it must not be renamed or repurposed. Its legacy hue-shift migration and all data members remain unchanged.
+
+`src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs` is the shared base class. `TargetPositioning = Strings` selects the existing dense string rendering flow. `TargetPositioning = Locations` calls `ConfigureVirtualBuffer()`, which collects leaf target locations, computes their enclosing preview rectangle, and later calls the derived `RenderEffectByLocation(int, PixelLocationFrameBuffer)` method. The base implementation throws, which is why Fire needs its override. `EnableTargetPositioning(true, true)` makes the inherited setup property visible. `UpdateStringOrientationAttributes(true)` makes `StringOrientation` visible only in string mode and refreshes type-descriptor metadata for property-grid consumers.
+
+The logical output coordinate system used by pixel-effect math has `(0, 0)` at the lower-left. Preview Y coordinates increase in the opposite direction. In a virtual rectangle, an absolute location `(absoluteX, absoluteY)` converts to logical output coordinates as `outputX = absoluteX - BufferWiOffset` and `outputY = previewYMax - absoluteY`. The equivalent base-class formula is:
+
+    outputY = Math.Abs((BufferHtOffset - absoluteY) + (BufferHt - 1 + BufferHtOffset));
+    outputY -= BufferHtOffset;
+
+The implementation must use the formula or the explicitly equivalent min/max expression, with the correct existing `PixelEffectBase` offsets. The test fixture must verify nonzero X and Y offsets so a swapped offset cannot pass unnoticed.
+
+`src/Vixen.Modules/Effect/Effect/Location/PixelLocationFrameBuffer.cs` is the location-mode output buffer. It stores only actual element preview coordinates; it is not a dense virtual image. For every actual location, Fire must write using the original absolute coordinate. Duplicate locations intentionally share one sparse cell.
+
+`src/Vixen.Tests/Effects/SpiralLocationRenderTests.cs` demonstrates the existing reflection-based test style for protected rendering methods and the location frame buffer. `src/Vixen.Tests/Vixen.Tests.csproj` already references the Location property module but does not reference Fire. Add only the Fire module project reference required for direct Fire tests, following existing project-reference style.
+
+## Plan of Work
+
+Begin with the issue-tracker record. Read `.agents/skills/jira/SKILL.md` before using Jira. If authenticated Jira access is available, update VIX-1119 before code changes using the user-facing scope in the contract: one continuous preview-location simulation, independent flame-origin direction, compatibility with existing string effects, test coverage, and the required performance evidence. If access remains unavailable, do not fabricate an update; record the failed access and keep the plan's implementation scope authoritative.
+
+Create `src/Vixen.Tests/Effects/FireLocationRenderTests.cs` and add `..\\Vixen.Modules\\Effect\\Fire\\Fire.csproj` to `src/Vixen.Tests/Vixen.Tests.csproj`. Use xUnit v3 and model protected-method invocation and virtual buffer setup on `SpiralLocationRenderTests`. Keep tests deterministic: never compare two independently random Fire runs. Prefer a private test-only reflection seam around a completed heat field, or a narrow internal seam only if it materially clarifies the production design and does not enter the hot loop. If internals are exposed, document why in this Decision Log and preserve the no-public-API constraint.
+
+First characterize representative existing string output for every `FireDirection`. The characterization must use a deterministic source/heat seam and prove the center sample is duplicated, the `Height` clamp and integer `step` behavior are retained, palette index handling is retained, hue adjustment occurs only for positive shifts, and level scaling is retained. The tests must establish parity before refactoring the string projection; a changed random sequence cannot be accepted merely because output looks like fire.
+
+In `Fire.cs`, initialize `_data`, call `EnableTargetPositioning(true, true)`, and refresh orientation attributes through a small private helper such as `InitAllAttributes()`. Use that helper in both the constructor and `ModuleData` setter after assigning new `FireData`. Verify that `TargetPositioning` becomes browsable, `StringOrientation` is visible in `Strings`, hidden in `Locations`, and remains hidden when a deserialized/replaced `FireData` already selects locations. Do not add a Fire-specific target-positioning property.
+
+Refactor only private Fire implementation details into three responsibilities: create a frame state (interval position, effective height, hue shift, and level), generate the dense integer heat field, and project a logical output coordinate to an HSV color. The dense heat generator must retain this exact semantic traversal: source-row X from zero through simulation width minus one; later rows Y from one upward and X left-to-right; every source and propagation `Rand()` call in the same conditions and order as the current code. It must retain the duplicated `GetFireBuffer(x, y - 1, ...)` sample, integer averaging, existing clamp behavior, `Height <= 0` clamped to one, and potentially zero integer `step` for large values. It must generate the complete field exactly once for each rendered frame.
+
+Use one inverse direction mapper for output sampling. Given logical lower-left output `(outputX, outputY)`, select simulation dimensions and coordinates as follows: Bottom uses width `BufferWi`, height `BufferHt`, and `(outputX, outputY)`; Top uses the same dimensions and `(outputX, BufferHt - outputY - 1)`; Left uses width `BufferHt`, height `BufferWi`, and `(outputY, outputX)`; Right uses the swapped dimensions and `(outputY, BufferWi - outputX - 1)`. This is the inverse of the current forward string projection. It prevents four separate location-render loops and places sources at the named edge. The pixel evaluator returns no output for heat index zero; otherwise it reads `FirePalette`, applies hue only when `hueShift > 0`, multiplies HSV value by `level`, and returns an HSV color.
+
+Either change string rendering to use the shared inverse mapper or retain the current forward output loop. A shared mapper is permitted only if deterministic parity tests prove unchanged output for all directions and representative values. Do not duplicate the dense heat-generation code. If parity cannot be proven, retain the current string projection and call the inverse mapper only from location rendering; record that decision and the evidence.
+
+Add `using VixenModules.Effect.Effect.Location;` and implement the inherited protected override `RenderEffectByLocation(int numFrames, PixelLocationFrameBuffer frameBuffer)` in `Fire.cs`. Return without rendering for nonpositive frame count or nonpositive virtual dimensions. For frames zero through `numFrames - 1`, set `frameBuffer.CurrentFrame`, create the frame state, generate the dense heat field once, iterate `frameBuffer.ElementLocations` once, translate its absolute preview coordinate to logical output coordinates, map those coordinates inversely for the selected direction, evaluate heat, and call `frameBuffer.SetPixel(elementLocation.X, elementLocation.Y, hsv)` only when it is lit. Do not allocate `PixelFrameBuffer`, an RGB array for the virtual rectangle, or a second dense color field. Missing output positions remain the sparse buffer's default black/transparent state.
+
+Keep `SetupRender()` ownership of a fresh zeroed dense heat array and `CleanUpRender()` ownership of releasing it. If validation requires a new multiplication or dimension calculation, check it safely before allocating, but do not introduce a preview-size cap without performance evidence and a separately accepted user behavior. Rendering remains sequential per effect instance: rows depend on preceding rows and parallel execution would change random order. Do not add locks, tasks, static mutable data, or UI-thread work.
+
+Add deterministic tests that exercise the real dense generator and both projections of the same heat field. `Fire_DefaultConstructor_EnablesTargetPositioning` verifies setup-property visibility and toggling. `Fire_RenderEffectByLocation_DoesNotThrow` invokes the protected location path with a nonempty rectangle. `Fire_LocationProjection_RectangularGridMatchesStringProjection` runs Bottom, Top, Left, and Right and compares every grid location to string output after preview-Y inversion. `Fire_LocationRender_OriginatesAtSelectedEdge` verifies each direction maps the source row to its named edge. `Fire_LocationRender_SparseCoordinatesSampleDenseHeatField` uses offset, noncontiguous locations and proves only their sparse cells are stored while an output depends on a missing intermediate virtual coordinate. `Fire_LocationRender_AppliesHeightHueAndLevel` characterizes Height propagation plus hue and value changes, including zero level producing black. `Fire_LocationRender_MultipleFramesAdvanceAndStayInBounds` covers more than one frame and 1-by-N/N-by-1 virtual rectangles in all directions. `Fire_ModuleData_PreservesLocationAttributeState` replaces `ModuleData` with location positioning and confirms the refreshed `StringOrientation` state. Add a string-regression test covering the same representative settings and all four directions.
+
+Measure performance in Release after behavior passes. Use an additive test/benchmark harness that reports elapsed wall-clock time and `GC.GetAllocatedBytesForCurrentThread()` (or the repository's established equivalent) with warm-up and repeat counts recorded. Measure: a 50 by 50 dense rectangle with 2,500 locations over 100 frames; 5,000 locations over a 1,000 by 500 rectangle for 20 frames; and 20,000 locations over a 2,000 by 1,000 rectangle for 3 frames. Report the proposed dense-heat/sparse-projection path and, if practical, a comparison prototype that additionally renders into a dense `PixelFrameBuffer` before sparse sampling. A dependency-pruned heat prototype is allowed only if the proposed path is materially too slow; it cannot be adopted unless it exactly reproduces dense results and random behavior. Remove throwaway prototype code unless it is retained as a meaningful regression benchmark. Record command, machine/runtime context, timings, allocations, and conclusion in this plan's living sections.
+
+Finish by running the focused tests and the full Vixen test flow using full MSBuild before `dotnet test --no-build`, as required for the C++/CLI transitive test dependencies. Manually exercise the effect in the application with separated preview props. Read `.agents/skills/commit-msg/SKILL.md` before every milestone-completion response that changes repository files and include its formatted proposed commit message in that response; do not create a commit unless explicitly requested. Then use the Jira skill to update VIX-1119 with final scope adjustments, validation results, and a comment when access is available.
+
+## Milestones
+
+### Milestone 1: Record the implementation contract in Jira
+
+Before changing repository code, read the project Jira skill and retrieve VIX-1119. Update its description with the user-visible purpose, independent meanings of `TargetPositioning` and Fire `Location`, dense-field/sparse-projection design, compatibility restrictions, test plan, performance scenarios, and acceptance criteria from this plan. The result is an issue that a reviewer can use without reading source. If access is unavailable, record the exact limitation in `Surprises & Discoveries`, leave this milestone pending, and proceed only because the local contract is complete.
+
+### Milestone 2: Establish deterministic characterization and test access
+
+Add the Fire project reference and focused Fire location test file. Implement the deterministic seam and initial tests that fail before production changes: hidden target positioning, missing location override, and baseline string characterization in all directions. Establish correct nonzero-offset virtual-buffer setup so tests use actual coordinate semantics. Run the focused filter and record the expected pre-change failures. The result is a reliable regression harness that does not depend on unrelated thread-local random sequences.
+
+### Milestone 3: Enable the inherited configuration without changing data contracts
+
+Change only Fire's construction and module-data replacement behavior to expose inherited target positioning and refresh orientation attributes. Test `Strings` versus `Locations`, the independent Fire direction property, and module-data replacement. No data contract, descriptor, shared infrastructure, UI, or public API may change. Run the focused tests and confirm existing default Fire data still has `Strings` positioning.
+
+### Milestone 4: Separate heat generation from output projection while preserving strings
+
+Extract private frame-state, dense-generation, coordinate-mapping, and color-evaluation helpers in `Fire.cs`. Preserve all source/propagation iteration and random semantics. Keep or carefully refactor the string output loop only after deterministic parity passes for Bottom, Top, Left, and Right. The result is one generation algorithm whose exact heat field can be projected by the existing string path and later by locations. Run string-regression and direction tests after each small refactor; record any decision to retain the original forward projection.
+
+### Milestone 5: Implement sparse preview-location projection
+
+Implement `RenderEffectByLocation` with one dense heat generation per frame and one pass over actual element locations. Translate absolute preview coordinates to lower-left logical coordinates, apply the inverse direction map, and write output only at absolute element keys. Add and run no-throw, rectangular parity, directional edge, sparse-gap, controls, multi-frame, narrow-buffer, and duplicate-location tests. The result is continuous Fire across gaps without a dense color buffer.
+
+### Milestone 6: Collect performance evidence and make only evidence-backed changes
+
+Run the three required Release scenarios with the production dense-heat/sparse-projection implementation. When practical, compare it with a dense-color-buffer projection prototype. Preserve the production design unless measurements show a material issue; if investigating dependency pruning, first prove bit-for-bit/deterministic equivalence and unchanged random order. Record measurements and conclusion in `Surprises & Discoveries` and `Decision Log`. The result is evidence that the normal location path avoids unnecessary dense color conversion while accepting Fire's unavoidable virtual-area simulation cost.
+
+### Milestone 7: Validate end to end and close the tracking loop
+
+Run the focused Fire tests and then the complete test workflow. In the UI, create or open two or more visibly separated props with preview locations, group them, add Fire, select `Locations`, verify `StringOrientation` hides, scrub with visible Height/Hue/Brightness curves, and verify one continuous simulation. Repeat Bottom, Top, Left, and Right; switch back to `Strings`; save and reopen to verify direction and positioning persist independently. Update Jira with final requirements changes if any and a validation comment. Complete Progress, Outcomes, and the revision note below.
+
+## Concrete Steps
+
+All commands below run from `C:\Dev\Vixen` in PowerShell. Use `rg` before editing to confirm method locations and use `apply_patch` for source and plan edits. Do not alter unrelated dirty files; the supplied contract is currently untracked and must be preserved.
+
+For focused development validation after the Fire module and tests build:
+
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~FireLocation
+
+Expected result after Milestone 5 is a successful xUnit run containing the Fire location tests, with no `NotImplementedException`, no out-of-range heat access, and every theory direction passing. Before implementation, record the specific expected characterization failures rather than treating a build failure as evidence.
+
+For the required full test flow, first build the C++/CLI-dependent test target with Visual Studio MSBuild, then run the already-built test assembly:
+
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="$(Get-Location)\"
+
+Expected success is MSBuild exit code zero followed by a passing Vixen test suite. Record test totals and pre-existing warnings separately; do not hide or attribute unrelated warnings to VIX-1119.
+
+For Release performance measurements, use the focused benchmark filter created in the Fire test file or a dedicated additive test helper. Run the exact command recorded by the benchmark harness, for example:
+
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~FireLocationBenchmark --logger "console;verbosity=detailed"
+
+Record a compact transcript in this plan in the form below, replacing placeholders with observed values:
+
+    Runtime: .NET <version>; configuration: Release; machine: <CPU/RAM summary>
+    Dense 50x50 / 2,500 locations / 100 frames: <ms>; <bytes> allocated
+    Sparse 1,000x500 / 5,000 locations / 20 frames: <ms>; <bytes> allocated
+    Sparse 2,000x1,000 / 20,000 locations / 3 frames: <ms>; <bytes> allocated
+    Dense-color comparison (if run): <ms>; <bytes> allocated
+    Conclusion: <whether the proposed path remains selected and why>
+
+## Validation and Acceptance
+
+VIX-1119 is accepted only when Fire exposes the inherited `TargetPositioning` property and a user can select `Locations` without an exception. A group of elements across multiple preview props must render as one fire simulation over their shared preview rectangle, not one simulation per prop. Empty areas between props must affect later heat propagation even though no output is stored there.
+
+For a full rectangular grid representing the same virtual rectangle, location output must match string output at every coordinate after the preview-Y inversion, using the same deterministic heat field, for Bottom, Top, Left, and Right. The source heat row must appear at the matching visual edge in every direction. Existing representative string-mode output must remain unchanged.
+
+Only actual location coordinates may receive sparse output. Normal location rendering may hold its one dense integer heat field but must not allocate a dense `PixelFrameBuffer` or convert the whole virtual field into a dense RGB output. The documented benchmark evidence must cover all three required layouts and state this allocation conclusion.
+
+Height, hue shift, and brightness/level curves must alter location output consistently with string output. Multiple frames and narrow rectangles must complete without out-of-range accesses. Existing effects must retain `Strings` default behavior; existing Fire `Location` direction must persist independently from target positioning. Focused tests, full-suite validation, and manual UI checks must be recorded in this plan and Jira when available.
+
+## Idempotence and Recovery
+
+The source edits are additive or private refactors and may be reapplied after checking current method bodies with `rg`. Re-run targeted tests after every refactor; if string parity changes, revert only the incomplete private refactor with a targeted patch and retain the known-good forward string projection while investigating. Do not reset the worktree or delete the untracked implementation contract.
+
+If test project build fails because C++/CLI dependencies are not built, rerun the full-MSBuild command above, then repeat `dotnet test --no-build`. If Jira authentication is unavailable, defer the remote update and record it; do not block local implementation or invent issue contents. If a benchmark prototype harms behavior or cannot retain deterministic output, remove only the prototype before final validation and leave the production dense-heat/sparse-projection path intact.
+
+## Artifacts and Notes
+
+The required inverse mapping for a lower-left logical output coordinate is:
+
+    Bottom: simulation size BufferWi by BufferHt; simulation coordinate (outputX, outputY)
+    Top:    simulation size BufferWi by BufferHt; simulation coordinate (outputX, BufferHt - outputY - 1)
+    Left:   simulation size BufferHt by BufferWi; simulation coordinate (outputY, outputX)
+    Right:  simulation size BufferHt by BufferWi; simulation coordinate (outputY, BufferWi - outputX - 1)
+
+The generator's compatibility-critical behavior is:
+
+    source-row order: x increases from 0 to maxWi - 1
+    propagation order: y increases from 1 to maxHt - 1, with x increasing left to right
+    previous-row samples: x - 1, x + 1, x, x (center deliberately duplicated)
+    Height <= 0: use 1; step remains integer 255 * 100 / maxHt / effectiveHeight
+    hue: apply only when hueShift > 0; value: multiply by level
+    heat index 0: do not write an output pixel
+
+At final completion, add the exact test transcript, benchmark results, a concise manual-validation result, and the final Jira update/comment outcome here or in the living sections. Never place credentials, machine usernames, or unrelated full logs in this plan.
+
+## Interfaces and Dependencies
+
+The only new production member expected is the existing protected extension point already declared by `PixelEffectBase`:
+
+    protected override void RenderEffectByLocation(int numFrames, PixelLocationFrameBuffer frameBuffer)
+
+It belongs in `src/Vixen.Modules/Effect/Fire/Fire.cs` and must remain protected; no new public or protected API is needed. Its contract is to set `frameBuffer.CurrentFrame` for every requested frame and call `frameBuffer.SetPixel` at original absolute preview coordinates only for lit target locations.
+
+Keep all helper types and methods used to create frame state, generate heat, transform coordinates, and evaluate palette color private to `Fire`. Reuse `VixenModules.Effect.Effect.Location.PixelLocationFrameBuffer`, `VixenModules.Effect.Effect.ElementLocation`, `FirePalette`, the existing `Curve` APIs, and the inherited buffer dimensions. Add only the Fire project reference to `Vixen.Tests.csproj`; use project references rather than DLLs and do not add projects or modify `Vixen.sln`.
+
+No `FireData` members, no new serialization, no `FireDirection` change, no descriptor change, no `PixelEffectBase` change, no UI/MVVM change, and no shared infrastructure change is authorized by this plan. If an implementation block proves one is necessary, stop, document the concrete evidence and compatibility impact in `Decision Log`, and obtain separately documented scope before making that change. If a public or protected API beyond the override becomes necessary, read and apply `.agents/skills/csharp-docs/SKILL.md` and update XML documentation in the same change.
+
+---
+
+Revision note (2026-08-24): Initial ExecPlan created from the user-supplied VIX-1119 implementation contract. It records the current Fire and shared-location code structure, required deterministic preservation rules, tests, performance evidence, Jira workflow, and explicit scope boundaries before implementation begins.
+
+Revision note (2026-08-24): Attempted Milestone 1. The Jira connection and VIX project edit permission are available, but VIX-1119 itself is not visible to the connected account, so no remote update was made and the milestone remains pending.
+
+Revision note (2026-08-24): Retried Milestone 1 after VIX-1119 became visible. Updated the Jira description with the user-facing scope and acceptance criteria, marked the milestone complete, and retained the earlier temporary-access observation for traceability.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -14,7 +14,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 
 - [x] (2026-08-24) Created this ExecPlan from the implementation contract after reading the current Fire renderer, `PixelEffectBase`, `PixelLocationFrameBuffer`, the existing Spiral location tests, and the completed VIX-3386 ExecPlan. No production code or tests have been changed.
 - [x] (2026-08-24) Updated Jira VIX-1119 with the user-facing preview-location scope, compatibility commitments, validation plan, and acceptance criteria. The issue is in progress; no implementation completion was claimed.
-- [ ] Add failing characterization tests and the Fire project reference.
+- [x] (2026-08-24) Added `FireLocationRenderTests` and the Fire module project reference. The Release-focused baseline builds successfully; four string-direction characterizations pass while the target-positioning and location-render tests fail as expected against current Fire.
 - [ ] Expose inherited target positioning and correctly refresh Fire setup-property visibility.
 - [ ] Separate Fire's dense heat generation from its string and sparse-location output projections without changing existing string output.
 - [ ] Add location projection, deterministic behavioral coverage, and boundary coverage.
@@ -33,6 +33,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: `ConfigureVirtualBuffer()` assigns raw preview Y extent to `_bufferWi` and X extent to `_bufferHt`; the public protected accessors swap them only when `StringOrientation` is horizontal. Tests must set or construct dimensions through the same orientation assumptions as production code.
 - Observation: VIX-1119 was temporarily unavailable to the connected Jira account but was retrievable and editable on retry.
   Evidence: the initial `getJiraIssue(VIX-1119)` call on 2026-08-24 returned “Issue does not exist or you do not have permission to see it.” A retry returned issue 15583 and `editJiraIssue` saved the planned description at 2026-08-24T15:08:11-05:00.
+- Observation: the Milestone 2 focused baseline has four passing string-direction characterizations and two expected failures.
+  Evidence: `dotnet test src\\Vixen.Tests\\Vixen.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~FireLocation` on 2026-08-24 reported 6 total tests: 4 passed and 2 failed. The failures are `TargetPositioning` not browsable and the base `RenderEffectByLocation` throwing `NotImplementedException`.
 
 ## Decision Log
 
@@ -47,6 +49,9 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Date/Author: 2026-08-24 / Codex
 - Decision: Make no changes to `FireData`, `FireDirection`, `FirePalette`, `FireDescriptor`, `PixelEffectBase`, UI/MVVM code, serialized data, or public APIs unless implementation evidence establishes a separate documented need.
   Rationale: inherited target-positioning storage and the required protected virtual override already exist, so expanding the scope would add compatibility risk without serving VIX-1119.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Use test-only reflection to inspect Fire's completed dense heat field for the initial string-direction characterization.
+  Rationale: Fire currently has no deterministic random-source seam. Comparing output to the exact heat field produced during the same render proves direction projection without asserting unrelated thread-local random values or modifying production APIs before the location-rendering design is implemented.
   Date/Author: 2026-08-24 / Codex
 
 ## Outcomes & Retrospective
@@ -215,3 +220,5 @@ Revision note (2026-08-24): Initial ExecPlan created from the user-supplied VIX-
 Revision note (2026-08-24): Attempted Milestone 1. The Jira connection and VIX project edit permission are available, but VIX-1119 itself is not visible to the connected account, so no remote update was made and the milestone remains pending.
 
 Revision note (2026-08-24): Retried Milestone 1 after VIX-1119 became visible. Updated the Jira description with the user-facing scope and acceptance criteria, marked the milestone complete, and retained the earlier temporary-access observation for traceability.
+
+Revision note (2026-08-24): Completed Milestone 2. Added Fire location characterization tests and the Fire project reference without modifying production code. Recorded the expected two failures and four passing string-direction characterizations from the Release-focused baseline.

--- a/docs/plans/effects/vix-1119-fire-location-support.md
+++ b/docs/plans/effects/vix-1119-fire-location-support.md
@@ -18,7 +18,7 @@ The existing setting named `Location` will continue to mean the flame-origin edg
 - [x] (2026-08-24) Enabled Fire's inherited target-positioning setup property and refreshed `StringOrientation` metadata after construction and `ModuleData` replacement. Added mode-toggle and replacement tests; all Milestone 3 tests pass.
 - [x] (2026-08-24) Extracted private simulation-dimension, frame-state, dense heat-generation, and color-evaluation helpers while retaining Fire's forward string projection. Added full-grid same-frame characterization for all four directions; string behavior remains covered before location projection is added.
 - [x] (2026-08-24) Implemented sparse preview-location projection over a single dense heat field per frame. Added offset-aware deterministic coverage for all directions, source edges, sparse gaps, controls, multi-frame narrow rectangles, and duplicate locations; the focused Release run passes 26 tests.
-- [ ] Record Release performance and allocation evidence for all required layouts.
+- [x] (2026-08-24) Added a Release benchmark harness and measured all required layouts with one warm-up and three measured runs. The dense-heat/sparse-projection implementation remains selected; no production optimization or dense-color buffer was introduced.
 - [ ] Run focused and full automated validation, complete manual UI validation, update Jira with outcomes, and complete this plan's retrospective.
 
 ## Surprises & Discoveries
@@ -41,6 +41,8 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Evidence: after the extraction, the focused Release run reported 12 total tests: 11 passed, including source-edge and full-grid same-frame projection theories for Bottom, Top, Left, and Right. The only failure remains the intentionally unimplemented location override.
 - Observation: the sparse location buffer stores output only at supplied preview coordinates, while Fire must still simulate the complete virtual rectangle.
   Evidence: `Fire.RenderEffectByLocation` generates `_fireBuffer` once per frame, then makes one pass through `PixelLocationFrameBuffer.ElementLocations`; `Fire_LocationRender_SparseCoordinatesSampleDenseHeatField` validates an offset, noncontiguous layout and confirms a missing coordinate has no sparse entry. The Release-focused run on 2026-08-24 passed all 26 Fire location tests.
+- Observation: Release performance scales with both the dense simulation rectangle and the count of actual sparse outputs, without requiring a second dense color frame.
+  Evidence: `FireLocationBenchmark_*` uses one warm-up plus three measured runs of Fire setup and location rendering, excluding sparse-buffer construction. On an AMD Ryzen 7 8845HS (8 cores/16 logical processors), 64 GB RAM, Windows 10.0.26200.0, and the .NET 10.0.8 test runtime: 50x50/2,500/100 averaged 177.2 ms and 81,555,901 bytes; 1000x500/5,000/20 averaged 99.1 ms and 30,055,035 bytes; 2000x1000/20,000/3 averaged 120.2 ms and 25,162,152 bytes.
 
 ## Decision Log
 
@@ -64,6 +66,9 @@ The existing setting named `Location` will continue to mean the flame-origin edg
   Date/Author: 2026-08-24 / Codex
 - Decision: Implement location sampling through one private inverse mapper and preserve the documented base-class absolute-coordinate conversion formula.
   Rationale: a single mapper covers all four origin directions without duplicating the generator, and the offset-aware tests detect swapped X/Y offsets or an omitted preview-Y inversion. The protected override is the existing extension point, so no new public API is required.
+  Date/Author: 2026-08-24 / Codex
+- Decision: Retain dense heat simulation with sparse output projection after measuring the required layouts.
+  Rationale: Fire's neighbor dependency makes virtual-area simulation unavoidable, while the benchmark confirms the renderer performs only actual-location color projection. A dense-color comparison prototype would add code that deliberately violates the selected allocation strategy without a demonstrated performance concern, so it was not retained.
   Date/Author: 2026-08-24 / Codex
 
 ## Outcomes & Retrospective
@@ -168,14 +173,15 @@ For Release performance measurements, use the focused benchmark filter created i
 
     dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~FireLocationBenchmark --logger "console;verbosity=detailed"
 
-Record a compact transcript in this plan in the form below, replacing placeholders with observed values:
+Recorded Release benchmark transcript (2026-08-24; one warm-up, three measured runs; measurements include Fire setup and rendering but exclude sparse-buffer construction):
 
-    Runtime: .NET <version>; configuration: Release; machine: <CPU/RAM summary>
-    Dense 50x50 / 2,500 locations / 100 frames: <ms>; <bytes> allocated
-    Sparse 1,000x500 / 5,000 locations / 20 frames: <ms>; <bytes> allocated
-    Sparse 2,000x1,000 / 20,000 locations / 3 frames: <ms>; <bytes> allocated
-    Dense-color comparison (if run): <ms>; <bytes> allocated
-    Conclusion: <whether the proposed path remains selected and why>
+    Command: dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~FireLocationBenchmark --logger "console;verbosity=detailed"
+    Runtime: .NET 10.0.8 test runtime; configuration: Release; machine: AMD Ryzen 7 8845HS (8 cores/16 logical processors), 64 GB RAM
+    Dense 50x50 / 2,500 locations / 100 frames: 177.2 ms; 81,555,901 bytes allocated
+    Sparse 1,000x500 / 5,000 locations / 20 frames: 99.1 ms; 30,055,035 bytes allocated
+    Sparse 2,000x1,000 / 20,000 locations / 3 frames: 120.2 ms; 25,162,152 bytes allocated
+    Dense-color comparison: not retained; the normal path contains no PixelFrameBuffer allocation and no measured concern justified a deliberately less-efficient prototype
+    Conclusion: retain dense heat plus sparse projection; virtual-area simulation is required for neighbor propagation, and output conversion remains limited to actual locations
 
 ## Validation and Acceptance
 
@@ -240,3 +246,5 @@ Revision note (2026-08-24): Completed Milestone 3. Enabled inherited target posi
 Revision note (2026-08-24): Completed Milestone 4. Separated private frame state, dense heat generation, and color evaluation from the retained forward string projection. Added full-grid same-frame string characterization for all four directions and preserved the existing random traversal structure.
 
 Revision note (2026-08-24): Completed Milestone 5. Added Fire's protected location-rendering override with a dense heat field generated once per frame and sparse absolute-coordinate output. Added deterministic offset, direction, source-edge, sparse-gap, control, multi-frame, narrow-buffer, and duplicate-location coverage; the focused Release run passed 26 tests.
+
+Revision note (2026-08-24): Completed Milestone 6. Added focused Release benchmark tests using one warm-up and three measured runs for all required dense and sparse layouts. Recorded machine/runtime context, timing, and setup-plus-render allocations; retained the production dense-heat/sparse-projection design without a dense-color prototype or optimization.

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -8,14 +8,22 @@ using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Fire
 {
+	/// <summary>
+	/// Renders a heat-based fire effect for string and preview-location targets.
+	/// </summary>
 	public class Fire:PixelEffectBase
 	{
 		private FireData _data;
 		private int[] _fireBuffer = new int[1];
 		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Fire"/> class.
+		/// </summary>
 		public Fire()
 		{
 			_data = new FireData();
+			EnableTargetPositioning(true, true);
+			InitAllAttributes();
 		}
 
 		#region Setup
@@ -123,12 +131,17 @@ namespace VixenModules.Effect.Fire
 
 		#endregion
 
+		/// <summary>
+		/// Gets or sets the serialized Fire settings and refreshes setup-property visibility.
+		/// </summary>
+		/// <value>The Fire module data that supplies effect settings.</value>
 		public override IModuleDataModel ModuleData
 		{
 			get { return _data; }
 			set
 			{
 				_data = value as FireData;
+				InitAllAttributes();
 				IsDirty = true;
 			}
 		}
@@ -136,6 +149,11 @@ namespace VixenModules.Effect.Fire
 		protected override EffectTypeModuleData EffectModuleData
 		{
 			get { return _data; }
+		}
+
+		private void InitAllAttributes()
+		{
+			UpdateStringOrientationAttributes(true);
 		}
 
 		// 0 <= x < BufferWi

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -4,6 +4,7 @@ using Vixen.Module;
 using Vixen.Sys.Attribute;
 using VixenModules.App.Curves;
 using VixenModules.Effect.Effect;
+using VixenModules.Effect.Effect.Location;
 using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Fire
@@ -211,6 +212,39 @@ namespace VixenModules.Effect.Fire
 			}
 		}
 
+		/// <summary>
+		/// Renders Fire frames for the configured sparse preview locations.
+		/// </summary>
+		/// <param name="numFrames">The number of frames to render.</param>
+		/// <param name="frameBuffer">The sparse preview-location frame buffer that receives rendered colors.</param>
+		protected override void RenderEffectByLocation(int numFrames, PixelLocationFrameBuffer frameBuffer)
+		{
+			if (numFrames <= 0 || BufferWi <= 0 || BufferHt <= 0)
+			{
+				return;
+			}
+
+			var (maxWi, maxHt) = GetSimulationDimensions();
+			for (var frame = 0; frame < numFrames; frame++)
+			{
+				frameBuffer.CurrentFrame = frame;
+				var frameState = CreateFrameState(frame, maxHt);
+				GenerateFireBuffer(maxWi, maxHt, frameState.Step);
+
+				foreach (var elementLocation in frameBuffer.ElementLocations)
+				{
+					var outputX = elementLocation.X - BufferWiOffset;
+					var outputY = Math.Abs((BufferHtOffset - elementLocation.Y) + (BufferHt - 1 + BufferHtOffset));
+					outputY -= BufferHtOffset;
+					var (simulationX, simulationY) = GetSimulationCoordinate(Location, outputX, outputY);
+					if (TryGetFireColor(simulationX, simulationY, maxWi, maxHt, frameState, out var hsv))
+					{
+						frameBuffer.SetPixel(elementLocation.X, elementLocation.Y, hsv);
+					}
+				}
+			}
+		}
+
 		private (int Width, int Height) GetSimulationDimensions()
 		{
 			var maxHt = BufferHt;
@@ -222,6 +256,18 @@ namespace VixenModules.Effect.Fire
 			}
 
 			return (maxWi, maxHt);
+		}
+
+		private (int X, int Y) GetSimulationCoordinate(FireDirection direction, int outputX, int outputY)
+		{
+			return direction switch
+			{
+				FireDirection.Bottom => (outputX, outputY),
+				FireDirection.Top => (outputX, BufferHt - outputY - 1),
+				FireDirection.Left => (outputY, outputX),
+				FireDirection.Right => (outputY, BufferWi - outputX - 1),
+				_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+			};
 		}
 
 		private FireFrameState CreateFrameState(int frame, int maxHt)

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -177,40 +177,79 @@ namespace VixenModules.Effect.Fire
 			_fireBuffer = null;
 		}
 
+		/// <summary>
+		/// Renders a Fire frame using the current string-target projection.
+		/// </summary>
+		/// <param name="frame">The zero-based frame index to render.</param>
+		/// <param name="frameBuffer">The string-target frame buffer that receives rendered colors.</param>
 		protected override void RenderEffect(int frame, IPixelFrameBuffer frameBuffer)
 		{
-			double intervalPosFactor = GetEffectTimeIntervalPosition(frame) * 100;
-			double level = LevelCurve.GetValue(intervalPosFactor) / 100;
-			double hueShift = CalculateHueShift(intervalPosFactor);
+			var (maxWi, maxHt) = GetSimulationDimensions();
+			var frameState = CreateFrameState(frame, maxHt);
+			GenerateFireBuffer(maxWi, maxHt, frameState.Step);
 
-			int x, y;
+			for (var y = 0; y < maxHt; y++)
+			{
+				for (var x = 0; x < maxWi; x++)
+				{
+					if (!TryGetFireColor(x, y, maxWi, maxHt, frameState, out var hsv)) continue;
 
-			int maxHt = BufferHt;
-			int maxWi = BufferWi;
+					int xp = x;
+					int yp = y;
+					if (Location == FireDirection.Top || Location == FireDirection.Right)
+					{
+						yp = maxHt - y - 1;
+					}
+					if (Location == FireDirection.Left || Location == FireDirection.Right)
+					{
+						int t = xp;
+						xp = yp;
+						yp = t;
+					}
+					frameBuffer.SetPixel(xp, yp, hsv);
+				}
+			}
+		}
+
+		private (int Width, int Height) GetSimulationDimensions()
+		{
+			var maxHt = BufferHt;
+			var maxWi = BufferWi;
 			if (Location == FireDirection.Left || Location == FireDirection.Right)
 			{
 				maxHt = BufferWi;
 				maxWi = BufferHt;
 			}
 
-			// build fire
-			for (x = 0; x < maxWi; x++)
+			return (maxWi, maxHt);
+		}
+
+		private FireFrameState CreateFrameState(int frame, int maxHt)
+		{
+			var intervalPosFactor = GetEffectTimeIntervalPosition(frame) * 100;
+			var effectiveHeight = (int)Height.GetValue(intervalPosFactor);
+			if (effectiveHeight <= 0)
+			{
+				effectiveHeight = 1;
+			}
+
+			return new FireFrameState(
+				LevelCurve.GetValue(intervalPosFactor) / 100,
+				CalculateHueShift(intervalPosFactor),
+				255 * 100 / maxHt / effectiveHeight);
+		}
+
+		private void GenerateFireBuffer(int maxWi, int maxHt, int step)
+		{
+			for (var x = 0; x < maxWi; x++)
 			{
 				var r = x % 2 == 0 ? 190 + (Rand() % 10) : 100 + (Rand() % 50);
 				_fireBuffer[x] = r;
 			}
 
-			int h = (int)Height.GetValue(intervalPosFactor);
-
-			if(h <= 0)
+			for (var y = 1; y < maxHt; y++)
 			{
-				h = 1;
-			}
-			int step = 255 * 100 / maxHt / h;
-
-			for (y = 1; y < maxHt; y++)
-			{
-				for (x = 0; x < maxWi; x++)
+				for (var x = 0; x < maxWi; x++)
 				{
 					var v1 = GetFireBuffer(x - 1, y - 1, maxWi, maxHt);
 					var v2 = GetFireBuffer(x + 1, y - 1, maxWi, maxHt);
@@ -248,40 +287,29 @@ namespace VixenModules.Effect.Fire
 					_fireBuffer[y * maxWi + x] = newIndex;
 				}
 			}
+		}
 
-			for (y = 0; y < maxHt; y++)
+		private bool TryGetFireColor(int x, int y, int maxWi, int maxHt, FireFrameState frameState, out HSV hsv)
+		{
+			var colorIndex = GetFireBuffer(x, y, maxWi, maxHt);
+			if (colorIndex == 0)
 			{
-				for (x = 0; x < maxWi; x++)
-				{
-					var colorIndex = GetFireBuffer(x, y, maxWi, maxHt);
-					if (colorIndex == 0) continue; // No point going any further if color index is 0 (Black). Significantly reduces render time.
-					
-					int xp = x;
-					int yp = y;
-					if (Location == FireDirection.Top || Location == FireDirection.Right)
-					{
-						yp = maxHt - y - 1;
-					}
-					if (Location == FireDirection.Left || Location == FireDirection.Right)
-					{
-						int t = xp;
-						xp = yp;
-						yp = t;
-					}
-					HSV hsv = FirePalette.GetColor(colorIndex);
-					if (hueShift > 0) hsv.H = hsv.H + hueShift / 100.0f;
-
-					hsv.V *= level;
-					
-					frameBuffer.SetPixel(xp, yp, hsv);
-				}
+				hsv = default;
+				return false;
 			}
+
+			hsv = FirePalette.GetColor(colorIndex);
+			if (frameState.HueShift > 0) hsv.H = hsv.H + frameState.HueShift / 100.0f;
+			hsv.V *= frameState.Level;
+			return true;
 		}
 
 		private double CalculateHueShift(double intervalPos)
 		{
 			return ScaleCurveToValue(HueShiftCurve.GetValue(intervalPos), 100, 0);
 		}
+
+		private readonly record struct FireFrameState(double Level, double HueShift, int Step);
 		
 	}
 }

--- a/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
+++ b/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
@@ -1,6 +1,9 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Reflection;
+using Moq;
+using Vixen.Sys;
+using VixenModules.App.Curves;
 using VixenModules.Effect.Effect;
 using VixenModules.Effect.Effect.Location;
 using VixenModules.Effect.Fire;
@@ -79,8 +82,9 @@ public sealed class FireLocationRenderTests
 	{
 		// Arrange
 		var effect = new Fire();
-		var frameBuffer = new PixelLocationFrameBuffer([], 1);
-		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight);
+		var locations = CreateGridLocations(DefaultWidth, DefaultHeight, 10, 20);
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 1);
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight, 10, 20);
 		InvokeSetupRender(effect);
 
 		// Act
@@ -88,6 +92,178 @@ public sealed class FireLocationRenderTests
 
 		// Assert
 		Assert.Null(exception);
+	}
+
+	/// <summary>
+	/// Verifies that location rendering samples its generated dense heat field for every direction.
+	/// </summary>
+	/// <param name="direction">The selected Fire source edge.</param>
+	[Theory]
+	[InlineData(FireDirection.Bottom)]
+	[InlineData(FireDirection.Top)]
+	[InlineData(FireDirection.Left)]
+	[InlineData(FireDirection.Right)]
+	public void Fire_LocationProjection_RectangularGridSamplesGeneratedHeatField(FireDirection direction)
+	{
+		// Arrange
+		const int xOffset = 10;
+		const int yOffset = 20;
+		var effect = new Fire
+		{
+			Location = direction,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		var locations = CreateGridLocations(DefaultWidth, DefaultHeight, xOffset, yOffset);
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 1);
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight, xOffset, yOffset);
+		InvokeSetupRender(effect);
+
+		// Act
+		InvokeRenderByLocation(effect, 1, frameBuffer);
+		var heat = GetFireBuffer(effect);
+
+		// Assert
+		foreach (var location in frameBuffer.ElementLocations)
+		{
+			var outputX = location.X - xOffset;
+			var outputY = yOffset + DefaultHeight - 1 - location.Y;
+			var (simulationX, simulationY) = GetSimulationCoordinate(direction, outputX, outputY, DefaultWidth, DefaultHeight);
+			var simulationWidth = direction is FireDirection.Left or FireDirection.Right ? DefaultHeight : DefaultWidth;
+			var colorIndex = heat[simulationY * simulationWidth + simulationX];
+			AssertSameRgb(FirePalette.GetColor(colorIndex).ToRGB(), frameBuffer.GetColorAt(location.X, location.Y));
+		}
+	}
+
+	/// <summary>
+	/// Verifies that location rendering projects the generated source row to each selected origin edge.
+	/// </summary>
+	/// <param name="direction">The selected Fire source edge.</param>
+	[Theory]
+	[InlineData(FireDirection.Bottom)]
+	[InlineData(FireDirection.Top)]
+	[InlineData(FireDirection.Left)]
+	[InlineData(FireDirection.Right)]
+	public void Fire_LocationRender_OriginatesAtSelectedEdge(FireDirection direction)
+	{
+		// Arrange
+		const int xOffset = 10;
+		const int yOffset = 20;
+		var effect = new Fire { Location = direction, TimeSpan = TimeSpan.FromMilliseconds(1000) };
+		var locations = CreateGridLocations(DefaultWidth, DefaultHeight, xOffset, yOffset);
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 1);
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight, xOffset, yOffset);
+		InvokeSetupRender(effect);
+
+		// Act
+		InvokeRenderByLocation(effect, 1, frameBuffer);
+		var heat = GetFireBuffer(effect);
+
+		// Assert
+		var simulationWidth = direction is FireDirection.Left or FireDirection.Right ? DefaultHeight : DefaultWidth;
+		var simulationHeight = direction is FireDirection.Left or FireDirection.Right ? DefaultWidth : DefaultHeight;
+		for (var x = 0; x < simulationWidth; x++)
+		{
+			var (outputX, outputY) = GetSourceOutputCoordinate(direction, x, simulationHeight);
+			var absoluteX = xOffset + outputX;
+			var absoluteY = yOffset + DefaultHeight - outputY - 1;
+			AssertSameRgb(FirePalette.GetColor(heat[x]).ToRGB(), frameBuffer.GetColorAt(absoluteX, absoluteY));
+		}
+	}
+
+	/// <summary>
+	/// Verifies that sparse preview locations retain their absolute keys while sampling the complete virtual heat field.
+	/// </summary>
+	[Fact]
+	public void Fire_LocationRender_SparseCoordinatesSampleDenseHeatField()
+	{
+		// Arrange
+		const int width = 8;
+		const int height = 5;
+		const int xOffset = 10;
+		const int yOffset = 20;
+		var locations = new List<ElementLocation>
+		{
+			CreateElementLocation(xOffset, yOffset),
+			CreateElementLocation(xOffset + 3, yOffset + 2),
+			CreateElementLocation(xOffset + width - 1, yOffset + height - 1)
+		};
+		var effect = new Fire { TimeSpan = TimeSpan.FromMilliseconds(1000) };
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 1);
+		SetVirtualBuffer(effect, width, height, xOffset, yOffset);
+		InvokeSetupRender(effect);
+
+		// Act
+		InvokeRenderByLocation(effect, 1, frameBuffer);
+		var heat = GetFireBuffer(effect);
+
+		// Assert
+		Assert.Equal(locations.Count, frameBuffer.ElementLocations.Count());
+		var target = locations[1];
+		var outputX = target.X - xOffset;
+		var outputY = yOffset + height - 1 - target.Y;
+		AssertSameRgb(FirePalette.GetColor(heat[outputY * width + outputX]).ToRGB(), frameBuffer.GetColorAt(target.X, target.Y));
+		Assert.ThrowsAny<Exception>(() => frameBuffer.GetColorAt(xOffset + 1, yOffset + 1));
+	}
+
+	/// <summary>
+	/// Verifies that location rendering applies level controls and retains generated heat for height-controlled frames.
+	/// </summary>
+	[Fact]
+	public void Fire_LocationRender_AppliesHeightHueAndLevel()
+	{
+		// Arrange
+		var locations = CreateGridLocations(DefaultWidth, DefaultHeight);
+		var effect = new Fire
+		{
+			Height = new Curve(0d),
+			HueShiftCurve = new Curve(50),
+			LevelCurve = new Curve(50),
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 1);
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight);
+		InvokeSetupRender(effect);
+
+		// Act
+		InvokeRenderByLocation(effect, 1, frameBuffer);
+		var heat = GetFireBuffer(effect);
+		var expected = FirePalette.GetColor(heat[0]);
+		expected.H += 0.5f;
+		expected.V *= 0.5;
+
+		// Assert
+		Assert.Equal(255 * 100 / DefaultHeight, GetFrameStep(effect, 0, DefaultHeight));
+		AssertSameRgb(expected.ToRGB(), frameBuffer.GetColorAt(0, DefaultHeight - 1));
+	}
+
+	/// <summary>
+	/// Verifies that location rendering supports multiple frames, narrow virtual rectangles, and duplicate locations.
+	/// </summary>
+	/// <param name="direction">The selected Fire source edge.</param>
+	/// <param name="width">The virtual rectangle width.</param>
+	/// <param name="height">The virtual rectangle height.</param>
+	[Theory]
+	[InlineData(FireDirection.Bottom, 1, 4)]
+	[InlineData(FireDirection.Top, 1, 4)]
+	[InlineData(FireDirection.Left, 4, 1)]
+	[InlineData(FireDirection.Right, 4, 1)]
+	public void Fire_LocationRender_MultipleFramesSupportNarrowBuffersAndDuplicateLocations(FireDirection direction, int width, int height)
+	{
+		// Arrange
+		var location = CreateElementLocation(10, 20);
+		var locations = new List<ElementLocation> { location, location };
+		var effect = new Fire { Location = direction, TimeSpan = TimeSpan.FromMilliseconds(1000) };
+		var frameBuffer = new PixelLocationFrameBuffer(locations, 2);
+		SetVirtualBuffer(effect, width, height, 10, 20);
+		InvokeSetupRender(effect);
+
+		// Act
+		var exception = Record.Exception(() => InvokeRenderByLocation(effect, 2, frameBuffer));
+
+		// Assert
+		Assert.Null(exception);
+		Assert.Single(frameBuffer.ElementLocations);
+		Assert.Equal(2, frameBuffer.GetFrameDataAt(location.X, location.Y).Length);
 	}
 
 	/// <summary>
@@ -197,6 +373,43 @@ public sealed class FireLocationRenderTests
 			: (simulationX, outputY);
 	}
 
+	private static (int X, int Y) GetSimulationCoordinate(FireDirection direction, int outputX, int outputY, int width, int height)
+	{
+		return direction switch
+		{
+			FireDirection.Bottom => (outputX, outputY),
+			FireDirection.Top => (outputX, height - outputY - 1),
+			FireDirection.Left => (outputY, outputX),
+			FireDirection.Right => (outputY, width - outputX - 1),
+			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+		};
+	}
+
+	private static List<ElementLocation> CreateGridLocations(int width, int height, int xOffset = 0, int yOffset = 0)
+	{
+		var locations = new List<ElementLocation>();
+		for (var y = 0; y < height; y++)
+		{
+			for (var x = 0; x < width; x++)
+			{
+				locations.Add(CreateElementLocation(x + xOffset, y + yOffset));
+			}
+		}
+
+		return locations;
+	}
+
+	private static ElementLocation CreateElementLocation(int x, int y)
+	{
+		var node = new Mock<IElementNode>();
+		node.SetupGet(elementNode => elementNode.Properties).Returns(new PropertyManager(node.Object));
+		return new ElementLocation(node.Object)
+		{
+			X = x,
+			Y = y
+		};
+	}
+
 	private static PropertyDescriptor GetProperty(Fire effect, string propertyName)
 	{
 		var property = TypeDescriptor.GetProperties(effect)[propertyName];
@@ -211,10 +424,23 @@ public sealed class FireLocationRenderTests
 		return Assert.IsType<int[]>(field.GetValue(effect));
 	}
 
-	private static void SetVirtualBuffer(Fire effect, int width, int height)
+	private static int GetFrameStep(Fire effect, int frame, int simulationHeight)
+	{
+		var createFrameState = typeof(Fire).GetMethod("CreateFrameState", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(createFrameState);
+		var frameState = createFrameState.Invoke(effect, [frame, simulationHeight]);
+		Assert.NotNull(frameState);
+		var step = frameState.GetType().GetProperty("Step", BindingFlags.Instance | BindingFlags.Public);
+		Assert.NotNull(step);
+		return Assert.IsType<int>(step.GetValue(frameState));
+	}
+
+	private static void SetVirtualBuffer(Fire effect, int width, int height, int xOffset = 0, int yOffset = 0)
 	{
 		SetPixelEffectBaseField(effect, "_bufferHt", width);
 		SetPixelEffectBaseField(effect, "_bufferWi", height);
+		SetPixelEffectBaseField(effect, "_bufferHtOffset", xOffset);
+		SetPixelEffectBaseField(effect, "_bufferWiOffset", yOffset);
 	}
 
 	private static void SetPixelEffectBaseField(Fire effect, string fieldName, int value)

--- a/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
+++ b/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
@@ -1,0 +1,163 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Reflection;
+using VixenModules.Effect.Effect;
+using VixenModules.Effect.Effect.Location;
+using VixenModules.Effect.Fire;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+/// <summary>
+/// Characterizes Fire's current target-positioning and dense string-rendering behavior.
+/// </summary>
+public sealed class FireLocationRenderTests
+{
+	private const int DefaultWidth = 4;
+	private const int DefaultHeight = 3;
+
+	/// <summary>
+	/// Verifies that Fire exposes the inherited target-positioning setup property.
+	/// </summary>
+	[Fact]
+	public void Fire_DefaultConstructor_EnablesTargetPositioning()
+	{
+		// Arrange
+		var effect = new Fire();
+
+		// Act
+		var property = TypeDescriptor.GetProperties(effect)[nameof(PixelEffectBase.TargetPositioning)];
+
+		// Assert
+		Assert.True(property?.IsBrowsable);
+	}
+
+	/// <summary>
+	/// Verifies that Fire implements location rendering without throwing.
+	/// </summary>
+	[Fact]
+	public void Fire_RenderEffectByLocation_DoesNotThrow()
+	{
+		// Arrange
+		var effect = new Fire();
+		var frameBuffer = new PixelLocationFrameBuffer([], 1);
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight);
+		InvokeSetupRender(effect);
+
+		// Act
+		var exception = Record.Exception(() => InvokeRenderByLocation(effect, 1, frameBuffer));
+
+		// Assert
+		Assert.Null(exception);
+	}
+
+	/// <summary>
+	/// Verifies that each direction projects the generated source row to its selected edge.
+	/// </summary>
+	/// <param name="direction">The selected Fire source edge.</param>
+	[Theory]
+	[InlineData(FireDirection.Bottom)]
+	[InlineData(FireDirection.Top)]
+	[InlineData(FireDirection.Left)]
+	[InlineData(FireDirection.Right)]
+	public void Fire_StringRender_ProjectsGeneratedSourceRowAtSelectedEdge(FireDirection direction)
+	{
+		// Arrange
+		var effect = new Fire
+		{
+			Location = direction,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight);
+		InvokeSetupRender(effect);
+		var frameBuffer = new PixelFrameBuffer(DefaultWidth, DefaultHeight);
+
+		// Act
+		InvokeRenderEffect(effect, 0, frameBuffer);
+		var heat = GetFireBuffer(effect);
+
+		// Assert
+		var simulationWidth = direction is FireDirection.Left or FireDirection.Right
+			? DefaultHeight
+			: DefaultWidth;
+		var simulationHeight = direction is FireDirection.Left or FireDirection.Right
+			? DefaultWidth
+			: DefaultHeight;
+		for (var x = 0; x < simulationWidth; x++)
+		{
+			var expected = FirePalette.GetColor(heat[x]).ToRGB();
+			var (outputX, outputY) = GetSourceOutputCoordinate(direction, x, simulationHeight);
+			AssertSameRgb(expected, frameBuffer.GetColorAt(outputX, outputY));
+		}
+	}
+
+	private static (int X, int Y) GetSourceOutputCoordinate(FireDirection direction, int simulationX, int simulationHeight)
+	{
+		return direction switch
+		{
+			FireDirection.Bottom => (simulationX, 0),
+			FireDirection.Top => (simulationX, simulationHeight - 1),
+			FireDirection.Left => (0, simulationX),
+			FireDirection.Right => (simulationHeight - 1, simulationX),
+			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+		};
+	}
+
+	private static int[] GetFireBuffer(Fire effect)
+	{
+		var field = typeof(Fire).GetField("_fireBuffer", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(field);
+		return Assert.IsType<int[]>(field.GetValue(effect));
+	}
+
+	private static void SetVirtualBuffer(Fire effect, int width, int height)
+	{
+		SetPixelEffectBaseField(effect, "_bufferHt", width);
+		SetPixelEffectBaseField(effect, "_bufferWi", height);
+	}
+
+	private static void SetPixelEffectBaseField(Fire effect, string fieldName, int value)
+	{
+		var field = typeof(PixelEffectBase).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(field);
+		field.SetValue(effect, value);
+	}
+
+	private static void InvokeSetupRender(Fire effect)
+	{
+		var setupRender = typeof(Fire).GetMethod("SetupRender", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(setupRender);
+		setupRender.Invoke(effect, []);
+	}
+
+	private static void InvokeRenderEffect(Fire effect, int frame, IPixelFrameBuffer frameBuffer)
+	{
+		var renderEffect = typeof(Fire).GetMethod(
+			"RenderEffect",
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[typeof(int), typeof(IPixelFrameBuffer)],
+			null);
+		Assert.NotNull(renderEffect);
+		renderEffect.Invoke(effect, [frame, frameBuffer]);
+	}
+
+	private static void InvokeRenderByLocation(Fire effect, int numFrames, PixelLocationFrameBuffer frameBuffer)
+	{
+		var renderByLocation = typeof(Fire).GetMethod(
+			"RenderEffectByLocation",
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[typeof(int), typeof(PixelLocationFrameBuffer)],
+			null);
+		Assert.NotNull(renderByLocation);
+		renderByLocation.Invoke(effect, [numFrames, frameBuffer]);
+	}
+
+	private static void AssertSameRgb(Color expected, Color actual)
+	{
+		Assert.Equal(expected.R, actual.R);
+		Assert.Equal(expected.G, actual.G);
+		Assert.Equal(expected.B, actual.B);
+	}
+}

--- a/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
+++ b/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
@@ -30,6 +30,45 @@ public sealed class FireLocationRenderTests
 
 		// Assert
 		Assert.True(property?.IsBrowsable);
+		Assert.Equal(TargetPositioningType.Strings, effect.TargetPositioning);
+	}
+
+	/// <summary>
+	/// Verifies that switching target positioning updates the StringOrientation property visibility.
+	/// </summary>
+	[Fact]
+	public void Fire_TargetPositioning_TogglesStringOrientationVisibility()
+	{
+		// Arrange
+		var effect = new Fire();
+
+		// Act and Assert
+		Assert.True(GetProperty(effect, nameof(PixelEffectBase.StringOrientation)).IsBrowsable);
+		effect.TargetPositioning = TargetPositioningType.Locations;
+		Assert.False(GetProperty(effect, nameof(PixelEffectBase.StringOrientation)).IsBrowsable);
+		effect.TargetPositioning = TargetPositioningType.Strings;
+		Assert.True(GetProperty(effect, nameof(PixelEffectBase.StringOrientation)).IsBrowsable);
+	}
+
+	/// <summary>
+	/// Verifies that replacing Fire data configured for locations refreshes StringOrientation visibility.
+	/// </summary>
+	[Fact]
+	public void Fire_ModuleData_PreservesLocationAttributeState()
+	{
+		// Arrange
+		var effect = new Fire();
+		var data = new FireData
+		{
+			TargetPositioning = TargetPositioningType.Locations
+		};
+
+		// Act
+		effect.ModuleData = data;
+
+		// Assert
+		Assert.True(GetProperty(effect, nameof(PixelEffectBase.TargetPositioning)).IsBrowsable);
+		Assert.False(GetProperty(effect, nameof(PixelEffectBase.StringOrientation)).IsBrowsable);
 	}
 
 	/// <summary>
@@ -101,6 +140,13 @@ public sealed class FireLocationRenderTests
 			FireDirection.Right => (simulationHeight - 1, simulationX),
 			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
 		};
+	}
+
+	private static PropertyDescriptor GetProperty(Fire effect, string propertyName)
+	{
+		var property = TypeDescriptor.GetProperties(effect)[propertyName];
+		Assert.NotNull(property);
+		return property;
 	}
 
 	private static int[] GetFireBuffer(Fire effect)

--- a/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
+++ b/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Reflection;
 using Moq;
@@ -267,6 +268,63 @@ public sealed class FireLocationRenderTests
 	}
 
 	/// <summary>
+	/// Measures location rendering for a dense 50 by 50 preview rectangle.
+	/// </summary>
+	[Fact]
+	public void FireLocationBenchmark_Dense50By50()
+	{
+		// Arrange
+		const int width = 50;
+		const int height = 50;
+		const int locationCount = 2500;
+		const int frameCount = 100;
+
+		// Act
+		var measurements = MeasureLocationRendering(width, height, locationCount, frameCount);
+
+		// Assert
+		AssertMeasurements("Dense 50x50 / 2,500 locations / 100 frames", measurements);
+	}
+
+	/// <summary>
+	/// Measures location rendering for a medium sparse preview rectangle.
+	/// </summary>
+	[Fact]
+	public void FireLocationBenchmark_Sparse1000By500()
+	{
+		// Arrange
+		const int width = 1000;
+		const int height = 500;
+		const int locationCount = 5000;
+		const int frameCount = 20;
+
+		// Act
+		var measurements = MeasureLocationRendering(width, height, locationCount, frameCount);
+
+		// Assert
+		AssertMeasurements("Sparse 1000x500 / 5,000 locations / 20 frames", measurements);
+	}
+
+	/// <summary>
+	/// Measures location rendering for a large sparse preview rectangle.
+	/// </summary>
+	[Fact]
+	public void FireLocationBenchmark_Sparse2000By1000()
+	{
+		// Arrange
+		const int width = 2000;
+		const int height = 1000;
+		const int locationCount = 20000;
+		const int frameCount = 3;
+
+		// Act
+		var measurements = MeasureLocationRendering(width, height, locationCount, frameCount);
+
+		// Assert
+		AssertMeasurements("Sparse 2000x1000 / 20,000 locations / 3 frames", measurements);
+	}
+
+	/// <summary>
 	/// Verifies that each direction projects the generated source row to its selected edge.
 	/// </summary>
 	/// <param name="direction">The selected Fire source edge.</param>
@@ -408,6 +466,64 @@ public sealed class FireLocationRenderTests
 			X = x,
 			Y = y
 		};
+	}
+
+	private static (TimeSpan Elapsed, long AllocatedBytes)[] MeasureLocationRendering(int width, int height, int locationCount, int frameCount)
+	{
+		var locations = CreateBenchmarkLocations(width, height, locationCount);
+		RenderLocationFrames(CreateBenchmarkEffect(width, height, frameCount), new PixelLocationFrameBuffer(locations, frameCount), frameCount);
+		var measurements = new (TimeSpan Elapsed, long AllocatedBytes)[3];
+		for (var repeat = 0; repeat < measurements.Length; repeat++)
+		{
+			var effect = CreateBenchmarkEffect(width, height, frameCount);
+			var frameBuffer = new PixelLocationFrameBuffer(locations, frameCount);
+			var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+			var stopwatch = Stopwatch.StartNew();
+			RenderLocationFrames(effect, frameBuffer, frameCount);
+			stopwatch.Stop();
+			measurements[repeat] = (stopwatch.Elapsed, GC.GetAllocatedBytesForCurrentThread() - allocatedBefore);
+		}
+
+		return measurements;
+	}
+
+	private static Fire CreateBenchmarkEffect(int width, int height, int frameCount)
+	{
+		var effect = new Fire { TimeSpan = TimeSpan.FromMilliseconds(frameCount * 50) };
+		SetVirtualBuffer(effect, width, height);
+		return effect;
+	}
+
+	private static void RenderLocationFrames(Fire effect, PixelLocationFrameBuffer frameBuffer, int frameCount)
+	{
+		InvokeSetupRender(effect);
+		InvokeRenderByLocation(effect, frameCount, frameBuffer);
+	}
+
+	private static List<ElementLocation> CreateBenchmarkLocations(int width, int height, int locationCount)
+	{
+		var locations = new List<ElementLocation>(locationCount);
+		var virtualArea = width * height;
+		for (var locationIndex = 0; locationIndex < locationCount; locationIndex++)
+		{
+			var virtualIndex = (int)((long)locationIndex * virtualArea / locationCount);
+			locations.Add(CreateElementLocation(virtualIndex % width, virtualIndex / width));
+		}
+
+		return locations;
+	}
+
+	private static void AssertMeasurements(string scenario, (TimeSpan Elapsed, long AllocatedBytes)[] measurements)
+	{
+		Assert.All(measurements, measurement =>
+		{
+			Assert.True(measurement.Elapsed > TimeSpan.Zero);
+			Assert.True(measurement.AllocatedBytes > 0);
+		});
+
+		var averageMilliseconds = measurements.Average(measurement => measurement.Elapsed.TotalMilliseconds);
+		var averageAllocatedBytes = measurements.Average(measurement => measurement.AllocatedBytes);
+		TestContext.Current.TestOutputHelper?.WriteLine($"{scenario}: {averageMilliseconds:F1} ms; {averageAllocatedBytes:F0} bytes allocated for Fire setup and rendering (one warm-up, three measured runs; sparse-buffer construction excluded).");
 	}
 
 	private static PropertyDescriptor GetProperty(Fire effect, string propertyName)

--- a/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
+++ b/src/Vixen.Tests/Effects/FireLocationRenderTests.cs
@@ -130,6 +130,51 @@ public sealed class FireLocationRenderTests
 		}
 	}
 
+	/// <summary>
+	/// Verifies that every lit heat cell is projected to its existing string-render position.
+	/// </summary>
+	/// <param name="direction">The selected Fire source edge.</param>
+	[Theory]
+	[InlineData(FireDirection.Bottom)]
+	[InlineData(FireDirection.Top)]
+	[InlineData(FireDirection.Left)]
+	[InlineData(FireDirection.Right)]
+	public void Fire_StringRender_ProjectsEveryLitGeneratedHeatCell(FireDirection direction)
+	{
+		// Arrange
+		var effect = new Fire
+		{
+			Location = direction,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		SetVirtualBuffer(effect, DefaultWidth, DefaultHeight);
+		InvokeSetupRender(effect);
+		var frameBuffer = new PixelFrameBuffer(DefaultWidth, DefaultHeight);
+
+		// Act
+		InvokeRenderEffect(effect, 0, frameBuffer);
+		var heat = GetFireBuffer(effect);
+
+		// Assert
+		var simulationWidth = direction is FireDirection.Left or FireDirection.Right
+			? DefaultHeight
+			: DefaultWidth;
+		var simulationHeight = direction is FireDirection.Left or FireDirection.Right
+			? DefaultWidth
+			: DefaultHeight;
+		for (var y = 0; y < simulationHeight; y++)
+		{
+			for (var x = 0; x < simulationWidth; x++)
+			{
+				var colorIndex = heat[y * simulationWidth + x];
+				if (colorIndex == 0) continue;
+
+				var (outputX, outputY) = GetOutputCoordinate(direction, x, y, simulationHeight);
+				AssertSameRgb(FirePalette.GetColor(colorIndex).ToRGB(), frameBuffer.GetColorAt(outputX, outputY));
+			}
+		}
+	}
+
 	private static (int X, int Y) GetSourceOutputCoordinate(FireDirection direction, int simulationX, int simulationHeight)
 	{
 		return direction switch
@@ -140,6 +185,16 @@ public sealed class FireLocationRenderTests
 			FireDirection.Right => (simulationHeight - 1, simulationX),
 			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
 		};
+	}
+
+	private static (int X, int Y) GetOutputCoordinate(FireDirection direction, int simulationX, int simulationY, int simulationHeight)
+	{
+		var outputY = direction is FireDirection.Top or FireDirection.Right
+			? simulationHeight - simulationY - 1
+			: simulationY;
+		return direction is FireDirection.Left or FireDirection.Right
+			? (outputY, simulationX)
+			: (simulationX, outputY);
 	}
 
 	private static PropertyDescriptor GetProperty(Fire effect, string propertyName)

--- a/src/Vixen.Tests/Vixen.Tests.csproj
+++ b/src/Vixen.Tests/Vixen.Tests.csproj
@@ -32,6 +32,7 @@
 		<ProjectReference Include="..\Vixen.Modules\App\LivePreview\LivePreview.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\App\Marks\Marks.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Chase\Chase.csproj" />
+		<ProjectReference Include="..\Vixen.Modules\Effect\Fire\Fire.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\LipSync\LipSync.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\PinWheel\PinWheel.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Video\Video.csproj" />


### PR DESCRIPTION
## Summary

Adds preview-location rendering to the Fire effect so one continuous fire simulation can span grouped, separated props.

## Changes

- Enables Fire’s inherited `TargetPositioning` option while keeping its existing `Location` direction independent.
- Simulates the complete virtual heat field, including gaps, then writes output only to actual preview locations.
- Preserves existing Fire formulas, random-call order, controls, and string-mode behavior.
- Adds deterministic location, direction, sparse-layout, control, boundary, and performance coverage.

## Validation

- Full Release build passed.
- All 836 unit tests passed.
- Manual testing confirmed location mode and tested controls behave as expected.
- Release performance evidence recorded for dense and sparse layouts.

## Notes

No shared infrastructure, serialized data, UI/MVVM code, or public APIs were changed.