### PR TITLE
VIX-3994 Add Fire target grouping and stabilize selectors

### DIFF
--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -17,6 +17,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 22:01Z) Added `FireTargetNodeSelectionTests` for default data/effect settings, serialized fields, legacy-data compatibility, editor visibility, and default group-mode location rendering. Full `Vixen_Tests` build passed; the focused filter passed 1 group-render test and failed 6 tests only for the deliberately absent Fire target-selection contract.
 - [x] (2026-08-31 22:10Z) Added persisted Fire target settings, property-grid visibility/normalization, `FireTargetElementDepthConverter`, and Fire localization resources. The focused suite now passes all 10 tests.
 - [x] (2026-08-31 22:35Z) Added the documented `PixelEffectBase` render-group seam and Fire's group resolver. Each group now receives its own target-scoped buffer configuration, setup/render/cleanup lifecycle, and merged intents. Focused location lifecycle tests verify two intermediate-depth groups and two separately selected targets each use independent local `3 x 1` buffers. The full `Vixen_Tests` build and focused Fire filter passed (41 tests).
+- [x] (2026-08-31 22:50Z) Removed the re-entrant descriptor refresh from Fire's `DepthOfEffect` setter after manual target-drag testing exposed a property-grid refresh loop. The setter now normalizes before raising its change notification. A focused regression test confirms depth changes do not issue a `TypeDescriptor` refresh; the full build and focused Fire filter passed (42 tests).
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -35,6 +36,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: `ProviderDisplayNameAttribute` and `ProviderDescriptionAttribute` call `EffectResourceManager`, while the existing generated designer files do not contain Wipe's already-shipped `WipeTargetNodeSelection` key. Adding the Fire keys to the `.resx` files is therefore the complete runtime localization change.
 - Observation: the previous pixel lifecycle configured one shared location buffer, then invoked the location renderer for every selected root; explicit render groups need one renderer invocation for the complete group instead.
   Evidence: `PixelEffectBase.RenderNodeByLocation()` renders every entry in `ElementLocations`, which already contains all leaves of the configured group. The scoped renderer now calls `RenderNodes()` once per group and merges the resulting intents.
+- Observation: refreshing an effect's `TypeDescriptor` from the depth setter can re-enter the property-grid selector while a target change is already rebuilding it.
+  Evidence: the target-drag stack trace repeatedly alternates `Fire.set_DepthOfEffect`, `TypeDescriptor.Refresh`, and WPF `ItemCollection.SetCollectionView`. `DepthOfEffect` visibility does not depend on the chosen value, so it can normalize and notify without refreshing the descriptor.
 
 ## Decision Log
 
@@ -68,6 +71,8 @@ Milestone 2 is complete. `src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.c
 Milestone 3 is complete. Fire now serializes `TargetNodeSelection` and `DepthOfEffect`, defaults new and legacy data to group handling and depth zero, normalizes invalid persisted values, and preserves these values when cloned. `Fire.TargetNodeHandling` and `Fire.DepthOfEffect` expose the Wipe-compatible editor behavior; depth is visible only for a single deep individual target, and its local converter offers intermediate values only. Fire rendering itself remains unchanged for Milestone 4. The full `Vixen_Tests` build and focused filter passed with 10 tests.
 
 Milestone 4 is complete. `PixelEffectBase` now exposes a documented protected render-group selector whose default is one group containing all selected targets. It configures, sets up, renders, cleans up, and clears location state independently for each supplied group, while merging every group's intents. Fire overrides that selector to preserve group mode, split multiple selected targets, or resolve one deep target at its selected depth. The shared string path builds a single scoped frame buffer and maps the scoped roots' elements once; the location path renders the scoped location buffer once. `FireTargetNodeSelectionTests` now verifies depth and multiple-target location groups use local buffers. The full `Vixen_Tests` build passed, and the focused Fire filter passed 41 tests.
+
+Manual drag testing found a Fire property-grid refresh loop after a target change. The depth setter now applies targeting normalization before its one property-change notification and deliberately does not refresh `TypeDescriptor`; a depth value does not affect which controls are visible. The regression test verifies no descriptor refresh occurs when selecting depth. The full build passed and the focused Fire filter passed 42 tests.
 
 At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
 
@@ -226,3 +231,5 @@ Plan revised 2026-08-31 / Codex. Reason: Milestone 2 added focused Fire target-s
 Plan revised 2026-08-31 / Codex. Reason: Milestone 3 implemented Fire data compatibility, property-grid target handling, filtered depth selection, and runtime localization resources.
 
 Plan revised 2026-08-31 / Codex. Reason: Milestone 4 added target-scoped pixel rendering and Fire's independent group selection with focused lifecycle coverage.
+
+Plan revised 2026-08-31 / Codex. Reason: Manual target-drag testing exposed a re-entrant Fire depth-selector refresh, which is now covered and avoided.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -22,6 +22,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 23:30Z) A subsequent Wipe target-drag trace showed the descriptor refresh itself reapplying unchanged target-handling selection values. Fire and Wipe now suppress descriptor refreshes for no-op `TargetNodeHandling` writes. Focused Fire/Wipe tests passed 28/28; the full `Vixen_Tests` build passed.
 - [x] (2026-08-31 23:45Z) The next trace isolated the remaining recursion to the shared effect property grid: its `TypeDescriptor` handler invalidated every selector's `StandardValues` while a selector was writing. The grid now recalculates browsability without resetting all selector item sources. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
 - [x] (2026-09-01 00:00Z) The final trace identified the original global selector broadcast: `PropertyItem.ComponentValueChanged` fanned a `TargetNodes` notification out to every property's `StandardValues`. Removed that fan-out; metadata visibility remains handled by the descriptor refresh. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
+- [x] (2026-09-01 15:20Z) Manual Dissolve drag testing found the same stale-depth reapplication risk: unlike the other target-depth effects, Dissolve did not normalize depth after its targets changed. It now resets an invalid depth to zero and suppresses a no-op stale binding notification. The focused State/Fire/Wipe/Dissolve filter passed 87/87.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -261,3 +262,5 @@ Plan revised 2026-09-01 / Codex. Reason: Restored target-context standard-value 
 Plan revised 2026-09-01 / Codex. Reason: Target reassignment now raises `DepthOfEffect` (and target-handling, when applicable) notifications when target validation normalizes persisted values. This keeps the selector's selected value synchronized with its refreshed valid values; focused Fire/Wipe coverage asserts a depth of `2` becomes `1` after moving to a shallower target.
 
 Plan revised 2026-09-01 / Codex. Reason: State selectors also depended on the removed per-property standard-value signal. The property grid now coalesces that signal at idle for the affected property (or all properties after target changes), while State refreshes existing custom State item rows after target reassignment.
+
+Plan revised 2026-09-01 / Codex. Reason: Dissolve was the remaining depth-selector effect that retained an invalid depth after a target reassignment. It now normalizes stale values before notifying the property grid, preventing repeated rendering updates.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -23,7 +23,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 23:45Z) The next trace isolated the remaining recursion to the shared effect property grid: its `TypeDescriptor` handler invalidated every selector's `StandardValues` while a selector was writing. The grid now recalculates browsability without resetting all selector item sources. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
 - [x] (2026-09-01 00:00Z) The final trace identified the original global selector broadcast: `PropertyItem.ComponentValueChanged` fanned a `TargetNodes` notification out to every property's `StandardValues`. Removed that fan-out; metadata visibility remains handled by the descriptor refresh. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
 - [x] (2026-09-01 15:20Z) Manual Dissolve drag testing found the same stale-depth reapplication risk: unlike the other target-depth effects, Dissolve did not normalize depth after its targets changed. It now resets an invalid depth to zero and suppresses a no-op stale binding notification. The focused State/Fire/Wipe/Dissolve filter passed 87/87.
-- [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
+- [x] (2026-09-01) Completed final validation. The full solution build and all unit tests passed. Manual regression testing passed for Fire, Wipe, Dissolve, State, fixture property selectors, Mark Collection selectors, Waveform, and Vertical Meter, including moving effects from deeper to shallower targets. Added the VIX-3994 completion comment (40422) with the validation results and property-grid refresh cleanup record.
 
 ## Surprises & Discoveries
 
@@ -72,6 +72,9 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - Decision: Do not manually edit the generated resource designer files.
   Rationale: Runtime provider attributes use the embedded `.resx` resources via `EffectResourceManager`, and the designer files are already stale for Wipe's identical feature key. Editing generated code would not affect runtime behavior and would create avoidable generated-file drift.
   Date/Author: 2026-08-31 / Codex
+- Decision: Refresh dynamic selector values at idle and only within the affected property scope, except when a target change can affect all target-dependent values.
+  Rationale: Rebuilding every selector during a selector commit caused re-entrant WPF binding updates. Coalescing the necessary refresh retains dynamic depth, state, and mark-collection values while avoiding needless item-source rebuilds for unrelated edits.
+  Date/Author: 2026-09-01 / Codex
 
 ## Outcomes & Retrospective
 
@@ -87,7 +90,15 @@ Milestone 4 is complete. `PixelEffectBase` now exposes a documented protected re
 
 Manual drag testing found a Fire property-grid refresh loop after a target change. The depth setter applies targeting normalization without refreshing `TypeDescriptor`, because a depth value does not affect which controls are visible. A follow-up trace showed that an unchanged final depth could still be broadcast to the selector, which then reapplied its stale value. Fire and Wipe now raise `PropertyChanged` and set dirty state only when normalization leaves a depth that differs from the prior stored value. Regression tests cover both the absence of descriptor refresh and the absence of a notification for a normalized stale value. The full build passed and the focused Fire/Wipe filter passed 26 tests.
 
-At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
+VIX-3994 is complete. Fire now supports `Across Elements/Groups` and `Each Element/Group` rendering for string and preview-location targets while retaining group mode as the compatible default for existing effects. The renderer scopes Fire state and buffers independently for each selected group in individual mode.
+
+The target-drag follow-up fixed a property-grid re-entrancy regression without returning to the previous blanket refresh behavior. Dynamic selector values are refreshed once at idle, scoped to the changed property where possible and expanded to all properties only after a target change. Effect-level normalization keeps selected values valid when a target becomes shallower. State also explicitly refreshes its dependent State Item choices after either its targets or State Definition change.
+
+Final validation is clean: the full solution build and all unit tests passed. Manual regression testing passed for Fire, Wipe, Dissolve, State, fixture property selectors, Mark Collection selectors, Waveform, and Vertical Meter. In particular, moving effects from depth `0–2` targets to `0–1` targets now recalculates choices, selects a valid value, and does not crash or enter a render-update loop.
+
+The key lesson is that `StandardValues` is an item-source invalidation, not merely a value notification: rebuilding it from a synchronous property change can re-enter the selector that is currently committing. Deferring and coalescing the refresh preserves dynamic property behavior while improving editor responsiveness by avoiding unrelated selector rebuilds.
+
+The VIX-3994 completion comment records the final user-visible result, full build and unit-test success, the manual regression coverage, and the blanket-refresh cleanup for future issue review.
 
 ## Context and Orientation
 

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -1,0 +1,207 @@
+# Add each element/group behavior to the Fire effect
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository contains `.agents/PLANS.md`; maintain this document according to that file. VIX-3994 is the tracker issue for this work. The completed Wipe precedent is `docs/plans/effects/vix-3938-wipe-target-node-selection.md`; this plan incorporates the relevant behavior rather than requiring the implementer to read that plan.
+
+## Purpose / Big Picture
+
+After this change, a user can choose whether Fire runs as one continuous fire field across all selected elements/groups or starts an independent fire field for each selected element/group. This is useful for strings and preview-location targets: a user can make one flame pattern span an entire display group, or make each prop/subgroup have its own locally sized fire pattern.
+
+Existing Fire effects must remain visually and serially compatible. They will load with `Across Elements/Groups` selected and use the current combined rendering behavior. The new controls are visible only when a target hierarchy or multiple selected targets makes the choice meaningful. In individual mode, a single deep target may select an intermediate child depth, matching Wipe's useful-depth rules.
+
+## Progress
+
+- [x] (2026-08-31 16:00Z) Read VIX-3994, its clarification comment, `.agents/PLANS.md`, the Wipe ExecPlan/implementation, Spin and Chase precedents, Fire, `PixelEffectBase`, and Fire's existing test coverage.
+- [x] (2026-08-31 21:42Z) Updated VIX-3994 with the final user-facing summary, scope, acceptance criteria, and validation plan. No repository code or tests changed.
+- [ ] Add focused characterization tests for Fire target handling and preserve the current group-render result.
+- [ ] Add persisted Fire target settings, editor attributes, localized labels, and depth selection validation.
+- [ ] Add the narrow scoped-rendering seam and implement independent Fire rendering for strings and locations.
+- [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
+
+## Surprises & Discoveries
+
+- Observation: Fire already supports both string and preview-location positioning, but `PixelEffectBase._PreRender()` configures one buffer from all `TargetNodes` and has no per-target-group rendering seam.
+  Evidence: `src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs` calls `ConfigureDisplayElementSize()`, `SetupRender()`, and `RenderNode()` directly from its `_PreRender()` implementation; Fire enables both positioning modes in its constructor.
+- Observation: Wipe provides the exact requested user-facing terminology and persistence defaults, including `TargetNodeSelection.Group`, but it is not a pixel effect and cannot be reused directly by Fire.
+  Evidence: `src/Vixen.Modules/Effect/Wipe/WipeModule.cs` and `WipeData.cs` implement `TargetNodeHandling`, `DepthOfEffect`, and group-local rendering; Fire inherits `PixelEffectBase` instead of `BaseEffect` directly.
+- Observation: Fire's dense heat field is mutable instance state and must be initialized and cleaned up separately for every independent group.
+  Evidence: `src/Vixen.Modules/Effect/Fire/Fire.cs` allocates `_fireBuffer` in `SetupRender()`, mutates it once per frame in `GenerateFireBuffer()`, and clears it in `CleanUpRender()`.
+- Observation: the VIX-3994 comment explicitly removes the initial location-only limitation.
+  Evidence: Jira comment dated 2026-08-31: “This could be useful on strings or locations, so removing the original restriction that it should target only locations.”
+
+## Decision Log
+
+- Decision: Model VIX-3994 on Wipe's `Across Elements/Groups` and `Each Element/Group` behavior, including intermediate depth selection, rather than Spin/Chase's broader depth picker.
+  Rationale: The issue explicitly names Wipe. Wipe hides depth unless individual mode has one sufficiently deep target and excludes leaf-equivalent depth values, avoiding controls that cannot alter Fire's observable grouping.
+  Date/Author: 2026-08-31 / Codex
+- Decision: Preserve group mode as Fire's legacy and default behavior.
+  Rationale: Existing saved sequences must render unchanged. `TargetNodeSelection.Group` is enum value zero and `DepthOfEffect` is zero, but explicit constructor defaults and deserialization tests will prove compatibility rather than depend on implicit defaults.
+  Date/Author: 2026-08-31 / Codex
+- Decision: Render each individual group with its own buffer dimensions, locations/string layout, Fire setup, frame sequence, and cleanup.
+  Rationale: Reusing the parent buffer would restart random heat but would still make flame scale and source edges depend on sibling groups. Independent local buffers are the user-visible meaning of “Each Element/Group.”
+  Date/Author: 2026-08-31 / Codex
+- Decision: Add a narrow protected scoped-rendering seam to `PixelEffectBase`; do not duplicate its buffer projection implementation inside Fire or mutate `TargetNodes` while rendering.
+  Rationale: Fire needs both string and location rendering to honor the same groups. Temporarily replacing target state is unsafe during rendering, while copying the renderer would drift from existing pixel effects. The default seam must retain the current one-group behavior for every other pixel effect.
+  Date/Author: 2026-08-31 / Codex
+- Decision: Keep the useful-depth converter local to Fire, following Wipe's current isolation, unless implementation proves an existing shared converter can express the same filtered values without changing other effects.
+  Rationale: `TargetElementDepthConverter` exposes depth zero and the terminal leaf-equivalent depth; changing it would alter Chase and Spin. A Fire-local converter avoids a cross-module dependency on Wipe and limits behavioral scope.
+  Date/Author: 2026-08-31 / Codex
+
+## Outcomes & Retrospective
+
+Planning is complete. No production code, tests, JIRA fields, or issue comments were changed while creating this ExecPlan.
+
+Milestone 1 is complete. VIX-3994 now describes the Fire target-handling choice for both strings and preview locations, compatibility expectations for existing effects, user-facing acceptance criteria, and automated/manual validation outcomes. The issue remains in its existing Accepted status.
+
+At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
+
+## Context and Orientation
+
+Vixen effects are modules. A target node is an element or a group selected in the sequence editor. A leaf is an element node that has no children. A target depth is a number of child levels below a selected target at which rendering should split into independent groups. A virtual buffer is the rectangular grid used for a location-positioned pixel effect; it includes blank coordinates between actual preview elements so the Fire heat simulation can spread across gaps.
+
+`src/Vixen.Modules/Effect/Fire/Fire.cs` is the runtime Fire effect. It inherits `PixelEffectBase`, exposes Fire direction, height, hue shift, and brightness settings, and keeps the mutable `int[] _fireBuffer` heat field. `FireData.cs` is its serialized settings model. `FireDescriptor.cs` declares no parameter signature and requires no signature change for these effect-editor settings.
+
+`src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs` is the shared base for grid-style effects. Today it renders all `TargetNodes` through one setup/render/cleanup sequence. Its string path builds a dense `PixelFrameBuffer`; its location path builds a `PixelLocationFrameBuffer` only for actual preview locations while Fire still maintains its dense heat field. The change must preserve that lifecycle and call ordering within each group.
+
+`src/Vixen.Modules/Effect/Effect/BaseEffect.cs` supplies `DetermineDepth()` and protected `GetNodesAtEffectDepth(IElementNode node, int depthOfEffect)`. Depth zero means the leaf elements. A nonzero depth walks child nodes and falls back to leaves if it finds no nodes. Wipe, Chase, and Spin use `TargetNodeSelection` from `src/Vixen.Modules/Effect/Effect/TargetNodeSelection.cs`: `Group` displays as `Across Elements/Groups`, and `Individual` displays as `Each Element/Group`.
+
+The required Fire behavior is:
+
+- In group mode, all selected targets are one render group. This is the current Fire behavior and ignores `DepthOfEffect`.
+- In individual mode with several selected targets, each selected target is one render group and depth is reset to zero/hidden.
+- In individual mode with exactly one target, resolve the selected intermediate depth under that target. Each resolved node is a render group.
+- For every render group, configure dimensions from only that group's leaves, allocate/seed/render/clean up one Fire heat field, and write intents only for that group's elements. This applies equally to `Strings` and `Locations`.
+- Fire must not render empty groups, must respect the existing cancellation behavior exposed by the lifecycle, and must leave the base renderer's one-group behavior unchanged for all effects that do not opt in.
+
+Use Wipe's useful depth rules. Show target handling only when there are multiple selected targets or one target has child depth greater than two. Show depth only in individual mode with exactly one target and at least one useful intermediate depth. Permit values `1` through `availableDepth - 2`; do not offer `0` or `availableDepth - 1`, since each resolves to leaf-level behavior after the group is rendered. If the target changes so the selected value is invalid, reset it to `1` when useful values exist, otherwise reset to `0` and force group mode where individual mode is no longer meaningful.
+
+## Plan of Work
+
+### Milestone 1: align Jira with the implementation contract
+
+Before repository code changes, update VIX-3994 using `.agents/skills/jira/SKILL.md`. Keep the issue user-facing. State that Fire will offer `Across Elements/Groups` and `Each Element/Group` for both strings and preview locations, retain the first as the compatibility default, and independently restart/scale the fire for each individual group. Include the acceptance criteria from this plan and the focused/broader test commands below. Do not include internal class names in the Jira description.
+
+At the end of this milestone, the tracker is sufficient for a reviewer to understand the outcome and test approach without this document.
+
+### Milestone 2: characterize compatibility and the new grouping contract
+
+Add `src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs`. Keep the existing `FireLocationRenderTests.cs` focused on heat/projection math; add only narrowly related assertions there if a shared helper must be inspected. The test project already references the Fire module and Location property module, so do not add duplicate project references.
+
+Test a new `Fire` and a new `FireData` for `TargetNodeSelection.Group` and depth zero. Test a payload or data instance that omits the new data members to prove legacy defaults. Test clone preservation once the data fields exist. Use `TypeDescriptor.GetProperties` to test target-handling and depth visibility for a shallow target, a single deep target in both modes, and multiple targets. Test the Fire-specific depth converter returns only `1..depth-2` and returns no choices for depth two or less.
+
+Add end-to-end lifecycle tests using real or mock element hierarchies consistent with `WipeTargetNodeSelectionTests.cs` and `FireLocationRenderTests.cs`. Establish a deterministic Fire seam for tests without changing production random behavior: either provide a protected/internal testable random source only if existing patterns permit it, or assert group-local dimensions, output element membership, and independent buffer setup rather than exact random colors. Cover both target-positioning modes:
+
+- Group mode uses one scoped render and produces output for the union of two separated child groups.
+- Individual mode at an intermediate depth creates one scoped render per child group; both groups begin at their own source edge and neither group's buffer dimensions include its sibling.
+- Multi-target individual mode creates one local render per selected target, hides/resets depth, and does not combine the two target geometries.
+- Existing one-target string and location rendering tests still pass unchanged, including all four Fire directions and sparse location behavior.
+
+Run the focused test filter before implementing the production behavior. It may initially fail only for the missing public property/data contract; record the exact result in `Progress` and `Surprises & Discoveries`.
+
+### Milestone 3: add Fire persistence and property-grid behavior
+
+Modify `src/Vixen.Modules/Effect/Fire/FireData.cs`. Add `[DataMember]` properties `int DepthOfEffect` and `TargetNodeSelection TargetNodeSelection`; initialize them to zero and `Group` in the constructor, copy both in `CreateInstanceForClone()`, and extend `OnDeserialized` to normalize an invalid enum and negative depth. Retain the existing hue-shift migration logic. These are public serialized APIs, so update XML documentation for the changed public members according to `.agents/skills/csharp-docs/SKILL.md`.
+
+Add `src/Vixen.Modules/Effect/Fire/FireTargetElementDepthConverter.cs`, modeled on Wipe's converter but in the Fire namespace. It must derive from `TypeConverter`, resolve the minimum usable selected-target depth from the property-grid context, and return string choices from `1` inclusive to `depth - 1` exclusive. Document its public type and overridden behavior with XML comments. Do not reference the Wipe assembly.
+
+Modify `Fire.cs` to add `TargetNodeHandling` under the `Behavior` category and `DepthOfEffect` under the `Depth` category. Use `[Value]`, the standard provider display/description attributes, a `SelectionEditor` for depth, and the Fire-specific converter. Both setters must update the data model, mark the effect dirty, notify the property grid, recalculate targeting visibility/normalization, and refresh `TypeDescriptor` exactly as Wipe does. Override `TargetNodesChanged()` to call `base.TargetNodesChanged()` first so existing string counts/orientation behavior remains intact, then update Fire targeting attributes and refresh the descriptor. Call the same attribute initialization from the constructor and `ModuleData` setter.
+
+Add `FireTargetNodeSelection` entries to `src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx` with value `Fire` and to `EffectDescriptionDescriptors.resx` with value `Determines how the Fire effect is applied across the target elements that are presented to the effect.` Regenerate or update the corresponding `.Designer.cs` files by the repository's established resource-generation process; do not hand-edit generated code if that process is available.
+
+### Milestone 4: scope the pixel renderer and render Fire independently
+
+Refactor `PixelEffectBase` only enough to render an explicit list of target roots as one scoped render. Preserve the current public behavior and default one-group path. The resulting protected seam must let a derived effect provide a sequence of render groups without assigning to `TargetNodes`, and it must perform, for each group, the following in order: calculate string counts or location bounds from that group's leaves; set up renderer state; render the group's string/location output once; merge its intents; clean up renderer state; clear per-group location state. Add XML documentation for every new or changed protected API.
+
+Keep the existing default implementation equivalent to one group containing all `TargetNodes`. Do not make unrelated pixel effects opt in and do not change their serialized models. Extract parameterized private helpers only as necessary so group-scoped configuration cannot accidentally retain locations, string pixel counts, buffer offsets, or cached elements from the previous group. In location mode, render a group once against its own `PixelLocationFrameBuffer` and emit intents for that group's leaf elements once. In string mode, create/map the frame buffer once for the scoped set and preserve the existing orientation and element ordering semantics. Add a focused base-level regression test only if the new protected seam needs one; otherwise Fire's group-mode characterization test is the compatibility guard.
+
+Override the new group-selection seam in `Fire.cs`. Return `[TargetNodes]` for group mode, each selected root for multiple-target individual mode, and one root per `GetNodesAtEffectDepth(TargetNodes.Single(), DepthOfEffect)` result for one-target individual mode. Ensure a target node is not duplicated within a group and skip empty results. Do not alter Fire's `GenerateFireBuffer`, palette clamping, direction coordinate mapping, random call order inside a single group, height/hue/level calculations, or sparse-location projection algorithm.
+
+Run the focused tests after each refactoring step. If legacy group mode differs from the characterization, stop, restore the default path to a single scoped group containing all targets, and add evidence before continuing. If an existing pixel-effect test reveals that the shared default path changed, revert that broader behavior and narrow the seam further before proceeding.
+
+### Milestone 5: validate, document results, and close the tracker loop
+
+Run the focused Fire target-selection tests, the existing Fire location tests, and the repository test workflow specified below. Manually verify the effect editor and sequencer with a parent group containing two separated subgroups in both `Strings` and `Locations`: verify a single large fire in Across mode, then verify two locally scaled fires in Each mode. Save and reopen a sequence containing both settings and verify the choice persists. Also open an older Fire effect and verify it remains in Across mode with its prior output.
+
+Update VIX-3994 if implementation evidence changes requirements or tests, then add a concise user-facing Jira comment with validation results. Update every living section of this plan with commands, pass/fail evidence, decisions, and final outcomes. When this milestone changes repository files, generate the required formatted commit message with `.agents/skills/commit-msg/SKILL.md`; do not create a commit unless explicitly asked.
+
+## Concrete Steps
+
+Run all commands from `C:\Dev\Vixen` in PowerShell.
+
+First build the test target with full MSBuild because Vixen's test graph includes C++/CLI dependencies:
+
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+
+Then run the focused tests without rebuilding:
+
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="$(pwd)\" --filter "FullyQualifiedName~FireTargetNodeSelection|FullyQualifiedName~FireLocationRender"
+
+Expect all selected Fire tests to pass. The output should end with a successful test summary, for example:
+
+    Passed!  - Failed:     0, Passed:    <count>, Skipped:     0, Total:    <count>
+
+Run the broader already-built suite before finalizing:
+
+    dotnet test src\Vixen.Tests\Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="$(pwd)\"
+
+If the build or broad test command fails for an unrelated pre-existing reason, preserve the output in `Artifacts and Notes`, run the narrow Fire filter to isolate this change, and report the unrelated blocker in Jira rather than weakening the new assertions.
+
+## Validation and Acceptance
+
+VIX-3994 is accepted when all of the following are demonstrably true:
+
+- A newly created Fire effect and a legacy Fire data payload use `Across Elements/Groups` and depth zero by default; an existing Fire sequence looks the same after loading.
+- The editor shows the Fire behavior choice only for multiple targets or a sufficiently deep single target. In individual mode, it shows a depth picker only for one deep target and offers intermediate values only.
+- With a deep parent that contains two child groups, Across mode creates one Fire simulation across their combined string layout or preview rectangle. Each mode creates two independent simulations whose dimensions and source edges are local to their respective groups.
+- With two separately selected targets, Each mode runs independently for each target in both string and location positioning and does not expose a stale depth selection.
+- Fire's Bottom, Top, Left, and Right origins, sparse preview-location behavior, Height, Hue Shift, Brightness, and string-orientation behavior continue to pass the existing tests.
+- The focused and broad test commands complete successfully, and the manual save/reopen test proves persisted settings.
+
+## Idempotence and Recovery
+
+The code and test steps are additive and safe to rerun. Do not delete or rewrite existing sequences. If a scoped-rendering refactor causes a regression, first restore `PixelEffectBase` so its default group is all `TargetNodes`, then retain the focused failing test and reintroduce only the protected Fire opt-in seam. If migration tests reveal a malformed saved value, normalize only invalid enum values and negative depths; do not overwrite valid individual-mode settings. If resource generation is unavailable, identify the established generation command before modifying designer output.
+
+## Artifacts and Notes
+
+The Jira description to apply in Milestone 1 is:
+
+    ## Summary
+
+    Add a choice to the Fire effect that controls whether one fire pattern spans all selected elements and groups or each selected element/group receives its own fire pattern.
+
+    ## Scope
+
+    - Support the choice for both string-based and preview-location Fire effects.
+    - Keep the current across-target behavior as the default for existing sequences.
+    - Allow a deeply nested target to split Fire at a useful child-group depth.
+    - Preserve Fire direction, brightness, height, hue shift, and existing string/location behavior.
+
+    ## Acceptance Criteria
+
+    - Given an existing Fire effect, when it is opened after the change, then it remains an across-target Fire effect and retains its appearance.
+    - Given a group containing multiple child props, when Each Element/Group is selected, then each prop has an independent locally scaled Fire effect.
+    - Given two separately selected targets, when Each Element/Group is selected, then Fire renders independently for both string and preview-location targets.
+    - Given a target without useful child depth, when Fire is edited, then unavailable target-depth controls are not shown.
+
+No `FireDescriptor.Parameters` change is planned: it is currently empty, and these are persisted effect settings rather than descriptor parameters used by an existing signature. Revisit only if implementation discovers a caller that requires these fields in a parameter signature; record the evidence and compatibility decision here before changing it.
+
+## Interfaces and Dependencies
+
+The implementation must end with these persisted Fire data members in `VixenModules.Effect.Fire.FireData`:
+
+    [DataMember]
+    public int DepthOfEffect { get; set; }
+
+    [DataMember]
+    public TargetNodeSelection TargetNodeSelection { get; set; }
+
+`VixenModules.Effect.Fire.Fire` must expose a `[Value]` `TargetNodeHandling` property backed by `FireData.TargetNodeSelection` and a `[Value]` `DepthOfEffect` property backed by `FireData.DepthOfEffect`. Use the existing `TargetNodeSelection` enum; do not create a Fire-specific enum.
+
+`PixelEffectBase` must expose a protected, documented mechanism for a derived pixel effect to supply render groups. Its default must represent exactly one group containing all current `TargetNodes`; Fire is the only effect that opts in for this ticket. A render group is a non-empty collection of `IElementNode` roots that shares one complete pixel buffer and Fire heat-field lifecycle. This mechanism must not change `TargetNodes`, module data, or UI state while rendering.
+
+---
+
+Plan created 2026-08-31 / Codex. Reason: VIX-3994 requires a self-contained implementation plan following the established Wipe, Chase, and Spin target-node pattern while extending it safely to Fire's shared pixel rendering pipeline.
+
+Plan revised 2026-08-31 / Codex. Reason: Milestone 1 updated VIX-3994 with the final user-facing requirements, acceptance criteria, and validation plan before repository implementation begins.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -19,6 +19,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 22:35Z) Added the documented `PixelEffectBase` render-group seam and Fire's group resolver. Each group now receives its own target-scoped buffer configuration, setup/render/cleanup lifecycle, and merged intents. Focused location lifecycle tests verify two intermediate-depth groups and two separately selected targets each use independent local `3 x 1` buffers. The full `Vixen_Tests` build and focused Fire filter passed (41 tests).
 - [x] (2026-08-31 22:50Z) Removed the re-entrant descriptor refresh from Fire's `DepthOfEffect` setter after manual target-drag testing exposed a property-grid refresh loop. The setter now normalizes before raising its change notification. A focused regression test confirms depth changes do not issue a `TypeDescriptor` refresh; the full build and focused Fire filter passed (42 tests).
 - [x] (2026-08-31 23:15Z) The target-drag loop persisted because the property grid reapplied a stale depth after targeting normalized it back to its already-stored value. Fire and Wipe now notify bindings only if the final normalized depth changed. Focused Fire/Wipe tests passed 26/26, including new stale-selection notification regressions; the full `Vixen_Tests` build passed.
+- [x] (2026-08-31 23:30Z) A subsequent Wipe target-drag trace showed the descriptor refresh itself reapplying unchanged target-handling selection values. Fire and Wipe now suppress descriptor refreshes for no-op `TargetNodeHandling` writes. Focused Fire/Wipe tests passed 28/28; the full `Vixen_Tests` build passed.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -41,6 +42,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: the target-drag stack trace repeatedly alternates `Fire.set_DepthOfEffect`, `TypeDescriptor.Refresh`, and WPF `ItemCollection.SetCollectionView`. `DepthOfEffect` visibility does not depend on the chosen value, so it can normalize and notify without refreshing the descriptor.
 - Observation: removing the descriptor refresh alone is insufficient when a selector's stale value is normalized back to the value that was stored before its setter ran.
   Evidence: the second target-drag stack trace repeats `Fire.set_DepthOfEffect` through `PropertyItem.ComponentValueChanged` without `TypeDescriptor.Refresh` in the repeated cycle. Raising `PropertyChanged` for an unchanged final value causes the selector to reapply its stale value indefinitely.
+- Observation: `TypeDescriptor.Refresh` updates every selection editor's standard values; this can reassign the existing target-handling enum even when depth is already stable.
+  Evidence: the Wipe trace reaches `WipeModule.TargetNodesChanged` and `TypeDescriptor.Refresh` at the start of every cycle, while the repeated frames contain `PropertyItem.SetValueCore` but no depth setter. Making the target-handling setter a no-op when normalization leaves its prior value breaks that refresh cycle.
 
 ## Decision Log
 
@@ -238,3 +241,5 @@ Plan revised 2026-08-31 / Codex. Reason: Milestone 4 added target-scoped pixel r
 Plan revised 2026-08-31 / Codex. Reason: Manual target-drag testing exposed a re-entrant Fire depth-selector refresh, which is now covered and avoided.
 
 Plan revised 2026-08-31 / Codex. Reason: The follow-up target-drag trace exposed a stale selector value being re-notified after depth normalization; Fire and Wipe now suppress no-op depth notifications.
+
+Plan revised 2026-08-31 / Codex. Reason: The Wipe target-drag trace exposed no-op target-handling selector writes triggering recursive descriptor refreshes; Fire and Wipe now suppress those refreshes.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -14,7 +14,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 
 - [x] (2026-08-31 16:00Z) Read VIX-3994, its clarification comment, `.agents/PLANS.md`, the Wipe ExecPlan/implementation, Spin and Chase precedents, Fire, `PixelEffectBase`, and Fire's existing test coverage.
 - [x] (2026-08-31 21:42Z) Updated VIX-3994 with the final user-facing summary, scope, acceptance criteria, and validation plan. No repository code or tests changed.
-- [ ] Add focused characterization tests for Fire target handling and preserve the current group-render result.
+- [x] (2026-08-31 22:01Z) Added `FireTargetNodeSelectionTests` for default data/effect settings, serialized fields, legacy-data compatibility, editor visibility, and default group-mode location rendering. Full `Vixen_Tests` build passed; the focused filter passed 1 group-render test and failed 6 tests only for the deliberately absent Fire target-selection contract.
 - [ ] Add persisted Fire target settings, editor attributes, localized labels, and depth selection validation.
 - [ ] Add the narrow scoped-rendering seam and implement independent Fire rendering for strings and locations.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
@@ -29,6 +29,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: `src/Vixen.Modules/Effect/Fire/Fire.cs` allocates `_fireBuffer` in `SetupRender()`, mutates it once per frame in `GenerateFireBuffer()`, and clears it in `CleanUpRender()`.
 - Observation: the VIX-3994 comment explicitly removes the initial location-only limitation.
   Evidence: Jira comment dated 2026-08-31: “This could be useful on strings or locations, so removing the original restriction that it should target only locations.”
+- Observation: The characterization tests can protect legacy group-mode output without adding a deterministic random source to Fire.
+  Evidence: `FireRender_DefaultGroupModeRendersLocatedLeavesTogether` passes through the existing Fire lifecycle and verifies both located leaves receive intents. The remaining focused failures all stop at missing `TargetNodeHandling`, `DepthOfEffect`, `TargetNodeSelection`, or their data members.
 
 ## Decision Log
 
@@ -53,6 +55,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 Planning is complete. No production code, tests, JIRA fields, or issue comments were changed while creating this ExecPlan.
 
 Milestone 1 is complete. VIX-3994 now describes the Fire target-handling choice for both strings and preview locations, compatibility expectations for existing effects, user-facing acceptance criteria, and automated/manual validation outcomes. The issue remains in its existing Accepted status.
+
+Milestone 2 is complete. `src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs` adds seven focused tests. `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` completed successfully. The focused `FireTargetNodeSelection` test run passed the existing group-mode location rendering characterization and failed the other six tests only because the Milestone 3 data and property APIs are intentionally not implemented yet.
 
 At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
 
@@ -205,3 +209,5 @@ The implementation must end with these persisted Fire data members in `VixenModu
 Plan created 2026-08-31 / Codex. Reason: VIX-3994 requires a self-contained implementation plan following the established Wipe, Chase, and Spin target-node pattern while extending it safely to Fire's shared pixel rendering pipeline.
 
 Plan revised 2026-08-31 / Codex. Reason: Milestone 1 updated VIX-3994 with the final user-facing requirements, acceptance criteria, and validation plan before repository implementation begins.
+
+Plan revised 2026-08-31 / Codex. Reason: Milestone 2 added focused Fire target-selection characterization tests and recorded their expected pre-implementation results.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -18,6 +18,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 22:10Z) Added persisted Fire target settings, property-grid visibility/normalization, `FireTargetElementDepthConverter`, and Fire localization resources. The focused suite now passes all 10 tests.
 - [x] (2026-08-31 22:35Z) Added the documented `PixelEffectBase` render-group seam and Fire's group resolver. Each group now receives its own target-scoped buffer configuration, setup/render/cleanup lifecycle, and merged intents. Focused location lifecycle tests verify two intermediate-depth groups and two separately selected targets each use independent local `3 x 1` buffers. The full `Vixen_Tests` build and focused Fire filter passed (41 tests).
 - [x] (2026-08-31 22:50Z) Removed the re-entrant descriptor refresh from Fire's `DepthOfEffect` setter after manual target-drag testing exposed a property-grid refresh loop. The setter now normalizes before raising its change notification. A focused regression test confirms depth changes do not issue a `TypeDescriptor` refresh; the full build and focused Fire filter passed (42 tests).
+- [x] (2026-08-31 23:15Z) The target-drag loop persisted because the property grid reapplied a stale depth after targeting normalized it back to its already-stored value. Fire and Wipe now notify bindings only if the final normalized depth changed. Focused Fire/Wipe tests passed 26/26, including new stale-selection notification regressions; the full `Vixen_Tests` build passed.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -38,6 +39,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: `PixelEffectBase.RenderNodeByLocation()` renders every entry in `ElementLocations`, which already contains all leaves of the configured group. The scoped renderer now calls `RenderNodes()` once per group and merges the resulting intents.
 - Observation: refreshing an effect's `TypeDescriptor` from the depth setter can re-enter the property-grid selector while a target change is already rebuilding it.
   Evidence: the target-drag stack trace repeatedly alternates `Fire.set_DepthOfEffect`, `TypeDescriptor.Refresh`, and WPF `ItemCollection.SetCollectionView`. `DepthOfEffect` visibility does not depend on the chosen value, so it can normalize and notify without refreshing the descriptor.
+- Observation: removing the descriptor refresh alone is insufficient when a selector's stale value is normalized back to the value that was stored before its setter ran.
+  Evidence: the second target-drag stack trace repeats `Fire.set_DepthOfEffect` through `PropertyItem.ComponentValueChanged` without `TypeDescriptor.Refresh` in the repeated cycle. Raising `PropertyChanged` for an unchanged final value causes the selector to reapply its stale value indefinitely.
 
 ## Decision Log
 
@@ -72,7 +75,7 @@ Milestone 3 is complete. Fire now serializes `TargetNodeSelection` and `DepthOfE
 
 Milestone 4 is complete. `PixelEffectBase` now exposes a documented protected render-group selector whose default is one group containing all selected targets. It configures, sets up, renders, cleans up, and clears location state independently for each supplied group, while merging every group's intents. Fire overrides that selector to preserve group mode, split multiple selected targets, or resolve one deep target at its selected depth. The shared string path builds a single scoped frame buffer and maps the scoped roots' elements once; the location path renders the scoped location buffer once. `FireTargetNodeSelectionTests` now verifies depth and multiple-target location groups use local buffers. The full `Vixen_Tests` build passed, and the focused Fire filter passed 41 tests.
 
-Manual drag testing found a Fire property-grid refresh loop after a target change. The depth setter now applies targeting normalization before its one property-change notification and deliberately does not refresh `TypeDescriptor`; a depth value does not affect which controls are visible. The regression test verifies no descriptor refresh occurs when selecting depth. The full build passed and the focused Fire filter passed 42 tests.
+Manual drag testing found a Fire property-grid refresh loop after a target change. The depth setter applies targeting normalization without refreshing `TypeDescriptor`, because a depth value does not affect which controls are visible. A follow-up trace showed that an unchanged final depth could still be broadcast to the selector, which then reapplied its stale value. Fire and Wipe now raise `PropertyChanged` and set dirty state only when normalization leaves a depth that differs from the prior stored value. Regression tests cover both the absence of descriptor refresh and the absence of a notification for a normalized stale value. The full build passed and the focused Fire/Wipe filter passed 26 tests.
 
 At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
 
@@ -233,3 +236,5 @@ Plan revised 2026-08-31 / Codex. Reason: Milestone 3 implemented Fire data compa
 Plan revised 2026-08-31 / Codex. Reason: Milestone 4 added target-scoped pixel rendering and Fire's independent group selection with focused lifecycle coverage.
 
 Plan revised 2026-08-31 / Codex. Reason: Manual target-drag testing exposed a re-entrant Fire depth-selector refresh, which is now covered and avoided.
+
+Plan revised 2026-08-31 / Codex. Reason: The follow-up target-drag trace exposed a stale selector value being re-notified after depth normalization; Fire and Wipe now suppress no-op depth notifications.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -259,3 +259,5 @@ Plan revised 2026-09-01 / Codex. Reason: A depth-selection trace then isolated t
 Plan revised 2026-09-01 / Codex. Reason: Restored target-context standard-value recalculation through one coalesced idle-dispatch refresh after `TargetNodes` changes. This updates dynamic depth choices after a drag without rebinding selector sources while a property value is being committed.
 
 Plan revised 2026-09-01 / Codex. Reason: Target reassignment now raises `DepthOfEffect` (and target-handling, when applicable) notifications when target validation normalizes persisted values. This keeps the selector's selected value synchronized with its refreshed valid values; focused Fire/Wipe coverage asserts a depth of `2` becomes `1` after moving to a shallower target.
+
+Plan revised 2026-09-01 / Codex. Reason: State selectors also depended on the removed per-property standard-value signal. The property grid now coalesces that signal at idle for the affected property (or all properties after target changes), while State refreshes existing custom State item rows after target reassignment.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -15,7 +15,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 16:00Z) Read VIX-3994, its clarification comment, `.agents/PLANS.md`, the Wipe ExecPlan/implementation, Spin and Chase precedents, Fire, `PixelEffectBase`, and Fire's existing test coverage.
 - [x] (2026-08-31 21:42Z) Updated VIX-3994 with the final user-facing summary, scope, acceptance criteria, and validation plan. No repository code or tests changed.
 - [x] (2026-08-31 22:01Z) Added `FireTargetNodeSelectionTests` for default data/effect settings, serialized fields, legacy-data compatibility, editor visibility, and default group-mode location rendering. Full `Vixen_Tests` build passed; the focused filter passed 1 group-render test and failed 6 tests only for the deliberately absent Fire target-selection contract.
-- [ ] Add persisted Fire target settings, editor attributes, localized labels, and depth selection validation.
+- [x] (2026-08-31 22:10Z) Added persisted Fire target settings, property-grid visibility/normalization, `FireTargetElementDepthConverter`, and Fire localization resources. The focused suite now passes all 10 tests.
 - [ ] Add the narrow scoped-rendering seam and implement independent Fire rendering for strings and locations.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
@@ -31,6 +31,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: Jira comment dated 2026-08-31: “This could be useful on strings or locations, so removing the original restriction that it should target only locations.”
 - Observation: The characterization tests can protect legacy group-mode output without adding a deterministic random source to Fire.
   Evidence: `FireRender_DefaultGroupModeRendersLocatedLeavesTogether` passes through the existing Fire lifecycle and verifies both located leaves receive intents. The remaining focused failures all stop at missing `TargetNodeHandling`, `DepthOfEffect`, `TargetNodeSelection`, or their data members.
+- Observation: Provider display and description attributes resolve resource keys directly through `EffectResourceManager`; they do not consume the generated strongly typed resource properties.
+  Evidence: `ProviderDisplayNameAttribute` and `ProviderDescriptionAttribute` call `EffectResourceManager`, while the existing generated designer files do not contain Wipe's already-shipped `WipeTargetNodeSelection` key. Adding the Fire keys to the `.resx` files is therefore the complete runtime localization change.
 
 ## Decision Log
 
@@ -49,6 +51,9 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - Decision: Keep the useful-depth converter local to Fire, following Wipe's current isolation, unless implementation proves an existing shared converter can express the same filtered values without changing other effects.
   Rationale: `TargetElementDepthConverter` exposes depth zero and the terminal leaf-equivalent depth; changing it would alter Chase and Spin. A Fire-local converter avoids a cross-module dependency on Wipe and limits behavioral scope.
   Date/Author: 2026-08-31 / Codex
+- Decision: Do not manually edit the generated resource designer files.
+  Rationale: Runtime provider attributes use the embedded `.resx` resources via `EffectResourceManager`, and the designer files are already stale for Wipe's identical feature key. Editing generated code would not affect runtime behavior and would create avoidable generated-file drift.
+  Date/Author: 2026-08-31 / Codex
 
 ## Outcomes & Retrospective
 
@@ -57,6 +62,8 @@ Planning is complete. No production code, tests, JIRA fields, or issue comments 
 Milestone 1 is complete. VIX-3994 now describes the Fire target-handling choice for both strings and preview locations, compatibility expectations for existing effects, user-facing acceptance criteria, and automated/manual validation outcomes. The issue remains in its existing Accepted status.
 
 Milestone 2 is complete. `src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs` adds seven focused tests. `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` completed successfully. The focused `FireTargetNodeSelection` test run passed the existing group-mode location rendering characterization and failed the other six tests only because the Milestone 3 data and property APIs are intentionally not implemented yet.
+
+Milestone 3 is complete. Fire now serializes `TargetNodeSelection` and `DepthOfEffect`, defaults new and legacy data to group handling and depth zero, normalizes invalid persisted values, and preserves these values when cloned. `Fire.TargetNodeHandling` and `Fire.DepthOfEffect` expose the Wipe-compatible editor behavior; depth is visible only for a single deep individual target, and its local converter offers intermediate values only. Fire rendering itself remains unchanged for Milestone 4. The full `Vixen_Tests` build and focused filter passed with 10 tests.
 
 At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
 
@@ -211,3 +218,5 @@ Plan created 2026-08-31 / Codex. Reason: VIX-3994 requires a self-contained impl
 Plan revised 2026-08-31 / Codex. Reason: Milestone 1 updated VIX-3994 with the final user-facing requirements, acceptance criteria, and validation plan before repository implementation begins.
 
 Plan revised 2026-08-31 / Codex. Reason: Milestone 2 added focused Fire target-selection characterization tests and recorded their expected pre-implementation results.
+
+Plan revised 2026-08-31 / Codex. Reason: Milestone 3 implemented Fire data compatibility, property-grid target handling, filtered depth selection, and runtime localization resources.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -20,6 +20,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 22:50Z) Removed the re-entrant descriptor refresh from Fire's `DepthOfEffect` setter after manual target-drag testing exposed a property-grid refresh loop. The setter now normalizes before raising its change notification. A focused regression test confirms depth changes do not issue a `TypeDescriptor` refresh; the full build and focused Fire filter passed (42 tests).
 - [x] (2026-08-31 23:15Z) The target-drag loop persisted because the property grid reapplied a stale depth after targeting normalized it back to its already-stored value. Fire and Wipe now notify bindings only if the final normalized depth changed. Focused Fire/Wipe tests passed 26/26, including new stale-selection notification regressions; the full `Vixen_Tests` build passed.
 - [x] (2026-08-31 23:30Z) A subsequent Wipe target-drag trace showed the descriptor refresh itself reapplying unchanged target-handling selection values. Fire and Wipe now suppress descriptor refreshes for no-op `TargetNodeHandling` writes. Focused Fire/Wipe tests passed 28/28; the full `Vixen_Tests` build passed.
+- [x] (2026-08-31 23:45Z) The next trace isolated the remaining recursion to the shared effect property grid: its `TypeDescriptor` handler invalidated every selector's `StandardValues` while a selector was writing. The grid now recalculates browsability without resetting all selector item sources. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
+- [x] (2026-09-01 00:00Z) The final trace identified the original global selector broadcast: `PropertyItem.ComponentValueChanged` fanned a `TargetNodes` notification out to every property's `StandardValues`. Removed that fan-out; metadata visibility remains handled by the descriptor refresh. The full `Vixen_Tests` build passed and the focused Fire/Wipe filter passed 28/28.
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -44,6 +46,10 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: the second target-drag stack trace repeats `Fire.set_DepthOfEffect` through `PropertyItem.ComponentValueChanged` without `TypeDescriptor.Refresh` in the repeated cycle. Raising `PropertyChanged` for an unchanged final value causes the selector to reapply its stale value indefinitely.
 - Observation: `TypeDescriptor.Refresh` updates every selection editor's standard values; this can reassign the existing target-handling enum even when depth is already stable.
   Evidence: the Wipe trace reaches `WipeModule.TargetNodesChanged` and `TypeDescriptor.Refresh` at the start of every cycle, while the repeated frames contain `PropertyItem.SetValueCore` but no depth setter. Making the target-handling setter a no-op when normalization leaves its prior value breaks that refresh cycle.
+- Observation: broadcasting `StandardValues` changes from the property grid's metadata-refresh handler re-enters a selector even when no effect setter participates in the repeated cycle.
+  Evidence: the latest trace repeats `PropertyItem.ComponentValueChanged` through WPF `Selector.OnItemsSourceChanged` and returns to `EffectPropertyEditorGrid.OnTypeDescriptorRefreshedInvoke` through `TypeDescriptor.Refresh`, with no Fire or Wipe property setter in the recurring frames. `ComponentChanged()` sends `OnComponentChanged()` to every property item, and that method raises `PropertyChanged("StandardValues")`.
+- Observation: target reassignment also had a direct global selector-refresh path independent of `TypeDescriptor.Refresh`.
+  Evidence: the final trace ends `EffectModuleInstanceBase.TargetNodes.set` -> `PropertyItem.ComponentValueChanged` -> `EffectPropertyEditorGrid.ComponentChanged` -> `PropertyItem.OnComponentChanged`, then repeats WPF selector source resets. The `TargetNodes` property is not an editor selector, so notifying every other property's standard values is unnecessary and re-entrant.
 
 ## Decision Log
 
@@ -243,3 +249,13 @@ Plan revised 2026-08-31 / Codex. Reason: Manual target-drag testing exposed a re
 Plan revised 2026-08-31 / Codex. Reason: The follow-up target-drag trace exposed a stale selector value being re-notified after depth normalization; Fire and Wipe now suppress no-op depth notifications.
 
 Plan revised 2026-08-31 / Codex. Reason: The Wipe target-drag trace exposed no-op target-handling selector writes triggering recursive descriptor refreshes; Fire and Wipe now suppress those refreshes.
+
+Plan revised 2026-08-31 / Codex. Reason: The final target-drag trace showed the shared property grid resetting all selector item sources during a metadata refresh; it now updates property visibility without globally invalidating selector standard values.
+
+Plan revised 2026-09-01 / Codex. Reason: The next trace identified `TargetNodes`' direct global selector invalidation path; removing it eliminates the repeating `ComponentChanged` call chain while retaining descriptor-based browsability updates.
+
+Plan revised 2026-09-01 / Codex. Reason: A depth-selection trace then isolated the remaining recursion to `PropertyItem.ComponentValueChanged` rebinding a selector's `StandardValues` item source while that selector committed its selected value. Property changes now notify only `PropertyValue`; valid-value collections are no longer reset for every value write.
+
+Plan revised 2026-09-01 / Codex. Reason: Restored target-context standard-value recalculation through one coalesced idle-dispatch refresh after `TargetNodes` changes. This updates dynamic depth choices after a drag without rebinding selector sources while a property value is being committed.
+
+Plan revised 2026-09-01 / Codex. Reason: Target reassignment now raises `DepthOfEffect` (and target-handling, when applicable) notifications when target validation normalizes persisted values. This keeps the selector's selected value synchronized with its refreshed valid values; focused Fire/Wipe coverage asserts a depth of `2` becomes `1` after moving to a shallower target.

--- a/docs/plans/effects/vix-3994-fire-target-node-selection.md
+++ b/docs/plans/effects/vix-3994-fire-target-node-selection.md
@@ -16,7 +16,7 @@ Existing Fire effects must remain visually and serially compatible. They will lo
 - [x] (2026-08-31 21:42Z) Updated VIX-3994 with the final user-facing summary, scope, acceptance criteria, and validation plan. No repository code or tests changed.
 - [x] (2026-08-31 22:01Z) Added `FireTargetNodeSelectionTests` for default data/effect settings, serialized fields, legacy-data compatibility, editor visibility, and default group-mode location rendering. Full `Vixen_Tests` build passed; the focused filter passed 1 group-render test and failed 6 tests only for the deliberately absent Fire target-selection contract.
 - [x] (2026-08-31 22:10Z) Added persisted Fire target settings, property-grid visibility/normalization, `FireTargetElementDepthConverter`, and Fire localization resources. The focused suite now passes all 10 tests.
-- [ ] Add the narrow scoped-rendering seam and implement independent Fire rendering for strings and locations.
+- [x] (2026-08-31 22:35Z) Added the documented `PixelEffectBase` render-group seam and Fire's group resolver. Each group now receives its own target-scoped buffer configuration, setup/render/cleanup lifecycle, and merged intents. Focused location lifecycle tests verify two intermediate-depth groups and two separately selected targets each use independent local `3 x 1` buffers. The full `Vixen_Tests` build and focused Fire filter passed (41 tests).
 - [ ] Run focused and broader validation, update the Jira issue, and record final evidence in this plan.
 
 ## Surprises & Discoveries
@@ -33,6 +33,8 @@ Existing Fire effects must remain visually and serially compatible. They will lo
   Evidence: `FireRender_DefaultGroupModeRendersLocatedLeavesTogether` passes through the existing Fire lifecycle and verifies both located leaves receive intents. The remaining focused failures all stop at missing `TargetNodeHandling`, `DepthOfEffect`, `TargetNodeSelection`, or their data members.
 - Observation: Provider display and description attributes resolve resource keys directly through `EffectResourceManager`; they do not consume the generated strongly typed resource properties.
   Evidence: `ProviderDisplayNameAttribute` and `ProviderDescriptionAttribute` call `EffectResourceManager`, while the existing generated designer files do not contain Wipe's already-shipped `WipeTargetNodeSelection` key. Adding the Fire keys to the `.resx` files is therefore the complete runtime localization change.
+- Observation: the previous pixel lifecycle configured one shared location buffer, then invoked the location renderer for every selected root; explicit render groups need one renderer invocation for the complete group instead.
+  Evidence: `PixelEffectBase.RenderNodeByLocation()` renders every entry in `ElementLocations`, which already contains all leaves of the configured group. The scoped renderer now calls `RenderNodes()` once per group and merges the resulting intents.
 
 ## Decision Log
 
@@ -64,6 +66,8 @@ Milestone 1 is complete. VIX-3994 now describes the Fire target-handling choice 
 Milestone 2 is complete. `src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs` adds seven focused tests. `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` completed successfully. The focused `FireTargetNodeSelection` test run passed the existing group-mode location rendering characterization and failed the other six tests only because the Milestone 3 data and property APIs are intentionally not implemented yet.
 
 Milestone 3 is complete. Fire now serializes `TargetNodeSelection` and `DepthOfEffect`, defaults new and legacy data to group handling and depth zero, normalizes invalid persisted values, and preserves these values when cloned. `Fire.TargetNodeHandling` and `Fire.DepthOfEffect` expose the Wipe-compatible editor behavior; depth is visible only for a single deep individual target, and its local converter offers intermediate values only. Fire rendering itself remains unchanged for Milestone 4. The full `Vixen_Tests` build and focused filter passed with 10 tests.
+
+Milestone 4 is complete. `PixelEffectBase` now exposes a documented protected render-group selector whose default is one group containing all selected targets. It configures, sets up, renders, cleans up, and clears location state independently for each supplied group, while merging every group's intents. Fire overrides that selector to preserve group mode, split multiple selected targets, or resolve one deep target at its selected depth. The shared string path builds a single scoped frame buffer and maps the scoped roots' elements once; the location path renders the scoped location buffer once. `FireTargetNodeSelectionTests` now verifies depth and multiple-target location groups use local buffers. The full `Vixen_Tests` build passed, and the focused Fire filter passed 41 tests.
 
 At implementation completion, replace this entry with the final user-visible outcome, the exact validation results, any remaining limitations, and lessons that affected the final design.
 
@@ -220,3 +224,5 @@ Plan revised 2026-08-31 / Codex. Reason: Milestone 1 updated VIX-3994 with the f
 Plan revised 2026-08-31 / Codex. Reason: Milestone 2 added focused Fire target-selection characterization tests and recorded their expected pre-implementation results.
 
 Plan revised 2026-08-31 / Codex. Reason: Milestone 3 implemented Fire data compatibility, property-grid target handling, filtered depth selection, and runtime localization resources.
+
+Plan revised 2026-08-31 / Codex. Reason: Milestone 4 added target-scoped pixel rendering and Fire's independent group selection with focused lifecycle coverage.

--- a/src/Vixen.Modules/Editor/EffectEditor/EffectPropertyEditorGrid.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/EffectPropertyEditorGrid.cs
@@ -20,6 +20,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Common.WPFCommon.Controls;
 using Vixen.Attributes;
 using Vixen.Module.Effect;
@@ -140,6 +141,7 @@ namespace VixenModules.Editor.EffectEditor
 		private string _informationLink = InformationLinkUrl;
 		private GridEntryCollection<PropertyItem> _properties;
 		private IComparer<PropertyItem> _propertyComparer;
+		private bool _standardValuesRefreshQueued;
 
 		/// <summary>
 		///     Gets or sets the brush for items background. This is a dependency property.
@@ -854,8 +856,26 @@ namespace VixenModules.Editor.EffectEditor
 
 		#region Private members
 
-		internal void ComponentChanged()
+		internal void QueueStandardValuesRefresh()
 		{
+			if (!Dispatcher.CheckAccess())
+			{
+				Dispatcher.BeginInvoke(new Action(QueueStandardValuesRefresh));
+				return;
+			}
+
+			if (_standardValuesRefreshQueued)
+			{
+				return;
+			}
+
+			_standardValuesRefreshQueued = true;
+			Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(RefreshStandardValues));
+		}
+
+		private void RefreshStandardValues()
+		{
+			_standardValuesRefreshQueued = false;
 			foreach (var propertyItem in Properties)
 			{
 				propertyItem.OnComponentChanged();
@@ -942,7 +962,6 @@ namespace VixenModules.Editor.EffectEditor
 						// clear our property hashes
 						//DoReload();
 						UpdateBrowsable();
-						ComponentChanged();
 						return;
 					}
 				}

--- a/src/Vixen.Modules/Editor/EffectEditor/EffectPropertyEditorGrid.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/EffectPropertyEditorGrid.cs
@@ -141,6 +141,8 @@ namespace VixenModules.Editor.EffectEditor
 		private string _informationLink = InformationLinkUrl;
 		private GridEntryCollection<PropertyItem> _properties;
 		private IComparer<PropertyItem> _propertyComparer;
+		private bool _refreshAllStandardValues;
+		private readonly HashSet<PropertyItem> _standardValuesRefreshItems = [];
 		private bool _standardValuesRefreshQueued;
 
 		/// <summary>
@@ -856,12 +858,26 @@ namespace VixenModules.Editor.EffectEditor
 
 		#region Private members
 
-		internal void QueueStandardValuesRefresh()
+		/// <summary>
+		/// Queues a refresh of one property's standard values, or all properties when <paramref name="propertyItem" /> is <see langword="null" />.
+		/// </summary>
+		/// <param name="propertyItem">The property whose standard values changed, or <see langword="null" /> when every property's values may have changed.</param>
+		internal void QueueStandardValuesRefresh(PropertyItem propertyItem = null)
 		{
 			if (!Dispatcher.CheckAccess())
 			{
-				Dispatcher.BeginInvoke(new Action(QueueStandardValuesRefresh));
+				Dispatcher.BeginInvoke(new Action(() => QueueStandardValuesRefresh(propertyItem)));
 				return;
+			}
+
+			if (propertyItem == null)
+			{
+				_refreshAllStandardValues = true;
+				_standardValuesRefreshItems.Clear();
+			}
+			else if (!_refreshAllStandardValues)
+			{
+				_standardValuesRefreshItems.Add(propertyItem);
 			}
 
 			if (_standardValuesRefreshQueued)
@@ -876,7 +892,12 @@ namespace VixenModules.Editor.EffectEditor
 		private void RefreshStandardValues()
 		{
 			_standardValuesRefreshQueued = false;
-			foreach (var propertyItem in Properties)
+			var propertyItems = _refreshAllStandardValues
+				? Properties.ToList()
+				: _standardValuesRefreshItems.ToList();
+			_refreshAllStandardValues = false;
+			_standardValuesRefreshItems.Clear();
+			foreach (var propertyItem in propertyItems)
 			{
 				propertyItem.OnComponentChanged();
 			}

--- a/src/Vixen.Modules/Editor/EffectEditor/PropertyItem.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/PropertyItem.cs
@@ -247,10 +247,9 @@ namespace VixenModules.Editor.EffectEditor
 		private void ComponentValueChanged(object sender, EventArgs e)
 		{
 			OnPropertyChanged("PropertyValue");
-			OnPropertyChanged("StandardValues");
 			if (Name.Equals("TargetNodes"))
 			{
-				Owner.ComponentChanged();
+				Owner.QueueStandardValuesRefresh();
 			}
 		}
 

--- a/src/Vixen.Modules/Editor/EffectEditor/PropertyItem.cs
+++ b/src/Vixen.Modules/Editor/EffectEditor/PropertyItem.cs
@@ -247,10 +247,7 @@ namespace VixenModules.Editor.EffectEditor
 		private void ComponentValueChanged(object sender, EventArgs e)
 		{
 			OnPropertyChanged("PropertyValue");
-			if (Name.Equals("TargetNodes"))
-			{
-				Owner.QueueStandardValuesRefresh();
-			}
+			Owner.QueueStandardValuesRefresh(Name.Equals("TargetNodes") ? null : this);
 		}
 
 		#endregion

--- a/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
+++ b/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
@@ -32,11 +32,21 @@ namespace VixenModules.Effect.Dissolve
 			InitAllAttributes();
 		}
 
+		/// <summary>
+		/// Validates target-dependent color and depth settings after the selected targets change.
+		/// </summary>
 		protected override void TargetNodesChanged()
 		{
+			var previousDepth = _data.DepthOfEffect;
 			if (TargetNodes.Any())
 			{
 				CheckForInvalidColorData();
+			}
+
+			NormalizeDepthOfEffect();
+			if (_data.DepthOfEffect != previousDepth)
+			{
+				OnPropertyChanged(nameof(DepthOfEffect));
 			}
 		}
 
@@ -466,9 +476,32 @@ namespace VixenModules.Effect.Dissolve
 			get { return _data.DepthOfEffect; }
 			set
 			{
+				var previousDepth = _data.DepthOfEffect;
 				_data.DepthOfEffect = value;
-				IsDirty = true;
-				OnPropertyChanged();
+				NormalizeDepthOfEffect();
+				if (_data.DepthOfEffect != previousDepth)
+				{
+					IsDirty = true;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		private void NormalizeDepthOfEffect()
+		{
+			if (!TargetNodes.Any())
+			{
+				return;
+			}
+
+			var maximumDepth = TargetNodes
+				.Where(node => node != null)
+				.Select(node => node.GetMaxChildDepth())
+				.DefaultIfEmpty(0)
+				.Min();
+			if (_data.DepthOfEffect < 0 || _data.DepthOfEffect > maximumDepth - 1)
+			{
+				_data.DepthOfEffect = 0;
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs
+++ b/src/Vixen.Modules/Effect/Effect/PixelEffectBase.cs
@@ -56,21 +56,34 @@ namespace VixenModules.Effect.Effect
 			}
 		}
 
+		/// <summary>
+		/// Gets the target-root groups that are rendered independently.
+		/// </summary>
+		/// <returns>A sequence containing all selected target roots as one render group.</returns>
+		protected virtual IEnumerable<IReadOnlyCollection<IElementNode>> GetRenderGroups()
+		{
+			return new[] { (IReadOnlyCollection<IElementNode>)TargetNodes };
+		}
+
 		protected override void _PreRender(CancellationTokenSource tokenSource = null)
 		{
-			ConfigureDisplayElementSize();
-
-			SetupRender();
-			int bufferSize = StringPixelCounts.Sum();
-			EffectIntents data = new EffectIntents(bufferSize);
-			foreach (IElementNode node in TargetNodes)
+			EffectIntents data = null;
+			foreach (var renderGroup in GetRenderGroups())
 			{
-				if (node != null)
-					RenderNode(node, ref data);
+				var targetNodes = renderGroup?.Where(node => node != null).Distinct().ToArray();
+				if (targetNodes == null || targetNodes.Length == 0)
+				{
+					continue;
+				}
+
+				ConfigureDisplayElementSize(targetNodes);
+				SetupRender();
+				data ??= new EffectIntents(StringPixelCounts.Sum());
+				RenderNodes(targetNodes, ref data);
+				CleanUpRender();
+				ElementLocations = null;
 			}
-			_elementData = data;
-			CleanUpRender();
-			ElementLocations = null;
+			_elementData = data ?? new EffectIntents();
 		}
 
 		[ReadOnly(true)]
@@ -212,13 +225,19 @@ namespace VixenModules.Effect.Effect
 
 		protected IEnumerable<IElementNode> FindLeafParents()
 		{
+			return FindLeafParents(TargetNodes);
+		}
+
+		private IEnumerable<IElementNode> FindLeafParents(IEnumerable<IElementNode> targetNodes)
+		{
 			var nodes = new List<IElementNode>();
 			var nonLeafElements = Enumerable.Empty<IElementNode>();
 
-			if (TargetNodes.FirstOrDefault() != null)
+			var nodesToInspect = targetNodes.Where(node => node != null).ToArray();
+			if (nodesToInspect.Length > 0)
 			{
-				nonLeafElements = TargetNodes.SelectMany(x => x.GetNonLeafEnumerator());
-				foreach (var elementNode in TargetNodes)
+				nonLeafElements = nodesToInspect.SelectMany(x => x.GetNonLeafEnumerator());
+				foreach (var elementNode in nodesToInspect)
 				{
 					foreach (var leafNode in elementNode.GetLeafEnumerator())
 					{
@@ -258,6 +277,16 @@ namespace VixenModules.Effect.Effect
 			_bufferWiOffset = 0;
 		}
 
+		private void ConfigureStringBuffer(IEnumerable<IElementNode> targetNodes)
+		{
+			var nodes = FindLeafParents(targetNodes).ToArray();
+			CalculatePixelsPerString(nodes);
+			_bufferHt = CalculateMaxStringCount(nodes);
+			_bufferWi = StringPixelCounts.Concat(new[] {0}).Max();
+			_bufferHtOffset = 0;
+			_bufferWiOffset = 0;
+		}
+
 		private void CalculateStringCounts()
 		{
 			var nodes = FindLeafParents();
@@ -268,7 +297,12 @@ namespace VixenModules.Effect.Effect
 
 		private void ConfigureVirtualBuffer()
 		{
-			ElementLocations = TargetNodes.SelectMany(x => x.GetLeafEnumerator()).Select(x => new ElementLocation(x)).ToList();
+			ConfigureVirtualBuffer(TargetNodes);
+		}
+
+		private void ConfigureVirtualBuffer(IEnumerable<IElementNode> targetNodes)
+		{
+			ElementLocations = targetNodes.SelectMany(x => x.GetLeafEnumerator()).Select(x => new ElementLocation(x)).ToList();
 			var xMax = ElementLocations.Max(p => p.X);
 			var xMin = ElementLocations.Min(p => p.X);
 			var yMax = ElementLocations.Max(p => p.Y);
@@ -278,6 +312,18 @@ namespace VixenModules.Effect.Effect
 			_bufferHt = (xMax - xMin) + 1;
 			_bufferWiOffset = yMin;
 			_bufferHtOffset = xMin;
+		}
+
+		private void ConfigureDisplayElementSize(IEnumerable<IElementNode> targetNodes)
+		{
+			if (TargetPositioning == TargetPositioningType.Strings)
+			{
+				ConfigureStringBuffer(targetNodes);
+			}
+			else
+			{
+				ConfigureVirtualBuffer(targetNodes);
+			}
 		}
 
 		protected int StringCountOffset { get; set; }
@@ -354,6 +400,16 @@ namespace VixenModules.Effect.Effect
 			return RenderNodeByLocation(node, ref effectIntents);
 		}
 
+		private EffectIntents RenderNodes(IReadOnlyCollection<IElementNode> nodes, ref EffectIntents effectIntents)
+		{
+			if (TargetPositioning == TargetPositioningType.Strings)
+			{
+				return RenderNodesByStrings(nodes, ref effectIntents);
+			}
+
+			return RenderNodeByLocation(nodes.First(), ref effectIntents);
+		}
+
 		protected EffectIntents RenderNodeByLocation(IElementNode node, ref EffectIntents effectIntents)
 		{
 			int nFrames = GetNumberFrames();
@@ -377,6 +433,11 @@ namespace VixenModules.Effect.Effect
 		}
 
 		protected EffectIntents RenderNodeByStrings(IElementNode node, ref EffectIntents effectIntents)
+		{
+			return RenderNodesByStrings(new[] {node}, ref effectIntents);
+		}
+
+		private EffectIntents RenderNodesByStrings(IEnumerable<IElementNode> nodes, ref EffectIntents effectIntents)
 		{
 			int nFrames = GetNumberFrames();
 			if (nFrames <= 0 | BufferWi==0 || BufferHt==0) return new EffectIntents();
@@ -436,7 +497,7 @@ namespace VixenModules.Effect.Effect
 			
 			// create the intents
 			var frameTs = new TimeSpan(0, 0, 0, 0, FrameTime);
-			var elements = _elementsCached?_cachedElements:node.Distinct().ToList();
+			var elements = _elementsCached ? _cachedElements : nodes.SelectMany(node => node.Distinct()).Distinct().ToList();
 			int numElements = elements.Count;
 
 			for (int eidx = 0; eidx < numElements; eidx++)

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -199,10 +199,14 @@ namespace VixenModules.Effect.Fire
 			get { return _data.DepthOfEffect; }
 			set
 			{
+				var previousDepth = _data.DepthOfEffect;
 				_data.DepthOfEffect = value;
 				UpdateTargetingAttributes();
-				IsDirty = true;
-				OnPropertyChanged();
+				if (_data.DepthOfEffect != previousDepth)
+				{
+					IsDirty = true;
+					OnPropertyChanged();
+				}
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -2,6 +2,7 @@
 using Vixen.Attributes;
 using System.ComponentModel;
 using Vixen.Module;
+using Vixen.Sys;
 using Vixen.Sys.Attribute;
 using VixenModules.App.Curves;
 using VixenModules.Effect.Effect;
@@ -36,6 +37,37 @@ namespace VixenModules.Effect.Fire
 			base.TargetNodesChanged();
 			UpdateTargetingAttributes();
 			TypeDescriptor.Refresh(this);
+		}
+
+		/// <summary>
+		/// Gets the target-root groups that receive independent Fire simulations.
+		/// </summary>
+		/// <returns>The selected targets as one group, or the groups resolved by individual target handling.</returns>
+		protected override IEnumerable<IReadOnlyCollection<IElementNode>> GetRenderGroups()
+		{
+			if (TargetNodeHandling == TargetNodeSelection.Group)
+			{
+				return base.GetRenderGroups();
+			}
+
+			if (TargetNodes.Length > 1)
+			{
+				return TargetNodes
+					.Where(node => node != null)
+					.Distinct()
+					.Select(node => (IReadOnlyCollection<IElementNode>)new[] {node});
+			}
+
+			var targetNode = TargetNodes.FirstOrDefault();
+			if (targetNode == null)
+			{
+				return Enumerable.Empty<IReadOnlyCollection<IElementNode>>();
+			}
+
+			return GetNodesAtEffectDepth(targetNode, DepthOfEffect)
+				.Where(node => node != null)
+				.Distinct()
+				.Select(node => (IReadOnlyCollection<IElementNode>)new[] {node});
 		}
 
 		#region Setup

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -200,10 +200,9 @@ namespace VixenModules.Effect.Fire
 			set
 			{
 				_data.DepthOfEffect = value;
+				UpdateTargetingAttributes();
 				IsDirty = true;
 				OnPropertyChanged();
-				UpdateTargetingAttributes();
-				TypeDescriptor.Refresh(this);
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -30,12 +30,24 @@ namespace VixenModules.Effect.Fire
 		}
 
 		/// <summary>
-		/// Updates target-specific property visibility after the selected targets change.
+		/// Updates target-specific property visibility and normalized targeting values after the selected targets change.
 		/// </summary>
 		protected override void TargetNodesChanged()
 		{
+			var previousTargetNodeHandling = _data.TargetNodeSelection;
+			var previousDepth = _data.DepthOfEffect;
 			base.TargetNodesChanged();
 			UpdateTargetingAttributes();
+			if (_data.TargetNodeSelection != previousTargetNodeHandling)
+			{
+				OnPropertyChanged(nameof(TargetNodeHandling));
+			}
+
+			if (_data.DepthOfEffect != previousDepth)
+			{
+				OnPropertyChanged(nameof(DepthOfEffect));
+			}
+
 			TypeDescriptor.Refresh(this);
 		}
 

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -176,11 +176,15 @@ namespace VixenModules.Effect.Fire
 			get { return _data.TargetNodeSelection; }
 			set
 			{
+				var previousTargetNodeSelection = _data.TargetNodeSelection;
 				_data.TargetNodeSelection = value;
-				IsDirty = true;
-				OnPropertyChanged();
 				UpdateTargetingAttributes();
-				TypeDescriptor.Refresh(this);
+				if (_data.TargetNodeSelection != previousTargetNodeSelection)
+				{
+					IsDirty = true;
+					OnPropertyChanged();
+					TypeDescriptor.Refresh(this);
+				}
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Fire/Fire.cs
+++ b/src/Vixen.Modules/Effect/Fire/Fire.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Controls.ColorManagement.ColorModels;
 using Vixen.Attributes;
+using System.ComponentModel;
 using Vixen.Module;
 using Vixen.Sys.Attribute;
 using VixenModules.App.Curves;
@@ -25,6 +26,16 @@ namespace VixenModules.Effect.Fire
 			_data = new FireData();
 			EnableTargetPositioning(true, true);
 			InitAllAttributes();
+		}
+
+		/// <summary>
+		/// Updates target-specific property visibility after the selected targets change.
+		/// </summary>
+		protected override void TargetNodesChanged()
+		{
+			base.TargetNodesChanged();
+			UpdateTargetingAttributes();
+			TypeDescriptor.Refresh(this);
 		}
 
 		#region Setup
@@ -118,6 +129,54 @@ namespace VixenModules.Effect.Fire
 
 		#endregion
 
+		#region Target handling
+
+		/// <summary>
+		/// Gets or sets how Fire applies to the selected target nodes.
+		/// </summary>
+		/// <value>The target-node handling mode. The default is <see cref="TargetNodeSelection.Group" />.</value>
+		[Value]
+		[ProviderCategory(@"Behavior", 0)]
+		[ProviderDisplayName(@"FireTargetNodeSelection")]
+		[ProviderDescription(@"FireTargetNodeSelection")]
+		public TargetNodeSelection TargetNodeHandling
+		{
+			get { return _data.TargetNodeSelection; }
+			set
+			{
+				_data.TargetNodeSelection = value;
+				IsDirty = true;
+				OnPropertyChanged();
+				UpdateTargetingAttributes();
+				TypeDescriptor.Refresh(this);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the target hierarchy depth used when target-node handling is individual.
+		/// </summary>
+		/// <value>The selected target hierarchy depth. The default is <c>0</c>.</value>
+		[Value]
+		[ProviderCategory(@"Depth", 20)]
+		[ProviderDisplayName(@"Depth")]
+		[ProviderDescription(@"Depth")]
+		[TypeConverter(typeof(FireTargetElementDepthConverter))]
+		[PropertyEditor("SelectionEditor")]
+		public int DepthOfEffect
+		{
+			get { return _data.DepthOfEffect; }
+			set
+			{
+				_data.DepthOfEffect = value;
+				IsDirty = true;
+				OnPropertyChanged();
+				UpdateTargetingAttributes();
+				TypeDescriptor.Refresh(this);
+			}
+		}
+
+		#endregion
+
 		#region Information
 
 		public override string Information
@@ -155,6 +214,49 @@ namespace VixenModules.Effect.Fire
 		private void InitAllAttributes()
 		{
 			UpdateStringOrientationAttributes(true);
+			UpdateTargetingAttributes();
+		}
+
+		private void UpdateTargetingAttributes()
+		{
+			var depth = DetermineDepth();
+			var hasUsefulIntermediateDepth = HasUsefulIntermediateDepth(depth);
+			var targetNodeHandlingVisible = TargetNodes.Any() && (TargetNodes.Length > 1 || depth > 2);
+
+			if (!targetNodeHandlingVisible && TargetNodeHandling == TargetNodeSelection.Individual)
+			{
+				_data.TargetNodeSelection = TargetNodeSelection.Group;
+			}
+
+			if (TargetNodes.Length > 1 || TargetNodeHandling == TargetNodeSelection.Group)
+			{
+				_data.DepthOfEffect = 0;
+			}
+			else if (TargetNodeHandling == TargetNodeSelection.Individual && !IsUsefulIntermediateDepth(DepthOfEffect, depth))
+			{
+				_data.DepthOfEffect = GetFirstUsefulIntermediateDepth(depth);
+			}
+
+			SetBrowsable(new Dictionary<string, bool>(2)
+			{
+				{nameof(TargetNodeHandling), targetNodeHandlingVisible},
+				{nameof(DepthOfEffect), TargetNodeHandling == TargetNodeSelection.Individual && TargetNodes.Length == 1 && hasUsefulIntermediateDepth}
+			});
+		}
+
+		private static bool HasUsefulIntermediateDepth(int depth)
+		{
+			return depth > 2;
+		}
+
+		private static bool IsUsefulIntermediateDepth(int selectedDepth, int availableDepth)
+		{
+			return selectedDepth > 0 && selectedDepth < availableDepth - 1;
+		}
+
+		private static int GetFirstUsefulIntermediateDepth(int depth)
+		{
+			return HasUsefulIntermediateDepth(depth) ? 1 : 0;
 		}
 
 		// 0 <= x < BufferWi

--- a/src/Vixen.Modules/Effect/Fire/FireData.cs
+++ b/src/Vixen.Modules/Effect/Fire/FireData.cs
@@ -15,6 +15,8 @@ namespace VixenModules.Effect.Fire
 			LevelCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 100.0, 100.0 }));
 			HueShiftCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { 0.0, 0.0 }));
 			Orientation = StringOrientation.Vertical;
+			DepthOfEffect = 0;
+			TargetNodeSelection = TargetNodeSelection.Group;
 		}
 
 		[DataMember]
@@ -35,8 +37,26 @@ namespace VixenModules.Effect.Fire
 		[DataMember]
 		public Curve LevelCurve { get; set; }
 
+		/// <summary>
+		/// Gets or sets the target hierarchy depth used for individual target rendering.
+		/// </summary>
+		/// <value>The selected target hierarchy depth. The default is <c>0</c>.</value>
+		[DataMember]
+		public int DepthOfEffect { get; set; }
+
+		/// <summary>
+		/// Gets or sets the target-node handling mode for the Fire effect.
+		/// </summary>
+		/// <value>The target-node handling mode. The default is <see cref="TargetNodeSelection.Group" />.</value>
+		[DataMember]
+		public TargetNodeSelection TargetNodeSelection { get; set; }
+
+		/// <summary>
+		/// Restores data omitted by legacy Fire effect payloads and normalizes invalid target settings.
+		/// </summary>
+		/// <param name="context">The serialization context for the deserialized data.</param>
 		[OnDeserialized]
-		public void OnDeserialized(StreamingContext c)
+		public void OnDeserialized(StreamingContext context)
 		{
 			//if one of them is null the others probably are, and if this one is not then they all should be good.
 			//Try to save some cycles on every load
@@ -45,6 +65,16 @@ namespace VixenModules.Effect.Fire
 				double value = PixelEffectBase.ScaleValueToCurve(HueShift, 100, 0);
 				HueShiftCurve = new Curve(new PointPairList(new[] { 0.0, 100.0 }, new[] { value, value }));
 				HueShift = 0;
+			}
+
+			if (!Enum.IsDefined<TargetNodeSelection>(TargetNodeSelection))
+			{
+				TargetNodeSelection = TargetNodeSelection.Group;
+			}
+
+			if (DepthOfEffect < 0)
+			{
+				DepthOfEffect = 0;
 			}
 		}
 		
@@ -56,7 +86,9 @@ namespace VixenModules.Effect.Fire
 				Height = Height,
 				Orientation = Orientation,
 				LevelCurve = new Curve(LevelCurve),
-				HueShiftCurve = new Curve(HueShiftCurve)
+				HueShiftCurve = new Curve(HueShiftCurve),
+				DepthOfEffect = DepthOfEffect,
+				TargetNodeSelection = TargetNodeSelection
 			};
 			return result;
 		}

--- a/src/Vixen.Modules/Effect/Fire/FireTargetElementDepthConverter.cs
+++ b/src/Vixen.Modules/Effect/Fire/FireTargetElementDepthConverter.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using System.Globalization;
+using Vixen.Module.Effect;
+
+namespace VixenModules.Effect.Fire;
+
+/// <summary>
+/// Provides useful target-depth choices for the Fire effect.
+/// </summary>
+public class FireTargetElementDepthConverter : TypeConverter
+{
+	/// <inheritdoc />
+	public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => true;
+
+	/// <inheritdoc />
+	public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => true;
+
+	/// <inheritdoc />
+	public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => Convert.ToInt32(value);
+
+	/// <inheritdoc />
+	public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		return value.ToString();
+	}
+
+	/// <inheritdoc />
+	public override bool GetStandardValuesExclusive(ITypeDescriptorContext context) => true;
+
+	/// <inheritdoc />
+	public override bool GetStandardValuesSupported(ITypeDescriptorContext context) => true;
+
+	/// <inheritdoc />
+	public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+	{
+		var depth = GetDepth(context);
+		var values = new List<string>();
+		for (var i = 1; i < depth - 1; i++)
+		{
+			values.Add(i.ToString());
+		}
+
+		return new StandardValuesCollection(values.ToArray());
+	}
+
+	private static int GetDepth(ITypeDescriptorContext context)
+	{
+		if (context?.Instance is IEffect[] effects)
+		{
+			var depth = Int32.MaxValue;
+			foreach (var effect in effects)
+			{
+				var node = effect.TargetNodes.FirstOrDefault();
+				if (node != null)
+				{
+					depth = Math.Min(node.GetMaxChildDepth(), depth);
+				}
+			}
+
+			return depth == Int32.MaxValue ? 0 : depth;
+		}
+
+		if (context?.Instance is IEffect effectInstance)
+		{
+			return effectInstance.TargetNodes.FirstOrDefault()?.GetMaxChildDepth() ?? 0;
+		}
+
+		return 0;
+	}
+}

--- a/src/Vixen.Modules/Effect/State/State.cs
+++ b/src/Vixen.Modules/Effect/State/State.cs
@@ -37,10 +37,14 @@ namespace VixenModules.Effect.State
 
 		#region Overrides of EffectModuleInstanceBase
 
+		/// <summary>
+		/// Refreshes the available State definitions and custom State item options after the selected targets change.
+		/// </summary>
 		protected override void TargetNodesChanged()
 		{
 			CheckForInvalidColorData();
 			RefreshStateDefinitionSelection();
+			RefreshCustomStateItemOptions();
 		}
 
 		protected override void _PreRender(CancellationTokenSource? cancellationToken = null)

--- a/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
+++ b/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
@@ -35,10 +35,25 @@ namespace VixenModules.Effect.Wipe
 		private int _pulsePercent;
 		private int _steps;
 
+		/// <summary>
+		/// Updates target-specific property visibility and normalized targeting values after the selected targets change.
+		/// </summary>
 		protected override void TargetNodesChanged()
 		{
+			var previousTargetNodeHandling = _data.TargetNodeSelection;
+			var previousDepth = _data.DepthOfEffect;
 			CheckForInvalidColorData();
 			UpdateAttributes();
+			if (_data.TargetNodeSelection != previousTargetNodeHandling)
+			{
+				OnPropertyChanged(nameof(TargetNodeHandling));
+			}
+
+			if (_data.DepthOfEffect != previousDepth)
+			{
+				OnPropertyChanged(nameof(DepthOfEffect));
+			}
+
 			TypeDescriptor.Refresh(this);
 		}
 

--- a/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
+++ b/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
@@ -983,10 +983,9 @@ namespace VixenModules.Effect.Wipe
 			set
 			{
 				_data.DepthOfEffect = value;
+				UpdateAttributes();
 				IsDirty = true;
 				OnPropertyChanged();
-				UpdateAttributes();
-				TypeDescriptor.Refresh(this);
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
+++ b/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
@@ -982,10 +982,14 @@ namespace VixenModules.Effect.Wipe
 			get { return _data.DepthOfEffect; }
 			set
 			{
+				var previousDepth = _data.DepthOfEffect;
 				_data.DepthOfEffect = value;
 				UpdateAttributes();
-				IsDirty = true;
-				OnPropertyChanged();
+				if (_data.DepthOfEffect != previousDepth)
+				{
+					IsDirty = true;
+					OnPropertyChanged();
+				}
 			}
 		}
 

--- a/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
+++ b/src/Vixen.Modules/Effect/Wipe/WipeModule.cs
@@ -959,11 +959,15 @@ namespace VixenModules.Effect.Wipe
 			get { return _data.TargetNodeSelection; }
 			set
 			{
+				var previousTargetNodeSelection = _data.TargetNodeSelection;
 				_data.TargetNodeSelection = value;
-				IsDirty = true;
-				OnPropertyChanged();
 				UpdateAttributes();
-				TypeDescriptor.Refresh(this);
+				if (_data.TargetNodeSelection != previousTargetNodeSelection)
+				{
+					IsDirty = true;
+					OnPropertyChanged();
+					TypeDescriptor.Refresh(this);
+				}
 			}
 		}
 

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDescriptionDescriptors.resx
@@ -1005,6 +1005,9 @@
   <data name="WipeTargetNodeSelection" xml:space="preserve">
     <value>Determines how the Wipe is applied across the target elements that are presented to the effect.</value>
   </data>
+  <data name="FireTargetNodeSelection" xml:space="preserve">
+    <value>Determines how the Fire effect is applied across the target elements that are presented to the effect.</value>
+  </data>
   <data name="Amplitude" xml:space="preserve">
     <value>Determines the height of the waveform.</value>
   </data>

--- a/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
+++ b/src/Vixen.Modules/EffectEditor/EffectDescriptorAttributes/EffectDisplayNameDescriptors.resx
@@ -993,6 +993,9 @@
   <data name="WipeTargetNodeSelection" xml:space="preserve">
     <value>Wipe</value>
   </data>
+  <data name="FireTargetNodeSelection" xml:space="preserve">
+    <value>Fire</value>
+  </data>
   <data name="PhaseShift" xml:space="preserve">
     <value>Phase Shift</value>
   </data>

--- a/src/Vixen.Tests/Effect/State/StateDataTests.cs
+++ b/src/Vixen.Tests/Effect/State/StateDataTests.cs
@@ -793,6 +793,56 @@ public class StateDataTests
 	}
 
 	[Fact]
+	public void StateDefinitionChange_UpdatesStateItemOptions()
+	{
+		// Arrange
+		var first = CreateDefinition("First", CreateStateItem("Open", Color.Green));
+		var second = CreateDefinition("Second", CreateStateItem("Closed", Color.Red));
+		var effect = CreateEffectWithDefinitions([first, second]);
+		var changedProperties = new List<string?>();
+		effect.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+		// Act
+		effect.StateDefinition = "Second";
+
+		// Assert
+		Assert.Contains(nameof(StateEffect.StateItem), changedProperties);
+		Assert.Equal([StateEffect.AllStateItemsLabel, "Closed"], effect.GetStateItemOptions());
+	}
+
+	[Fact]
+	public void TargetNodesChange_RefreshesExistingCustomStateItemOptions()
+	{
+		// Arrange
+		var sourceDefinition = CreateDefinition("Door", CreateStateItem("Open", Color.Green));
+		var destinationDefinition = CreateDefinition("Door", CreateStateItem("Closed", Color.Red));
+		destinationDefinition.Id = sourceDefinition.Id;
+		var sourceTarget = CreateNode(Guid.NewGuid(), "Source");
+		var destinationTarget = CreateNode(Guid.NewGuid(), "Destination");
+		AddStateModule(sourceTarget, [sourceDefinition]);
+		AddStateModule(destinationTarget, [destinationDefinition]);
+		var effect = new StateEffect
+		{
+			TargetNodes = [sourceTarget],
+			ModuleData = new StateEffectData
+			{
+				SelectedStateDefinitionId = sourceDefinition.Id
+			}
+		};
+		effect.RenderSource = StateRenderSource.Custom;
+		var row = Assert.Single(effect.CustomStateItems);
+		var changedProperties = new List<string?>();
+		row.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+		// Act
+		effect.TargetNodes = [destinationTarget];
+
+		// Assert
+		Assert.Contains(nameof(CustomStateItem.StateItem), changedProperties);
+		Assert.Contains("Closed", effect.GetCustomStateItemOptions(row));
+	}
+
+	[Fact]
 	public void SelectCustomStateItem_ResetsColorToSelectedStateItemColor()
 	{
 		// Arrange

--- a/src/Vixen.Tests/Effects/DissolveTargetDepthTests.cs
+++ b/src/Vixen.Tests/Effects/DissolveTargetDepthTests.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel;
+using System.Reflection;
+using Moq;
+using Vixen.Module.Effect;
+using Vixen.Module.Property;
+using Vixen.Sys;
+using VixenModules.Effect.Dissolve;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+/// <summary>
+/// Verifies that Dissolve keeps its target-dependent depth selection valid.
+/// </summary>
+public sealed class DissolveTargetDepthTests
+{
+	/// <summary>
+	/// Verifies that moving to a shallower target resets an invalid depth and notifies the editor binding.
+	/// </summary>
+	[Fact]
+	public void TargetChange_NormalizesInvalidDepthAndNotifiesBindings()
+	{
+		// Arrange
+		var effect = new Dissolve { EnableDepth = true };
+		SetTargetNodes(effect, [CreateTargetNode(3)]);
+		effect.DepthOfEffect = 2;
+		var changedProperties = new List<string?>();
+		effect.PropertyChanged += (_, eventArgs) => changedProperties.Add(eventArgs.PropertyName);
+
+		// Act
+		SetTargetNodes(effect, [CreateTargetNode(2)]);
+
+		// Assert
+		Assert.Equal(0, effect.DepthOfEffect);
+		Assert.Contains(nameof(Dissolve.DepthOfEffect), changedProperties);
+	}
+
+	/// <summary>
+	/// Verifies that a stale selector value cannot restore an invalid target depth.
+	/// </summary>
+	[Fact]
+	public void DepthSelection_ReapplyingInvalidValueDoesNotNotifyBindings()
+	{
+		// Arrange
+		var effect = new Dissolve { EnableDepth = true };
+		SetTargetNodes(effect, [CreateTargetNode(2)]);
+		effect.DepthOfEffect = 0;
+		var changedProperties = new List<string?>();
+		effect.PropertyChanged += (_, eventArgs) => changedProperties.Add(eventArgs.PropertyName);
+
+		// Act
+		effect.DepthOfEffect = 2;
+
+		// Assert
+		Assert.Equal(0, effect.DepthOfEffect);
+		Assert.DoesNotContain(nameof(Dissolve.DepthOfEffect), changedProperties);
+	}
+
+	private static IElementNode CreateTargetNode(int maximumChildDepth)
+	{
+		var targetNode = new Mock<IElementNode>();
+		targetNode.SetupGet(node => node.Children).Returns([]);
+		targetNode.SetupGet(node => node.Properties).Returns(new PropertyManager(targetNode.Object));
+		targetNode.Setup(node => node.GetMaxChildDepth()).Returns(maximumChildDepth);
+
+		return targetNode.Object;
+	}
+
+	private static void SetTargetNodes(Dissolve effect, IElementNode[] targetNodes)
+	{
+		var targetNodesField = typeof(EffectModuleInstanceBase).GetField("_targetNodes", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(targetNodesField);
+		targetNodesField.SetValue(effect, targetNodes);
+
+		var targetNodesChanged = typeof(Dissolve).GetMethod("TargetNodesChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(targetNodesChanged);
+		targetNodesChanged.Invoke(effect, []);
+	}
+}

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -261,6 +261,38 @@ public sealed class FireTargetNodeSelectionTests
 	}
 
 	/// <summary>
+	/// Verifies that reapplying the existing target handling does not refresh the property descriptor.
+	/// </summary>
+	[Fact]
+	public void FireProperties_ReapplyingTargetHandlingDoesNotRefreshItsPropertyDescriptor()
+	{
+		// Arrange
+		var effect = new Fire();
+		var refreshCount = 0;
+		RefreshEventHandler refreshed = eventArgs =>
+		{
+			if (ReferenceEquals(eventArgs.ComponentChanged, effect))
+			{
+				refreshCount++;
+			}
+		};
+		TypeDescriptor.Refreshed += refreshed;
+
+		try
+		{
+			// Act
+			effect.TargetNodeHandling = TargetNodeSelection.Group;
+		}
+		finally
+		{
+			TypeDescriptor.Refreshed -= refreshed;
+		}
+
+		// Assert
+		Assert.Equal(0, refreshCount);
+	}
+
+	/// <summary>
 	/// Verifies that Fire's current default location mode renders all leaves under one selected group.
 	/// </summary>
 	[Fact]

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -195,6 +195,39 @@ public sealed class FireTargetNodeSelectionTests
 	}
 
 	/// <summary>
+	/// Verifies that changing depth does not rebuild the property descriptor while a selector binding is updating.
+	/// </summary>
+	[Fact]
+	public void FireProperties_ChangingDepthDoesNotRefreshItsPropertyDescriptor()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		var refreshCount = 0;
+		RefreshEventHandler refreshed = eventArgs =>
+		{
+			if (ReferenceEquals(eventArgs.ComponentChanged, effect))
+			{
+				refreshCount++;
+			}
+		};
+		TypeDescriptor.Refreshed += refreshed;
+
+		try
+		{
+			// Act
+			effect.DepthOfEffect = 1;
+		}
+		finally
+		{
+			TypeDescriptor.Refreshed -= refreshed;
+		}
+
+		// Assert
+		Assert.Equal(0, refreshCount);
+	}
+
+	/// <summary>
 	/// Verifies that Fire's current default location mode renders all leaves under one selected group.
 	/// </summary>
 	[Fact]

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -228,6 +228,39 @@ public sealed class FireTargetNodeSelectionTests
 	}
 
 	/// <summary>
+	/// Verifies that a stale depth selection which normalizes to the existing depth does not notify bindings.
+	/// </summary>
+	[Fact]
+	public void FireProperties_NormalizedStaleDepthDoesNotNotifyBindings()
+	{
+		// Arrange
+		var effect = new Fire();
+		var depthChangedCount = 0;
+		PropertyChangedEventHandler propertyChanged = (_, eventArgs) =>
+		{
+			if (eventArgs.PropertyName == nameof(Fire.DepthOfEffect))
+			{
+				depthChangedCount++;
+			}
+		};
+		effect.PropertyChanged += propertyChanged;
+
+		try
+		{
+			// Act
+			effect.DepthOfEffect = 1;
+		}
+		finally
+		{
+			effect.PropertyChanged -= propertyChanged;
+		}
+
+		// Assert
+		Assert.Equal(0, effect.DepthOfEffect);
+		Assert.Equal(0, depthChangedCount);
+	}
+
+	/// <summary>
 	/// Verifies that Fire's current default location mode renders all leaves under one selected group.
 	/// </summary>
 	[Fact]

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -261,6 +261,44 @@ public sealed class FireTargetNodeSelectionTests
 	}
 
 	/// <summary>
+	/// Verifies that changing targets notifies bindings when target normalization changes the selected depth.
+	/// </summary>
+	[Fact]
+	public void FireProperties_TargetChangeNormalizingDepthNotifiesBindings()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		InvokeTargetNodesChanged(effect);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+		SetPropertyValue(effect, "DepthOfEffect", 2);
+		var depthChangedCount = 0;
+		PropertyChangedEventHandler propertyChanged = (_, eventArgs) =>
+		{
+			if (eventArgs.PropertyName == nameof(Fire.DepthOfEffect))
+			{
+				depthChangedCount++;
+			}
+		};
+		effect.PropertyChanged += propertyChanged;
+
+		try
+		{
+			// Act
+			SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(3)]);
+			InvokeTargetNodesChanged(effect);
+		}
+		finally
+		{
+			effect.PropertyChanged -= propertyChanged;
+		}
+
+		// Assert
+		Assert.Equal(1, effect.DepthOfEffect);
+		Assert.Equal(1, depthChangedCount);
+	}
+
+	/// <summary>
 	/// Verifies that reapplying the existing target handling does not refresh the property descriptor.
 	/// </summary>
 	[Fact]
@@ -490,6 +528,13 @@ public sealed class FireTargetNodeSelectionTests
 		var targetNodesField = typeof(EffectModuleInstanceBase).GetField("_targetNodes", BindingFlags.Instance | BindingFlags.NonPublic);
 		Assert.NotNull(targetNodesField);
 		targetNodesField.SetValue(effect, targetNodes);
+	}
+
+	private static void InvokeTargetNodesChanged(Fire effect)
+	{
+		var targetNodesChanged = typeof(Fire).GetMethod("TargetNodesChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(targetNodesChanged);
+		targetNodesChanged.Invoke(effect, []);
 	}
 
 	private sealed class RenderTrackingFire : Fire

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -221,6 +221,58 @@ public sealed class FireTargetNodeSelectionTests
 			intents.ElementIds.OrderBy(id => id));
 	}
 
+	/// <summary>
+	/// Verifies that individual depth groups use separate local location buffers.
+	/// </summary>
+	[Fact]
+	public void FireRender_IndividualDepthGroupsUseLocalLocationBuffers()
+	{
+		// Arrange
+		var firstGroup = CreateGroupNode("Group 1", CreateLocatedLeaf("Group 1 Leaf 1", 1, 1), CreateLocatedLeaf("Group 1 Leaf 2", 3, 1));
+		var secondGroup = CreateGroupNode("Group 2", CreateLocatedLeaf("Group 2 Leaf 1", 101, 1), CreateLocatedLeaf("Group 2 Leaf 2", 103, 1));
+		var effect = new RenderTrackingFire
+		{
+			TargetPositioning = TargetPositioningType.Locations,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateGroupNode("Root", [firstGroup, secondGroup], 3)]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+		SetPropertyValue(effect, "DepthOfEffect", 1);
+
+		// Act
+		var preRenderSucceeded = effect.PreRender();
+
+		// Assert
+		Assert.True(preRenderSucceeded);
+		Assert.Equal([(3, 1), (3, 1)], effect.RenderDimensions);
+	}
+
+	/// <summary>
+	/// Verifies that individually selected target roots are not combined into one location buffer.
+	/// </summary>
+	[Fact]
+	public void FireRender_IndividualMultipleTargetsUseSeparateLocationBuffers()
+	{
+		// Arrange
+		var firstTarget = CreateGroupNode("Target 1", CreateLocatedLeaf("Target 1 Leaf 1", 1, 1), CreateLocatedLeaf("Target 1 Leaf 2", 3, 1));
+		var secondTarget = CreateGroupNode("Target 2", CreateLocatedLeaf("Target 2 Leaf 1", 101, 1), CreateLocatedLeaf("Target 2 Leaf 2", 103, 1));
+		var effect = new RenderTrackingFire
+		{
+			TargetPositioning = TargetPositioningType.Locations,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		SetTargetNodesWithoutPropertyValidation(effect, [firstTarget, secondTarget]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+
+		// Act
+		var preRenderSucceeded = effect.PreRender();
+
+		// Assert
+		Assert.True(preRenderSucceeded);
+		Assert.Equal([(3, 1), (3, 1)], effect.RenderDimensions);
+		Assert.Equal(0, effect.DepthOfEffect);
+	}
+
 	private static FireData DeserializeJson(string json)
 	{
 		var serializer = new DataContractJsonSerializer(typeof(FireData));
@@ -272,12 +324,17 @@ public sealed class FireTargetNodeSelectionTests
 
 	private static IElementNode CreateGroupNode(string name, params IElementNode[] children)
 	{
+		return CreateGroupNode(name, children, children.Any() ? children.Max(child => child.GetMaxChildDepth()) + 1 : 0);
+	}
+
+	private static IElementNode CreateGroupNode(string name, IElementNode[] children, int maxChildDepth)
+	{
 		var targetNode = new Mock<IElementNode>();
 		targetNode.SetupGet(node => node.Name).Returns(name);
 		targetNode.SetupGet(node => node.Children).Returns(children);
 		targetNode.SetupGet(node => node.Properties).Returns(new PropertyManager(targetNode.Object));
 		targetNode.Setup(node => node.GetLeafEnumerator()).Returns(children.SelectMany(child => child.GetLeafEnumerator()));
-		targetNode.Setup(node => node.GetMaxChildDepth()).Returns(children.Max(child => child.GetMaxChildDepth()) + 1);
+		targetNode.Setup(node => node.GetMaxChildDepth()).Returns(maxChildDepth);
 
 		return targetNode.Object;
 	}
@@ -335,5 +392,16 @@ public sealed class FireTargetNodeSelectionTests
 		var targetNodesField = typeof(EffectModuleInstanceBase).GetField("_targetNodes", BindingFlags.Instance | BindingFlags.NonPublic);
 		Assert.NotNull(targetNodesField);
 		targetNodesField.SetValue(effect, targetNodes);
+	}
+
+	private sealed class RenderTrackingFire : Fire
+	{
+		public List<(int Width, int Height)> RenderDimensions { get; } = [];
+
+		protected override void SetupRender()
+		{
+			RenderDimensions.Add((BufferWi, BufferHt));
+			base.SetupRender();
+		}
 	}
 }

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -93,6 +93,27 @@ public sealed class FireTargetNodeSelectionTests
 	}
 
 	/// <summary>
+	/// Verifies that deserialization normalizes invalid target settings.
+	/// </summary>
+	[Fact]
+	public void FireData_OnDeserializedNormalizesInvalidTargetSettings()
+	{
+		// Arrange
+		var data = new FireData
+		{
+			DepthOfEffect = -1,
+			TargetNodeSelection = (TargetNodeSelection)99
+		};
+
+		// Act
+		data.OnDeserialized(default);
+
+		// Assert
+		Assert.Equal(0, data.DepthOfEffect);
+		Assert.Equal(TargetNodeSelection.Group, data.TargetNodeSelection);
+	}
+
+	/// <summary>
 	/// Verifies that a deep target exposes handling selection while group mode hides its depth picker.
 	/// </summary>
 	[Fact]
@@ -132,6 +153,45 @@ public sealed class FireTargetNodeSelectionTests
 		// Assert
 		Assert.NotNull(depthOfEffect);
 		Assert.True(depthOfEffect.IsBrowsable);
+	}
+
+	/// <summary>
+	/// Verifies that Fire depth choices exclude leaf-equivalent values.
+	/// </summary>
+	[Fact]
+	public void FireDepthConverter_ExcludesZeroAndMaximumDepth()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		var context = new Mock<ITypeDescriptorContext>();
+		context.SetupGet(typeDescriptorContext => typeDescriptorContext.Instance).Returns(effect);
+		var converter = new FireTargetElementDepthConverter();
+
+		// Act
+		var values = converter.GetStandardValues(context.Object).Cast<string>().ToArray();
+
+		// Assert
+		Assert.Equal(["1", "2"], values);
+	}
+
+	/// <summary>
+	/// Verifies that an invalid individual target depth resets to the first useful depth.
+	/// </summary>
+	[Fact]
+	public void FireProperties_IndividualModeResetsMaximumDepthToFirstUsefulDepth()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+
+		// Act
+		SetPropertyValue(effect, "DepthOfEffect", 3);
+		var depthOfEffect = GetIntValue(effect, "DepthOfEffect");
+
+		// Assert
+		Assert.Equal(1, depthOfEffect);
 	}
 
 	/// <summary>

--- a/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/FireTargetNodeSelectionTests.cs
@@ -1,0 +1,279 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using Moq;
+using Vixen.Module.Effect;
+using Vixen.Module.Property;
+using Vixen.Sys;
+using VixenModules.Effect.Effect;
+using VixenModules.Effect.Fire;
+using VixenModules.Property.Location;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+/// <summary>
+/// Characterizes the Fire target-node selection contract and preserves its group-mode location rendering.
+/// </summary>
+public sealed class FireTargetNodeSelectionTests
+{
+	/// <summary>
+	/// Verifies that a new Fire effect defaults to across-target handling at depth zero.
+	/// </summary>
+	[Fact]
+	public void Fire_DefaultsToGroupTargetHandlingAndDepthZero()
+	{
+		// Arrange
+		var effect = new Fire();
+
+		// Act
+		var targetNodeHandling = GetTargetNodeSelectionValue(effect, "TargetNodeHandling");
+		var depthOfEffect = GetIntValue(effect, "DepthOfEffect");
+
+		// Assert
+		Assert.Equal(TargetNodeSelection.Group, targetNodeHandling);
+		Assert.Equal(0, depthOfEffect);
+	}
+
+	/// <summary>
+	/// Verifies that new Fire data defaults to across-target handling at depth zero.
+	/// </summary>
+	[Fact]
+	public void FireData_DefaultsToGroupTargetSelectionAndDepthZero()
+	{
+		// Arrange
+		var data = new FireData();
+
+		// Act
+		var targetNodeSelection = GetTargetNodeSelectionValue(data, "TargetNodeSelection");
+		var depthOfEffect = GetIntValue(data, "DepthOfEffect");
+
+		// Assert
+		Assert.Equal(TargetNodeSelection.Group, targetNodeSelection);
+		Assert.Equal(0, depthOfEffect);
+	}
+
+	/// <summary>
+	/// Verifies that Fire persists the target-handling settings.
+	/// </summary>
+	[Fact]
+	public void FireData_TargetSelectionFieldsAreSerialized()
+	{
+		// Arrange
+		var dataType = typeof(FireData);
+
+		// Act
+		var targetNodeSelection = GetRequiredProperty(dataType, "TargetNodeSelection");
+		var depthOfEffect = GetRequiredProperty(dataType, "DepthOfEffect");
+
+		// Assert
+		Assert.Contains(targetNodeSelection.GetCustomAttributes(), attribute => attribute is DataMemberAttribute);
+		Assert.Contains(depthOfEffect.GetCustomAttributes(), attribute => attribute is DataMemberAttribute);
+	}
+
+	/// <summary>
+	/// Verifies that data saved before target-handling settings existed retains compatible defaults.
+	/// </summary>
+	[Fact]
+	public void FireData_LegacyPayloadDefaultsToGroupTargetSelectionAndDepthZero()
+	{
+		// Arrange
+		const string legacyJson = @"{""Location"":0}";
+
+		// Act
+		var data = DeserializeJson(legacyJson);
+		var targetNodeSelection = GetTargetNodeSelectionValue(data, "TargetNodeSelection");
+		var depthOfEffect = GetIntValue(data, "DepthOfEffect");
+
+		// Assert
+		Assert.Equal(TargetNodeSelection.Group, targetNodeSelection);
+		Assert.Equal(0, depthOfEffect);
+	}
+
+	/// <summary>
+	/// Verifies that a deep target exposes handling selection while group mode hides its depth picker.
+	/// </summary>
+	[Fact]
+	public void FireProperties_DeepSingleTargetShowsTargetHandlingButHidesDepthInGroupMode()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(3)]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Group);
+
+		// Act
+		var properties = TypeDescriptor.GetProperties(effect);
+		var targetNodeHandling = properties["TargetNodeHandling"];
+		var depthOfEffect = properties["DepthOfEffect"];
+
+		// Assert
+		Assert.NotNull(targetNodeHandling);
+		Assert.True(targetNodeHandling.IsBrowsable);
+		Assert.NotNull(depthOfEffect);
+		Assert.False(depthOfEffect.IsBrowsable);
+	}
+
+	/// <summary>
+	/// Verifies that a deep individual target exposes the useful target-depth picker.
+	/// </summary>
+	[Fact]
+	public void FireProperties_DeepSingleTargetInIndividualModeShowsDepth()
+	{
+		// Arrange
+		var effect = new Fire();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(3)]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+
+		// Act
+		var depthOfEffect = TypeDescriptor.GetProperties(effect)["DepthOfEffect"];
+
+		// Assert
+		Assert.NotNull(depthOfEffect);
+		Assert.True(depthOfEffect.IsBrowsable);
+	}
+
+	/// <summary>
+	/// Verifies that Fire's current default location mode renders all leaves under one selected group.
+	/// </summary>
+	[Fact]
+	public void FireRender_DefaultGroupModeRendersLocatedLeavesTogether()
+	{
+		// Arrange
+		var firstLeaf = CreateLocatedLeaf("Leaf 1", 1, 1);
+		var secondLeaf = CreateLocatedLeaf("Leaf 2", 3, 1);
+		var effect = new Fire
+		{
+			TargetPositioning = TargetPositioningType.Locations,
+			TimeSpan = TimeSpan.FromMilliseconds(1000)
+		};
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateGroupNode("Parent", firstLeaf, secondLeaf)]);
+
+		// Act
+		var preRenderSucceeded = effect.PreRender();
+		var intents = effect.Render();
+
+		// Assert
+		Assert.True(preRenderSucceeded);
+		Assert.Equal(
+			new[] { firstLeaf.Element.Id, secondLeaf.Element.Id }.OrderBy(id => id),
+			intents.ElementIds.OrderBy(id => id));
+	}
+
+	private static FireData DeserializeJson(string json)
+	{
+		var serializer = new DataContractJsonSerializer(typeof(FireData));
+		using var readStream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+		return (FireData)serializer.ReadObject(readStream)!;
+	}
+
+	private static TargetNodeSelection GetTargetNodeSelectionValue(object instance, string propertyName)
+	{
+		var property = GetRequiredProperty(instance.GetType(), propertyName);
+		var value = property.GetValue(instance);
+
+		Assert.IsType<TargetNodeSelection>(value);
+		return (TargetNodeSelection)value!;
+	}
+
+	private static int GetIntValue(object instance, string propertyName)
+	{
+		var property = GetRequiredProperty(instance.GetType(), propertyName);
+		var value = property.GetValue(instance);
+
+		Assert.IsType<int>(value);
+		return (int)value!;
+	}
+
+	private static void SetPropertyValue(object instance, string propertyName, object value)
+	{
+		GetRequiredProperty(instance.GetType(), propertyName).SetValue(instance, value);
+	}
+
+	private static PropertyInfo GetRequiredProperty(Type type, string propertyName)
+	{
+		var property = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+
+		Assert.NotNull(property);
+		return property;
+	}
+
+	private static IElementNode CreateTargetNode(int maxChildDepth)
+	{
+		var targetNode = new Mock<IElementNode>();
+		targetNode.SetupGet(node => node.Children).Returns([]);
+		targetNode.SetupGet(node => node.Properties).Returns(new PropertyManager(targetNode.Object));
+		targetNode.Setup(node => node.GetMaxChildDepth()).Returns(maxChildDepth);
+
+		return targetNode.Object;
+	}
+
+	private static IElementNode CreateGroupNode(string name, params IElementNode[] children)
+	{
+		var targetNode = new Mock<IElementNode>();
+		targetNode.SetupGet(node => node.Name).Returns(name);
+		targetNode.SetupGet(node => node.Children).Returns(children);
+		targetNode.SetupGet(node => node.Properties).Returns(new PropertyManager(targetNode.Object));
+		targetNode.Setup(node => node.GetLeafEnumerator()).Returns(children.SelectMany(child => child.GetLeafEnumerator()));
+		targetNode.Setup(node => node.GetMaxChildDepth()).Returns(children.Max(child => child.GetMaxChildDepth()) + 1);
+
+		return targetNode.Object;
+	}
+
+	private static IElementNode CreateLocatedLeaf(string name, int x, int y)
+	{
+		var leafNode = new Mock<IElementNode>();
+		var properties = new PropertyManager(leafNode.Object);
+		var locationModule = new LocationModule
+		{
+			Descriptor = new LocationDescriptor(),
+			ModuleData = new LocationData
+			{
+				X = x,
+				Y = y,
+				Z = 0
+			}
+		};
+		AddPropertyWithoutModuleStore(properties, locationModule);
+
+		leafNode.SetupGet(node => node.Element).Returns(CreateElement(name));
+		leafNode.SetupGet(node => node.Id).Returns(Guid.NewGuid());
+		leafNode.SetupGet(node => node.Name).Returns(name);
+		leafNode.SetupGet(node => node.Children).Returns([]);
+		leafNode.SetupGet(node => node.IsLeaf).Returns(true);
+		leafNode.SetupGet(node => node.Properties).Returns(properties);
+		leafNode.Setup(node => node.GetLeafEnumerator()).Returns([leafNode.Object]);
+		leafNode.Setup(node => node.GetMaxChildDepth()).Returns(0);
+
+		return leafNode.Object;
+	}
+
+	private static Element CreateElement(string name)
+	{
+		var constructor = typeof(Element).GetConstructor(
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[typeof(string)],
+			null);
+
+		Assert.NotNull(constructor);
+		return (Element)constructor.Invoke([name]);
+	}
+
+	private static void AddPropertyWithoutModuleStore(PropertyManager properties, IPropertyModuleInstance property)
+	{
+		var itemsField = typeof(PropertyManager).GetField("_items", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(itemsField);
+		var items = (Dictionary<Guid, IPropertyModuleInstance>)itemsField.GetValue(properties)!;
+		items[property.TypeId] = property;
+	}
+
+	private static void SetTargetNodesWithoutPropertyValidation(Fire effect, IElementNode[] targetNodes)
+	{
+		var targetNodesField = typeof(EffectModuleInstanceBase).GetField("_targetNodes", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(targetNodesField);
+		targetNodesField.SetValue(effect, targetNodes);
+	}
+}

--- a/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
@@ -200,6 +200,36 @@ public sealed class WipeTargetNodeSelectionTests
 		Assert.Equal(1, depthOfEffect);
 	}
 
+	[Fact]
+	public void WipeProperties_ChangingDepthDoesNotRefreshItsPropertyDescriptor()
+	{
+		// Arrange
+		var effect = new WipeModule();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		var refreshCount = 0;
+		RefreshEventHandler refreshed = eventArgs =>
+		{
+			if (ReferenceEquals(eventArgs.ComponentChanged, effect))
+			{
+				refreshCount++;
+			}
+		};
+		TypeDescriptor.Refreshed += refreshed;
+
+		try
+		{
+			// Act
+			effect.DepthOfEffect = 1;
+		}
+		finally
+		{
+			TypeDescriptor.Refreshed -= refreshed;
+		}
+
+		// Assert
+		Assert.Equal(0, refreshCount);
+	}
+
 	private static WipeData DeserializeJson(string json)
 	{
 		var serializer = new DataContractJsonSerializer(typeof(WipeData));

--- a/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
@@ -230,6 +230,36 @@ public sealed class WipeTargetNodeSelectionTests
 		Assert.Equal(0, refreshCount);
 	}
 
+	[Fact]
+	public void WipeProperties_NormalizedStaleDepthDoesNotNotifyBindings()
+	{
+		// Arrange
+		var effect = new WipeModule();
+		var depthChangedCount = 0;
+		PropertyChangedEventHandler propertyChanged = (_, eventArgs) =>
+		{
+			if (eventArgs.PropertyName == nameof(WipeModule.DepthOfEffect))
+			{
+				depthChangedCount++;
+			}
+		};
+		effect.PropertyChanged += propertyChanged;
+
+		try
+		{
+			// Act
+			effect.DepthOfEffect = 1;
+		}
+		finally
+		{
+			effect.PropertyChanged -= propertyChanged;
+		}
+
+		// Assert
+		Assert.Equal(0, effect.DepthOfEffect);
+		Assert.Equal(0, depthChangedCount);
+	}
+
 	private static WipeData DeserializeJson(string json)
 	{
 		var serializer = new DataContractJsonSerializer(typeof(WipeData));

--- a/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
@@ -261,6 +261,39 @@ public sealed class WipeTargetNodeSelectionTests
 	}
 
 	[Fact]
+	public void WipeProperties_TargetChangeNormalizingDepthNotifiesBindings()
+	{
+		// Arrange
+		var effect = new WipeModule();
+		SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(4)]);
+		SetPropertyValue(effect, "TargetNodeHandling", TargetNodeSelection.Individual);
+		SetPropertyValue(effect, "DepthOfEffect", 2);
+		var depthChangedCount = 0;
+		PropertyChangedEventHandler propertyChanged = (_, eventArgs) =>
+		{
+			if (eventArgs.PropertyName == nameof(WipeModule.DepthOfEffect))
+			{
+				depthChangedCount++;
+			}
+		};
+		effect.PropertyChanged += propertyChanged;
+
+		try
+		{
+			// Act
+			SetTargetNodesWithoutPropertyValidation(effect, [CreateTargetNode(3)]);
+		}
+		finally
+		{
+			effect.PropertyChanged -= propertyChanged;
+		}
+
+		// Assert
+		Assert.Equal(1, effect.DepthOfEffect);
+		Assert.Equal(1, depthChangedCount);
+	}
+
+	[Fact]
 	public void WipeProperties_ReapplyingTargetHandlingDoesNotRefreshItsPropertyDescriptor()
 	{
 		// Arrange

--- a/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/WipeTargetNodeSelectionTests.cs
@@ -260,6 +260,35 @@ public sealed class WipeTargetNodeSelectionTests
 		Assert.Equal(0, depthChangedCount);
 	}
 
+	[Fact]
+	public void WipeProperties_ReapplyingTargetHandlingDoesNotRefreshItsPropertyDescriptor()
+	{
+		// Arrange
+		var effect = new WipeModule();
+		var refreshCount = 0;
+		RefreshEventHandler refreshed = eventArgs =>
+		{
+			if (ReferenceEquals(eventArgs.ComponentChanged, effect))
+			{
+				refreshCount++;
+			}
+		};
+		TypeDescriptor.Refreshed += refreshed;
+
+		try
+		{
+			// Act
+			effect.TargetNodeHandling = TargetNodeSelection.Group;
+		}
+		finally
+		{
+			TypeDescriptor.Refreshed -= refreshed;
+		}
+
+		// Assert
+		Assert.Equal(0, refreshCount);
+	}
+
 	private static WipeData DeserializeJson(string json)
 	{
 		var serializer = new DataContractJsonSerializer(typeof(WipeData));

--- a/src/Vixen.Tests/Vixen.Tests.csproj
+++ b/src/Vixen.Tests/Vixen.Tests.csproj
@@ -32,6 +32,7 @@
 		<ProjectReference Include="..\Vixen.Modules\App\LivePreview\LivePreview.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\App\Marks\Marks.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Chase\Chase.csproj" />
+		<ProjectReference Include="..\Vixen.Modules\Effect\Dissolve\Dissolve.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\Fire\Fire.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\LipSync\LipSync.csproj" />
 		<ProjectReference Include="..\Vixen.Modules\Effect\PinWheel\PinWheel.csproj" />


### PR DESCRIPTION
### Summary

- Adds **Across Elements/Groups** and **Each Element/Group** targeting to Fire for both string and preview-location rendering, preserving the current across-target behavior for existing sequences.
- Adds target-depth validation and rendering isolation so each selected group receives an independent Fire buffer when using individual targeting.
- Fixes property-grid selector re-entrancy by replacing blanket standard-value refreshes with coalesced, idle-dispatch refreshes scoped to the affected property when possible.
- Ensures dynamic Depth, State Item, and Mark Collection choices refresh correctly after dependent values or targets change.
- Normalizes stale depth selections when an effect is moved to a shallower target, including Dissolve, Fire, and Wipe.

### Validation

- Full solution build passed.
- All unit tests passed.
- Manual regression testing passed for:
  - Fire and Wipe target handling/depth behavior
  - Dissolve shallower-target drag behavior
  - State and State Item refreshes
  - Fixture property selectors
  - Mark Collection selectors
  - Waveform and Vertical Meter depth behavior

### Notes

The property-grid cleanup avoids rebuilding unrelated selector item sources during a property commit, preventing stale values from being reapplied while preserving dynamic option lists.