### PR TITLE
VIX-3996 Auto select the preview type when there is only one

### DIFF
--- a/src/Vixen.Application/ConfigPreviews.Designer.cs
+++ b/src/Vixen.Application/ConfigPreviews.Designer.cs
@@ -174,7 +174,7 @@
 			this.buttonAddController.TabIndex = 2;
 			this.buttonAddController.Text = "Add New Preview";
 			this.buttonAddController.UseVisualStyleBackColor = false;
-			this.buttonAddController.Click += new System.EventHandler(this.buttonAddController_Click);
+			this.buttonAddController.Click += new System.EventHandler(this.buttonAddPreview_Click);
 			// 
 			// buttonCancel
 			// 

--- a/src/Vixen.Application/ConfigPreviews.cs
+++ b/src/Vixen.Application/ConfigPreviews.cs
@@ -43,36 +43,46 @@ namespace VixenApplication
 			buttonDuplicateSelected.Enabled = buttonDeleteController.Enabled = listViewControllers.SelectedItems.Count > 0;
 		}
 
-		private void buttonAddController_Click(object sender, EventArgs e)
+		private void buttonAddPreview_Click(object sender, EventArgs e)
 		{
 			List<KeyValuePair<string, object>> outputModules = new List<KeyValuePair<string, object>>();
 			var availableModules = ApplicationServices.GetAvailableModules<IPreviewModuleInstance>();
-			foreach (KeyValuePair<Guid, string> kvp in availableModules)
+			var previewToAddKey = availableModules.Any()?availableModules.First().Key:Guid.Empty;
+			
+			if (outputModules.Count > 1)
 			{
-				outputModules.Add(new KeyValuePair<string, object>(kvp.Value, kvp.Key));
-			}
-			ListSelectDialog addForm = new ListSelectDialog("Add Preview", (outputModules));
-			if (addForm.ShowDialog() == DialogResult.OK)
-			{
-				IModuleDescriptor moduleDescriptor = ApplicationServices.GetModuleDescriptor((Guid)addForm.SelectedItem);
-				string name = moduleDescriptor.TypeName;
-				PreviewFactory previewFactory = new PreviewFactory();
-				OutputPreview preview = (OutputPreview)previewFactory.CreateDevice((Guid)addForm.SelectedItem, name);
-				VixenSystem.Previews.Add(preview);
-				// In the case of a controller that has a form, the form will not be shown
-				// until this event handler completes.  To make sure it's in a visible state
-				// before evaluating if it's running or not, we're calling DoEvents.
-				// I hate DoEvents calls, so if you know of a better way...
-				Application.DoEvents();
+				foreach (KeyValuePair<Guid, string> kvp in availableModules)
+				{
+					outputModules.Add(new KeyValuePair<string, object>(kvp.Value, kvp.Key));
+				}
+				ListSelectDialog addForm = new ListSelectDialog("Add Preview", outputModules);
+				if (addForm.ShowDialog() != DialogResult.OK)
+				{
+					return;
+				}
 
-				// select the new controller, and then repopulate the list -- it will make sure the currently
-				// displayed controller is selected.
-				_PopulateFormWithController(preview);
-				_PopulateControllerList();
-
-				_changesMade = true;
-				Refresh();
+				previewToAddKey = (Guid)addForm.SelectedItem;
 			}
+			
+			IModuleDescriptor moduleDescriptor = ApplicationServices.GetModuleDescriptor(previewToAddKey);
+			string name = moduleDescriptor.TypeName;
+			PreviewFactory previewFactory = new PreviewFactory();
+			OutputPreview preview = (OutputPreview)previewFactory.CreateDevice(previewToAddKey, name);
+			VixenSystem.Previews.Add(preview);
+			// In the case of a controller that has a form, the form will not be shown
+			// until this event handler completes.  To make sure it's in a visible state
+			// before evaluating if it's running or not, we're calling DoEvents.
+			// I hate DoEvents calls, so if you know of a better way...
+			Application.DoEvents();
+
+			// select the new controller, and then repopulate the list -- it will make sure the currently
+			// displayed controller is selected.
+			_PopulateFormWithController(preview);
+			_PopulateControllerList();
+
+			_changesMade = true;
+			Refresh();
+			
 		}
 
 		private void buttonDeleteController_Click(object sender, EventArgs e)


### PR DESCRIPTION
Currently there is only one Preview type in Vixen, so the dialog to prompt the user to choose only has one selection. This is a waste of the users time. Add logic to skip the dialog when only one preview type exists.