### PR TITLE
VIX-3995 Add state-aware mark collection defaults

### DIFF
--- a/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
+++ b/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
@@ -12,8 +12,7 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 
 - [x] (2026-09-01 17:49Z) Updated Jira issue VIX-3995 with the user-facing requirements, acceptance criteria, and regression intent; status remains New Ticket. Evidence: https://vixenlights.atlassian.net/browse/VIX-3995 (updated 2026-09-01 12:49:27.792-05:00).
 - [x] (2026-09-01 18:08Z) Completed Milestone 2: appended documented `State = 4`, included State labels in export defaults, and added enum, native serialization, docker-menu/non-linkability, export-default, and external-timing classification regression coverage. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused `MarkCollectionTypeTests` and `PangolinBeyondMarkImportTests` filter passed 22 of 22 tests.
-- [ ] Add the documented, stateless Core selection contract and selection service.
-- [ ] Move mark-collection lifecycle normalization into `BaseEffect` and migrate effect-specific lifecycle work to its template hooks.
+- [x] (2026-09-01 18:05Z) Completed Milestone 3: added the documented, stateless Core selection contract/service and established `BaseEffect` as the sealed collection-lifecycle template. Migrated ten existing effect callback implementations to post-normalization hooks without adding policies yet. BaseEffect shares one immutable service instance across all effects. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused selection-service and BaseEffect lifecycle filter passed 15 of 15 tests.
 - [ ] Apply the State, ordinary, LipSync, Wave, and Liquid policies without changing persisted State effect data.
 - [ ] Add unit and integration-path regression tests; run the required Release/x64 test workflow.
 - [ ] Update VIX-3995 with final acceptance and validation results; record the final outcome in this plan.
@@ -28,6 +27,9 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 
 - Observation: Wave and Liquid retain child selection IDs around a name-list refresh, but their current update routines do not choose defaults for empty child IDs.
   Evidence: `Wave.UpdateMarkCollectionNames` and `Liquid.UpdateMarkCollectionNames` update child display names; Waveform and Emitter data preserve `MarkCollectionId` separately.
+
+- Observation: Ten effects currently override one or more collection lifecycle callbacks to manage listeners or refresh display names.
+  Evidence: `rg` found callbacks in Alternating, Dissolve, Fireworks, LipSync, Liquid, Shapes, State, Strobe, Text, and Wave; all now use BaseEffect's post-normalization hooks.
 
 ## Decision Log
 
@@ -46,6 +48,10 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 - Decision: Normalize only on mark-collection assignment and collection change notifications, plus the relevant effect-data/default application lifecycle. Never normalize during `_Render`, `RenderEffect`, or per-frame mark queries.
   Rationale: This keeps work at O(active selection slots × collections), avoids render-loop healing, and permits reading the shared `ObservableCollection` without mutating it.
   Date/Author: 2026-09-01 / Codex, from the approved performance/threading requirements.
+
+- Decision: Keep the template lifecycle policy-neutral until individual effects declare their active selections in Milestone 4.
+  Rationale: Moving every existing callback behind the sealed BaseEffect route first preserves listener and name-refresh behavior while preventing any effect from bypassing normalization once its policy is introduced.
+  Date/Author: 2026-09-01 / Codex, during Milestone 3 implementation.
 
 - Decision: Retain the existing LipSync rule: choose the first Phoneme collection when an active LipSync selector is empty or stale, otherwise choose `null`/`Guid.Empty` if there is no Phoneme collection. Do not fall back to Generic.
   Rationale: This is intentional existing behavior and differs from ordinary and State policies.
@@ -216,3 +222,7 @@ Revision note (2026-09-01 / Codex): Created from the approved VIX-3995 handoff a
 Revision note (2026-09-01 / Codex): Completed Milestone 1 by replacing VIX-3995's description with the approved user-facing Summary, Scope, and acceptance criteria. The issue remains in New Ticket; no transition or implementation work was performed.
 
 Revision note (2026-09-01 / Codex): Completed Milestone 2 by appending the documented State collection type, preserving all historic enum values, adding State export-text defaults, and adding focused persistence and docker behavior regression coverage. No collection-link behavior or external timing-import classification logic was changed.
+
+Revision note (2026-09-01 / Codex): Completed Milestone 3 by introducing the Core mark-collection selection contract and stateless policy service, then centralizing lifecycle normalization in sealed BaseEffect callbacks. Existing effect-specific listener and display-refresh callbacks now run through protected post-normalization hooks; effect policies remain deliberately deferred to Milestone 4.
+
+Revision note (2026-09-01 / Codex): Reused one static readonly MarkCollectionSelectionService from BaseEffect because the service has no per-effect state. This removes one otherwise unnecessary allocation per effect instance without changing its policy or threading behavior.

--- a/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
+++ b/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
@@ -11,7 +11,7 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 ## Progress
 
 - [x] (2026-09-01 17:49Z) Updated Jira issue VIX-3995 with the user-facing requirements, acceptance criteria, and regression intent; status remains New Ticket. Evidence: https://vixenlights.atlassian.net/browse/VIX-3995 (updated 2026-09-01 12:49:27.792-05:00).
-- [ ] Add the `State` enum value, its XML documentation, and serialization/menu/export coverage.
+- [x] (2026-09-01 18:08Z) Completed Milestone 2: appended documented `State = 4`, included State labels in export defaults, and added enum, native serialization, docker-menu/non-linkability, export-default, and external-timing classification regression coverage. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused `MarkCollectionTypeTests` and `PangolinBeyondMarkImportTests` filter passed 22 of 22 tests.
 - [ ] Add the documented, stateless Core selection contract and selection service.
 - [ ] Move mark-collection lifecycle normalization into `BaseEffect` and migrate effect-specific lifecycle work to its template hooks.
 - [ ] Apply the State, ordinary, LipSync, Wave, and Liquid policies without changing persisted State effect data.
@@ -214,3 +214,5 @@ No new NuGet packages, dispatcher usage, UI service registration, serialization 
 Revision note (2026-09-01 / Codex): Created from the approved VIX-3995 handoff after source research. This is a planning-only change; no product implementation was performed.
 
 Revision note (2026-09-01 / Codex): Completed Milestone 1 by replacing VIX-3995's description with the approved user-facing Summary, Scope, and acceptance criteria. The issue remains in New Ticket; no transition or implementation work was performed.
+
+Revision note (2026-09-01 / Codex): Completed Milestone 2 by appending the documented State collection type, preserving all historic enum values, adding State export-text defaults, and adding focused persistence and docker behavior regression coverage. No collection-link behavior or external timing-import classification logic was changed.

--- a/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
+++ b/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
@@ -14,8 +14,8 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 - [x] (2026-09-01 18:08Z) Completed Milestone 2: appended documented `State = 4`, included State labels in export defaults, and added enum, native serialization, docker-menu/non-linkability, export-default, and external-timing classification regression coverage. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused `MarkCollectionTypeTests` and `PangolinBeyondMarkImportTests` filter passed 22 of 22 tests.
 - [x] (2026-09-01 18:05Z) Completed Milestone 3: added the documented, stateless Core selection contract/service and established `BaseEffect` as the sealed collection-lifecycle template. Migrated ten existing effect callback implementations to post-normalization hooks without adding policies yet. BaseEffect shares one immutable service instance across all effects. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused selection-service and BaseEffect lifecycle filter passed 15 of 15 tests.
 - [x] (2026-09-01 19:11Z) Completed Milestone 4 implementation: bound ordinary policies to all ten scrubbed mark selectors, State preference to State, LipSync preference to Phoneme without generic fallback, and Wave/Liquid policies to active child models. `BaseEffect` now detaches removed collection listeners before repairing IDs and refreshes listeners after an add/remove repair. No serialized data model or default-exclusion attribute changed. Validation: Release/x64 `Vixen_Tests` build succeeded; the focused selection and BaseEffect lifecycle filter passed 15 of 15 tests.
-- [ ] Add unit and integration-path regression tests; run the required Release/x64 test workflow.
-- [ ] Update VIX-3995 with final acceptance and validation results; record the final outcome in this plan.
+- [ ] Add the remaining State/LipSync/Wave/Liquid lifecycle integration-path regressions described in Milestone 4. The shared-policy, BaseEffect lifecycle, enum, serialization, docker, and import regressions already exist; the full suite is green.
+- [x] (2026-09-01 20:30Z) Completed Milestone 5 automated validation and Jira closeout: Release/x64 `Vixen_Tests` MSBuild succeeded and `dotnet test --no-build --no-restore` passed 898 of 898 tests (0 failed, 0 skipped). Added VIX-3995 comment 40429 with the result; the issue remains In Progress and was not transitioned. The headless environment cannot perform the required Timed Sequence Editor walkthrough, so that manual verification remains a residual risk.
 
 ## Surprises & Discoveries
 
@@ -30,6 +30,9 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 
 - Observation: Ten effects currently override one or more collection lifecycle callbacks to manage listeners or refresh display names.
   Evidence: `rg` found callbacks in Alternating, Dissolve, Fireworks, LipSync, Liquid, Shapes, State, Strobe, Text, and Wave; all now use BaseEffect's post-normalization hooks.
+
+- Observation: Changing State mark mode before the sequence supplies `MarkCollections` caused the new post-normalization listener refresh to enumerate a null list.
+  Evidence: the initial Release/x64 full test run failed `StateDataTests.RenderSource_MarkCollectionBrowsability_ShowsOnlyMarkCollectionSelector` and `CycleOffset_IterateBrowsability_ShowsForEveryRenderSource` with `ArgumentNullException` from `State.GetSelectedMarkCollection`. Guarding the immediate State and LipSync refresh until a collection list exists restored the pre-existing no-sequence behavior; the final suite passed 898 of 898 tests.
 
 ## Decision Log
 
@@ -69,9 +72,15 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
   Rationale: A collection reference is sequence-local. The collection's own persisted `CollectionType` already carries the new enum value; repair is local to each effect instance.
   Date/Author: 2026-09-01 / Codex, from the approved data and isolation requirements.
 
+- Decision: On a State or LipSync mode change, refresh selection listeners immediately only when the effect has received a mark collection list.
+  Rationale: Normalization is intentionally a no-op without sequence-owned collections, and a listener refresh cannot identify a selected collection until that list exists. The later BaseEffect collection lifecycle callback still performs the normal repair and listener setup.
+  Date/Author: 2026-09-01 / Codex, during Milestone 5 validation.
+
 ## Outcomes & Retrospective
 
-Not started. On completion, replace this paragraph with the implemented behavior, the exact test/build results, any deviations cross-referenced to the Decision Log, and remaining risks. Add a dated note at the end of this plan for every revision and why it was made.
+Milestones 1 through 4 delivered a persisted `State = 4` mark collection type, State docker defaults, a stateless ID-only selection service, central BaseEffect lifecycle normalization, and policies for State, ordinary selectors, LipSync, Wave, and Liquid. Validation exposed and corrected a no-sequence State/LipSync mode-switch regression. The Release/x64 `Vixen_Tests` build succeeded, and the final already-built test run passed 898 of 898 tests with no failures or skips. VIX-3995 received closeout comment 40429 and remains In Progress without a transition.
+
+The unperformed manual Timed Sequence Editor walkthrough remains the residual risk because this session has no interactive WPF desktop. The focused State/LipSync/Wave/Liquid lifecycle integration scenarios listed in Milestone 4 also remain explicitly tracked work; existing unit, docker, serialization, import, service, BaseEffect lifecycle, and full-suite coverage passed.
 
 ## Context and Orientation
 
@@ -236,3 +245,5 @@ Revision note (2026-09-01 / Codex): Completed Milestone 3 by introducing the Cor
 Revision note (2026-09-01 / Codex): Reused one static readonly MarkCollectionSelectionService from BaseEffect because the service has no per-effect state. This removes one otherwise unnecessary allocation per effect instance without changing its policy or threading behavior.
 
 Revision note (2026-09-01 / Codex): Completed Milestone 4 implementation by making active effect and child-model selectors directly declare their policies. State and LipSync mode changes now normalize through the shared ID-only lifecycle rather than selecting by display name; removal cleanup remains in BaseEffect so normalization cannot hide the removed selection from listener management.
+
+Revision note (2026-09-01 / Codex): Performed Milestone 5 automated validation and added the Jira closeout comment. The full suite initially exposed a null mark-collection-list mode-switch regression, which was fixed before the final 898/898 pass. The required interactive editor walkthrough could not run in the headless environment and remains recorded as residual risk.

--- a/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
+++ b/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
@@ -13,7 +13,7 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 - [x] (2026-09-01 17:49Z) Updated Jira issue VIX-3995 with the user-facing requirements, acceptance criteria, and regression intent; status remains New Ticket. Evidence: https://vixenlights.atlassian.net/browse/VIX-3995 (updated 2026-09-01 12:49:27.792-05:00).
 - [x] (2026-09-01 18:08Z) Completed Milestone 2: appended documented `State = 4`, included State labels in export defaults, and added enum, native serialization, docker-menu/non-linkability, export-default, and external-timing classification regression coverage. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused `MarkCollectionTypeTests` and `PangolinBeyondMarkImportTests` filter passed 22 of 22 tests.
 - [x] (2026-09-01 18:05Z) Completed Milestone 3: added the documented, stateless Core selection contract/service and established `BaseEffect` as the sealed collection-lifecycle template. Migrated ten existing effect callback implementations to post-normalization hooks without adding policies yet. BaseEffect shares one immutable service instance across all effects. Validation: `msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m` succeeded; the focused selection-service and BaseEffect lifecycle filter passed 15 of 15 tests.
-- [ ] Apply the State, ordinary, LipSync, Wave, and Liquid policies without changing persisted State effect data.
+- [x] (2026-09-01 19:11Z) Completed Milestone 4 implementation: bound ordinary policies to all ten scrubbed mark selectors, State preference to State, LipSync preference to Phoneme without generic fallback, and Wave/Liquid policies to active child models. `BaseEffect` now detaches removed collection listeners before repairing IDs and refreshes listeners after an add/remove repair. No serialized data model or default-exclusion attribute changed. Validation: Release/x64 `Vixen_Tests` build succeeded; the focused selection and BaseEffect lifecycle filter passed 15 of 15 tests.
 - [ ] Add unit and integration-path regression tests; run the required Release/x64 test workflow.
 - [ ] Update VIX-3995 with final acceptance and validation results; record the final outcome in this plan.
 
@@ -52,6 +52,14 @@ The result is observable in the Timed Sequence Editor: State appears in the coll
 - Decision: Keep the template lifecycle policy-neutral until individual effects declare their active selections in Milestone 4.
   Rationale: Moving every existing callback behind the sealed BaseEffect route first preserves listener and name-refresh behavior while preventing any effect from bypassing normalization once its policy is introduced.
   Date/Author: 2026-09-01 / Codex, during Milestone 3 implementation.
+
+- Decision: Let each effect or active Wave/Liquid child model implement `IMarkCollectionSelection` directly instead of allocating a per-effect selection adapter.
+  Rationale: The selection contract maps directly onto existing local Guid state and mode properties, avoiding retained delegate objects for the hundreds of effect instances in a sequence.
+  Date/Author: 2026-09-01 / Codex, during Milestone 4 implementation.
+
+- Decision: Detach removed mark-collection listeners in BaseEffect before ID repair, then invoke the normal changed hook only when repair changed a selection.
+  Rationale: This preserves listener cleanup while ensuring replacement listeners are added after a policy chooses the new ID.
+  Date/Author: 2026-09-01 / Codex, during Milestone 4 implementation.
 
 - Decision: Retain the existing LipSync rule: choose the first Phoneme collection when an active LipSync selector is empty or stale, otherwise choose `null`/`Guid.Empty` if there is no Phoneme collection. Do not fall back to Generic.
   Rationale: This is intentional existing behavior and differs from ordinary and State policies.
@@ -226,3 +234,5 @@ Revision note (2026-09-01 / Codex): Completed Milestone 2 by appending the docum
 Revision note (2026-09-01 / Codex): Completed Milestone 3 by introducing the Core mark-collection selection contract and stateless policy service, then centralizing lifecycle normalization in sealed BaseEffect callbacks. Existing effect-specific listener and display-refresh callbacks now run through protected post-normalization hooks; effect policies remain deliberately deferred to Milestone 4.
 
 Revision note (2026-09-01 / Codex): Reused one static readonly MarkCollectionSelectionService from BaseEffect because the service has no per-effect state. This removes one otherwise unnecessary allocation per effect instance without changing its policy or threading behavior.
+
+Revision note (2026-09-01 / Codex): Completed Milestone 4 implementation by making active effect and child-model selectors directly declare their policies. State and LipSync mode changes now normalize through the shared ID-only lifecycle rather than selecting by display name; removal cleanup remains in BaseEffect so normalization cannot hide the removed selection from listener management.

--- a/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
+++ b/docs/plans/effects/vix-3995-effect-mark-collection-defaults.md
@@ -1,0 +1,216 @@
+# Add State-aware effect mark collection defaults
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. Maintain it in accordance with `.agents/PLANS.md` from the repository root.
+
+## Purpose / Big Picture
+
+VIX-3995 makes a State mark collection a first-class type and gives effects a dependable, sequence-local mark collection selection when their saved selection is empty or has been deleted. A user can tag a marks-docker track as `State`, select State effect mark rendering, and have the State effect choose the first State-tagged track; if none exists, it chooses the first track. Existing user choices always remain unchanged, including a valid generic fallback chosen before a State track is added later.
+
+The result is observable in the Timed Sequence Editor: State appears in the collection-type menu but offers no parent-link menu, State exports include label text by default, and State, ordinary mark-driven effects, LipSync, Wave, and Liquid repair only invalid selections. Automated tests prove the same behavior for effect defaults and a different sequence, so persisted defaults never carry a stale collection identifier.
+
+## Progress
+
+- [x] (2026-09-01 17:49Z) Updated Jira issue VIX-3995 with the user-facing requirements, acceptance criteria, and regression intent; status remains New Ticket. Evidence: https://vixenlights.atlassian.net/browse/VIX-3995 (updated 2026-09-01 12:49:27.792-05:00).
+- [ ] Add the `State` enum value, its XML documentation, and serialization/menu/export coverage.
+- [ ] Add the documented, stateless Core selection contract and selection service.
+- [ ] Move mark-collection lifecycle normalization into `BaseEffect` and migrate effect-specific lifecycle work to its template hooks.
+- [ ] Apply the State, ordinary, LipSync, Wave, and Liquid policies without changing persisted State effect data.
+- [ ] Add unit and integration-path regression tests; run the required Release/x64 test workflow.
+- [ ] Update VIX-3995 with final acceptance and validation results; record the final outcome in this plan.
+
+## Surprises & Discoveries
+
+- Observation: `StateData.MarkCollectionId` already is a `Guid`, is a `[DataMember]`, and is marked `[ExcludeFromEffectDefault]`.
+  Evidence: `src/Vixen.Modules/Effect/State/StateData.cs` stores `Guid.Empty` by default. The established effect-default scrubber deliberately clears sequence-specific mark identifiers, so this issue needs lifecycle repair, not a migration or a default-data exception.
+
+- Observation: State currently tries to discover the not-yet-defined enum member with `Enum.TryParse<MarkCollectionType>("State")`; its fallback activation only assigns when a State collection is found.
+  Evidence: `src/Vixen.Modules/Effect/State/State.cs`, `GetFirstStateMarkCollection` and the `RenderSource` setter.
+
+- Observation: Wave and Liquid retain child selection IDs around a name-list refresh, but their current update routines do not choose defaults for empty child IDs.
+  Evidence: `Wave.UpdateMarkCollectionNames` and `Liquid.UpdateMarkCollectionNames` update child display names; Waveform and Emitter data preserve `MarkCollectionId` separately.
+
+## Decision Log
+
+- Decision: Append `State = 4` to `MarkCollectionType`; explicitly assign all existing numeric values `Generic = 0`, `Phrase = 1`, `Word = 2`, and `Phoneme = 3`.
+  Rationale: Serialized enum values must retain their established meaning. Appending preserves every existing stored value.
+  Date/Author: 2026-09-01 / Codex, from the approved VIX-3995 handoff.
+
+- Decision: Treat an existing selection as valid solely when its non-empty `Guid` occurs in the current sequence's collection list. Do not require its collection type to match a policy.
+  Rationale: A user-selected generic, word, or any other valid collection is intentional and must not be replaced because a preferred State or Phoneme collection exists.
+  Date/Author: 2026-09-01 / Codex, from the authoritative clarification.
+
+- Decision: Put the reusable selection policy in `Vixen.Core/Marks` as a stateless service, and make `BaseEffect` own when normalization runs.
+  Rationale: Collection type and IDs are Core concepts; policy selection must be unit-testable without WPF or a dispatcher. `BaseEffect` is the common base already responsible for mark listeners, while individual effects retain only their active-slot declaration and listener/display-name details.
+  Date/Author: 2026-09-01 / Codex, informed by the repository's .NET design and documentation guidance.
+
+- Decision: Normalize only on mark-collection assignment and collection change notifications, plus the relevant effect-data/default application lifecycle. Never normalize during `_Render`, `RenderEffect`, or per-frame mark queries.
+  Rationale: This keeps work at O(active selection slots × collections), avoids render-loop healing, and permits reading the shared `ObservableCollection` without mutating it.
+  Date/Author: 2026-09-01 / Codex, from the approved performance/threading requirements.
+
+- Decision: Retain the existing LipSync rule: choose the first Phoneme collection when an active LipSync selector is empty or stale, otherwise choose `null`/`Guid.Empty` if there is no Phoneme collection. Do not fall back to Generic.
+  Rationale: This is intentional existing behavior and differs from ordinary and State policies.
+  Date/Author: 2026-09-01 / Codex, from the approved regression requirements.
+
+- Decision: Do not alter `StateData.MarkCollectionId`, remove `[ExcludeFromEffectDefault]`, add a State-data migration, or rewrite shared collection metadata such as names, types, order, links, tags, marks, or visibility.
+  Rationale: A collection reference is sequence-local. The collection's own persisted `CollectionType` already carries the new enum value; repair is local to each effect instance.
+  Date/Author: 2026-09-01 / Codex, from the approved data and isolation requirements.
+
+## Outcomes & Retrospective
+
+Not started. On completion, replace this paragraph with the implemented behavior, the exact test/build results, any deviations cross-referenced to the Decision Log, and remaining risks. Add a dated note at the end of this plan for every revision and why it was made.
+
+## Context and Orientation
+
+A mark collection is one named, ordered timeline track in a sequence. It has an immutable-in-practice identity (`IMarkCollection.Id`, a `Guid`) and a `CollectionType`. Effect data stores only the `Guid`; display-name properties and type converters exist for the editor UI but must never be used to commit a default selection because names can be duplicated or renamed.
+
+`src/Vixen.Core/Marks/IMarkType.cs` currently declares `MarkCollectionType` without explicit numeric values. `src/Vixen.Core/Marks/IMarkCollection.cs` exposes a collection's `Id`, `CollectionType`, marks, ordering, and links. `src/Vixen.Modules/App/Marks/MarkCollection.cs` is the concrete sequence-owned implementation whose persisted collection type will naturally serialize the new enum member.
+
+`src/Vixen.Core/Module/Effect/EffectModuleInstanceBase.cs` receives the sequence's shared `ObservableCollection<IMarkCollection>` and raises `MarkCollectionsChanged`, `MarkCollectionsAdded`, and `MarkCollectionsRemoved`. `src/Vixen.Modules/Effect/Effect/BaseEffect.cs` supplies the common mark-listener helpers and is the intended Template Method owner for this ticket. A Template Method is a base-class-controlled lifecycle sequence that calls small derived-class hooks; it prevents each effect from reimplementing selection validity and fallback rules inconsistently.
+
+The State effect is `src/Vixen.Modules/Effect/State/State.cs`; it is active for collection normalization only when `RenderSource == StateRenderSource.MarkCollection`. Its data remains in `StateData.cs`. LipSync is active only in `LipSyncMode.MarkCollection` and has an intentional Phoneme-only fallback. Wave owns multiple `IWaveform` children and Liquid owns multiple `IEmitter` children, each with its own `Guid MarkCollectionId`; normalize each active child separately. CountDown has no mark collection selector and is explicitly out of scope.
+
+The marks docker uses Catel view models. `MarkCollectionViewModel.SetupCollectionTypeCheckboxes` enumerates `Enum.GetValues`, so no menu-specific State branch is needed. Its link switch defaults unrecognized types to Generic, which makes State non-linkable and must remain so. `MarkCollectionExportRowViewModel` initializes export options and must include State labels as text by default. Native import/export must preserve State through existing `CollectionType` persistence; do not change classifications assigned by external timing importers.
+
+`src/Vixen.Core/Services/EffectDefaults/EffectDefaultScrubber.cs` removes fields decorated with `[ExcludeFromEffectDefault]`. The creation seam documented in `docs/plans/effects/vix-3964-effect-default-settings.md` applies scrubbed module data to a newly-created effect. Once the effect receives the destination sequence's mark collection list, the new lifecycle normalization must repair the empty selection locally.
+
+## Plan of Work
+
+### Milestone 1 — Record the approved user-facing contract in Jira
+
+Use the Jira connector to read VIX-3995 before editing it. Update its description using the repository Jira format: a concise Summary, Scope, and Given/When/Then acceptance criteria. Describe State-tagged collection selection, valid-selection preservation, State text export, and the fact that State tracks are non-linkable. Mention regression coverage succinctly, but do not expose source file names or internal service design. Do not transition the issue. Record the issue's current status and a link or update timestamp in this plan's Progress section.
+
+This milestone is independently verifiable by re-reading VIX-3995: a reviewer can understand what a user gains and how it is accepted without reading this plan.
+
+### Milestone 2 — Add the State collection type and docker/persistence coverage
+
+Edit `src/Vixen.Core/Marks/IMarkType.cs`. Add XML documentation for `MarkCollectionType` and every member, explicitly assigning the stable values: `Generic = 0`, `Phrase = 1`, `Word = 2`, `Phoneme = 3`, then append `State = 4`. Do not reorder members or use a migration.
+
+Edit `src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionExportRowViewModel.cs` so `IsTextIncluded` defaults to `true` for State as well as Phrase, Word, and Phoneme. Leave `MarkCollectionViewModel.SetupCollectionTypeCheckboxes` enumeration unchanged, and leave `SetupLinkedToCheckboxes`' default-to-Generic behavior unchanged; State must therefore show in the type menu and have `IsLinkableType == false`.
+
+Locate existing native collection serialization and import/export tests under `src/Vixen.Tests/Sequencer`. Add focused tests to prove all old enum integer values, `State == 4`, and a native persisted `MarkCollection` round-trip preserves `CollectionType == State`. Add marks-docker view-model tests that create a State collection and assert it appears among checkbox states, has no link candidates/is non-linkable, and creates an export row with `IsTextIncluded == true`. Keep external importer fixtures and classifications unchanged; add only a regression proving an externally classified collection remains its existing type if a relevant test seam already exists.
+
+Acceptance for this milestone is a State type visible in the docker and serializable without changing any historic type number.
+
+### Milestone 3 — Create the Core selection contract and BaseEffect lifecycle template
+
+Create `src/Vixen.Core/Marks/IMarkCollectionSelection.cs` and `src/Vixen.Core/Marks/MarkCollectionSelectionService.cs`, adding them to `Vixen.Core.csproj` only if the project does not use SDK default compile globs. Both public types and their public members require complete XML documentation.
+
+Make `IMarkCollectionSelection` the documented policy contract consumed by the base lifecycle. It must describe a selection as: the effect-local `Guid` getter/setter to normalize, whether that slot is currently active, its preferred collection type (or no preference), and whether it may use first-collection fallback. The contract must also make clear that it owns no shared collection state. Model the service as stateless—no static mutable state, caches, UI services, dispatcher calls, `TypeDescriptor.Refresh`, collection subscriptions, or writes to `IMarkCollection`.
+
+Give `MarkCollectionSelectionService` one documented operation that receives the current ordered collection sequence and an `IMarkCollectionSelection`, then returns/commits only an `IMarkCollection.Id` or `Guid.Empty`. The precise public signature should be selected to match repository style, but it must express these deterministic rules:
+
+    1. If the slot is inactive, do nothing.
+    2. If its non-empty ID matches any current collection ID, leave it unchanged regardless of collection type.
+    3. Otherwise, choose the first collection with the requested preferred type, when one is requested.
+    4. Otherwise, if the policy allows fallback, choose the first collection in current collection order.
+    5. Otherwise set/retain `Guid.Empty`.
+
+Use IDs and `IMarkCollection` instances throughout this operation. Do not call display-name setters or search by name. Enumerate only enough to satisfy the rule and treat the existing `ObservableCollection` as read-only. A straightforward scan per active slot is acceptable and is the required O(slots × collections) bound.
+
+Refactor `BaseEffect.cs` to override the three collection lifecycle callbacks inherited from `EffectModuleInstanceBase` and make those overrides the stable Template Method. It must normalize active slots before or at the same lifecycle point as effect-specific listener/display updates, mark the effect dirty only when an effect-local selection actually changes, and then invoke protected derived hooks for the legacy effect-specific work. Replace affected derived overrides of `MarkCollectionsChanged`, `MarkCollectionsAdded`, and `MarkCollectionsRemoved` with those new hooks so they cannot bypass normalization. Preserve existing listener attach/detach and name-refresh behavior. Do not put this shared behavior in `EffectModuleInstanceBase`, which is broader than the basic effects covered by the ticket.
+
+Add service-level xUnit tests in a new focused file under `src/Vixen.Tests/Effects` (or the existing Marks test grouping if it is the established Core test location). Test ordinary first-collection policy, State preference then first fallback, Phoneme preference with no fallback, valid ID preservation across every policy, missing non-empty ID repair, no-collection result, and that collection type/name/order/link/tag fields are not changed. Use concrete `MarkCollection` instances with deliberately distinct IDs and names to prove identity—not text—controls selection.
+
+Acceptance is a direct test run proving deterministic selection policy without WPF or rendering, and a `BaseEffect` lifecycle that has one normalization route.
+
+### Milestone 4 — Bind policies to effects without data migration
+
+Implement the ordinary policy for each active single-selector basic effect already deriving from `BaseEffect`: an empty or missing `Guid` selects the first sequence collection, and a valid ID remains untouched. Declare only slots that the effect is actively using; an inactive mode must neither receive a default nor be cleared. Audit the current mark-using effects listed in the effect-default scrubber and their lifecycle overrides, rather than assuming every `MarkCollectionId` is active in every mode.
+
+For `State.cs`, replace `Enum.TryParse<MarkCollectionType>("State")` with direct `MarkCollectionType.State`. Remove the ad hoc name-based fallback in the `RenderSource` setter and feed the active State slot to the shared lifecycle with preferred type `State` and first-collection fallback enabled. Keep listener management, but commit the chosen `Guid` directly to `_data.MarkCollectionId`; the display-name property remains UI conversion only. A valid Generic ID persists when State collections are later inserted. On removal, the BaseEffect lifecycle sees the missing ID and selects the next State collection in sequence order, otherwise the first remaining collection; it reaches `Guid.Empty` only when the sequence has no collections. Preserve `[ExcludeFromEffectDefault]` and `StateData` exactly.
+
+For `LipSync.cs`, replace pre-render/default and removal repair with the shared active-slot policy: preferred type `Phoneme`, no first-collection fallback. Preserve the existing converter behavior that lists a valid legacy non-Phoneme choice beside Phoneme choices; normalization must not invalidate a valid legacy selection. In particular, do not make LipSync fall back to Generic when a phoneme track is absent.
+
+For `Wave.cs` and `Liquid.cs`, declare one ordinary-policy selection per active child selector, respectively each `IWaveform` and each `IEmitter` that is in its mark-controlled mode. Normalize children independently, including after defaults/cross-sequence module data creates empty IDs and after deletion. Reuse their existing display-name/listener refresh routines only after IDs are repaired; do not let a name refresh silently clear or replace a valid ID. CountDown is unchanged because it declares no selection.
+
+Add effect integration tests. For State, cover: valid collection preservation irrespective of type; first State selection; Generic first fallback when no State exists; selected collection removal choosing next State then first remaining; and adding State after a valid Generic fallback causing no reselection. Exercise the effect-default/cross-sequence path by applying scrubbed State default data to a fresh State effect, supplying another sequence's ordered collections, and asserting its active State slot repairs as described. Add equivalent empty/missing ID and valid-preservation regressions for LipSync, Wave, and Liquid. If Wave/Liquid are not referenced by `Vixen.Tests.csproj`, add project references that follow repository convention (`Copy Local = No`, `Include Assets = None`) before writing their direct tests; do not use reflection to avoid a missing test reference.
+
+Every test must snapshot shared collection IDs, names, `CollectionType`, `LinkedMarkCollectionId`, order, and mark content before normalization, then assert they are identical afterwards. Only the effect-local selected IDs may change.
+
+Acceptance is a stateful effect-level test suite that proves selection repairs occur on lifecycle events, not in rendering, and that one child slot cannot overwrite another.
+
+### Milestone 5 — Validate, document results, and close the Jira loop
+
+Run the narrow test filters while iterating, then use the repository's full-MSBuild workflow because the test project has C++/CLI transitive dependencies. From `C:\Dev\Vixen`, run:
+
+    msbuild Vixen.sln -m -restore -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:m
+
+    dotnet test src/Vixen.Tests/Vixen.Tests.csproj -c Release --no-build --no-restore -p:Platform=x64 -p:SolutionDir="$(Get-Location)\\"
+
+The first command must build `Vixen_Tests` successfully; the second must report all tests passed. Also build the Release/x64 solution if the changed Core/module project graph is not fully covered by the test target:
+
+    msbuild Vixen.sln -m -t:restore -t:Rebuild -p:Configuration=Release -p:Platform=x64 -v:m
+
+Perform a manual Timed Sequence Editor walkthrough: create ordered Generic and State tracks; tag the State track; verify State is non-linkable; add a State effect in Mark Collection mode; remove its selected State track; add a State track after a valid Generic fallback; and export the State collection with default text inclusion. Observe the selection rules stated in Purpose / Big Picture and no unexpected collection mutations.
+
+Update VIX-3995 only if the final user-facing scope differs from Milestone 1, then add a concise closeout comment containing user-visible result, exact automated command outcome/counts, manual walkthrough result, and residual risk. Do not transition the issue. Update every living-plan section and append a dated revision note before handoff. If a milestone changes repository files, use the repository `commit-msg` skill to include its formatted proposed commit message in the completion response, but do not commit unless explicitly requested.
+
+## Concrete Steps
+
+1. Before edits, run `git status --short` in `C:\Dev\Vixen`; preserve all unrelated changes.
+2. Complete Milestone 1 through Milestone 5 in order. After each milestone, update Progress with a UTC timestamp, record discoveries/decisions, run that milestone's focused tests, and write a proposed conventional commit message in the milestone response when code changed.
+3. Use `rg` to find every `MarkCollectionId`, every `MarkCollectionsChanged`/`Added`/`Removed` override, and every collection importer before changing lifecycle code. Re-read each file that will be edited; do not mechanically modify unrelated effects.
+4. Use `apply_patch` for source and plan edits. Keep tabs and LF line endings per `src/.editorconfig`; do not reformat unrelated legacy code.
+
+Expected final test transcript shape:
+
+    Build succeeded.
+    Passed!  - Failed: 0, Passed: <updated total>, Skipped: 0, Total: <updated total>
+
+The exact passed total must be recorded rather than guessed in the final plan/Jira comment.
+
+## Validation and Acceptance
+
+Automated acceptance requires tests for enum number stability, State serialization, marks-docker menu/link/export defaults, shared selection rules, and the State/LipSync/Wave/Liquid lifecycle cases named above. A test that simply calls render is insufficient; include assignment, add, remove, and default/cross-sequence repair paths. The new State tests must fail before the change because `MarkCollectionType.State` does not exist and State cannot select it.
+
+Human acceptance requires these visible results:
+
+- State is offered as a collection type; it has no linking choices.
+- A State-mark-rendering effect with no selection uses the first State track, or the first track when none is State.
+- A valid selected track remains selected after a preferred State track is added.
+- Removing the selected track selects the next State track, otherwise the first remaining track.
+- Exporting a State track starts with mark text included.
+- A State default created in one sequence does not retain that sequence's ID in another; it selects from the destination sequence using the stated policy.
+
+## Idempotence and Recovery
+
+The source changes are additive or local refactors and can be re-run safely. No data migration, profile rewrite, or shared collection mutation is permitted. If a lifecycle refactor causes listener regressions, restore the pre-existing listener/name-refresh work inside the new BaseEffect hooks while retaining the centralized ID-only normalization; do not reintroduce per-effect policy copies. If a test project reference is required for Wave or Liquid, add it once with repository reference metadata and rerun restore; do not substitute a DLL reference.
+
+If build output is stale, rerun the full `Vixen_Tests` MSBuild command before `dotnet test --no-build`. If a Jira update fails due to credentials, leave code untouched, record the failure in this plan, and report it for user action; the local plan and implementation work can still be validated.
+
+## Artifacts and Notes
+
+The essential selection algorithm to preserve in code and tests is:
+
+    Normalize(slot, collections):
+        if slot is inactive:
+            return unchanged
+        if slot.Id is non-empty and collections contains collection.Id == slot.Id:
+            return unchanged
+        preferred = first collection where CollectionType == slot.PreferredType
+        if preferred exists:
+            slot.Id = preferred.Id
+        else if slot.AllowsFirstCollectionFallback:
+            slot.Id = collections.FirstOrDefault()?.Id ?? Guid.Empty
+        else:
+            slot.Id = Guid.Empty
+
+For State, `PreferredType` is `MarkCollectionType.State` and fallback is enabled. For ordinary active slots, no preferred type and fallback is enabled. For LipSync, `PreferredType` is `MarkCollectionType.Phoneme` and fallback is disabled. This order is intentional: validity always wins before preference.
+
+## Interfaces and Dependencies
+
+In `src/Vixen.Core/Marks/IMarkCollectionSelection.cs`, create a public, XML-documented interface representing one effect-local selectable mark-collection slot. Its final contract must make these members available to `BaseEffect`/the service: whether the slot is active, the current selected `Guid`, the optional preferred `MarkCollectionType`, and whether first-collection fallback is allowed. The setter writes only to the owning effect or child model; it must never write to an `IMarkCollection`.
+
+In `src/Vixen.Core/Marks/MarkCollectionSelectionService.cs`, create a public, XML-documented stateless service implementing a documented normalization method conceptually equivalent to:
+
+    Guid Normalize(IReadOnlyList<IMarkCollection> collections, IMarkCollectionSelection selection)
+
+The concrete signature may return a selected `IMarkCollection?` and let `BaseEffect` commit `.Id`, but it must preserve the exact rules in Artifacts and Notes and must not identify collections by name. Keep dependencies limited to Core `Vixen.Marks` contracts and BCL collection types.
+
+In `src/Vixen.Modules/Effect/Effect/BaseEffect.cs`, add the protected lifecycle extension points that expose active `IMarkCollectionSelection` slots and derived post-normalization collection-change handling. `BaseEffect` must be the only class calling the service in normal effect lifecycle. Derived effects declare policy/active slots and retain listeners/UI notifications only through the hooks.
+
+No new NuGet packages, dispatcher usage, UI service registration, serialization schema version, or State-data migration is allowed.
+
+Revision note (2026-09-01 / Codex): Created from the approved VIX-3995 handoff after source research. This is a planning-only change; no product implementation was performed.
+
+Revision note (2026-09-01 / Codex): Completed Milestone 1 by replacing VIX-3995's description with the approved user-facing Summary, Scope, and acceptance criteria. The issue remains in New Ticket; no transition or implementation work was performed.

--- a/src/Vixen.Core/Marks/IMarkCollectionSelection.cs
+++ b/src/Vixen.Core/Marks/IMarkCollectionSelection.cs
@@ -1,0 +1,35 @@
+namespace Vixen.Marks
+{
+	/// <summary>
+	/// Represents an effect-local mark collection selection that can be normalized against a sequence's collections.
+	/// </summary>
+	/// <remarks>
+	/// Implementations own only effect or child-model state. They must not modify the shared <see cref="IMarkCollection" /> instances supplied to the selection service.
+	/// </remarks>
+	public interface IMarkCollectionSelection
+	{
+		/// <summary>
+		/// Gets a value that indicates whether this selection participates in collection normalization.
+		/// </summary>
+		/// <value><see langword="true" /> if the effect is currently using this selection; otherwise, <see langword="false" />.</value>
+		bool IsActive { get; }
+
+		/// <summary>
+		/// Gets or sets the identifier of the selected mark collection.
+		/// </summary>
+		/// <value>The identifier stored by the owning effect or child model, or <see cref="Guid.Empty" /> when no collection is selected.</value>
+		Guid MarkCollectionId { get; set; }
+
+		/// <summary>
+		/// Gets the collection type preferred when the current selection is missing.
+		/// </summary>
+		/// <value>The preferred collection type, or <see langword="null" /> when no type is preferred.</value>
+		MarkCollectionType? PreferredCollectionType { get; }
+
+		/// <summary>
+		/// Gets a value that indicates whether the first collection may be used when no preferred collection is available.
+		/// </summary>
+		/// <value><see langword="true" /> to select the first collection when needed; otherwise, <see langword="false" />.</value>
+		bool AllowsFirstCollectionFallback { get; }
+	}
+}

--- a/src/Vixen.Core/Marks/IMarkType.cs
+++ b/src/Vixen.Core/Marks/IMarkType.cs
@@ -1,10 +1,33 @@
 ﻿namespace Vixen.Marks
 {
+	/// <summary>
+	/// Defines the semantic purpose of a mark collection.
+	/// </summary>
 	public enum MarkCollectionType
 	{
-		Generic,
-		Phrase,
-		Word,
-		Phoneme,
+		/// <summary>
+		/// Represents a general-purpose mark collection.
+		/// </summary>
+		Generic = 0,
+
+		/// <summary>
+		/// Represents a phrase-level mark collection.
+		/// </summary>
+		Phrase = 1,
+
+		/// <summary>
+		/// Represents a word-level mark collection.
+		/// </summary>
+		Word = 2,
+
+		/// <summary>
+		/// Represents a phoneme-level mark collection.
+		/// </summary>
+		Phoneme = 3,
+
+		/// <summary>
+		/// Represents a state-label mark collection.
+		/// </summary>
+		State = 4,
 	}
 }

--- a/src/Vixen.Core/Marks/MarkCollectionSelectionService.cs
+++ b/src/Vixen.Core/Marks/MarkCollectionSelectionService.cs
@@ -1,0 +1,52 @@
+namespace Vixen.Marks
+{
+	/// <summary>
+	/// Selects an appropriate mark collection identifier for an effect-local selection.
+	/// </summary>
+	/// <remarks>
+	/// This service is stateless. It reads the supplied collection sequence without subscribing to or modifying it, and returns only a collection identifier for the owning effect to commit.
+	/// </remarks>
+	public sealed class MarkCollectionSelectionService
+	{
+		/// <summary>
+		/// Normalizes a selection against the supplied collections in their existing order.
+		/// </summary>
+		/// <param name="markCollections">The ordered shared mark collections to inspect.</param>
+		/// <param name="selection">The effect-local selection to evaluate.</param>
+		/// <returns>The existing identifier when it is active and valid; otherwise, a preferred or fallback collection identifier, or <see cref="Guid.Empty" /> when no collection may be selected.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="markCollections" /> or <paramref name="selection" /> is <see langword="null" />.</exception>
+		public Guid Normalize(IEnumerable<IMarkCollection> markCollections, IMarkCollectionSelection selection)
+		{
+			ArgumentNullException.ThrowIfNull(markCollections);
+			ArgumentNullException.ThrowIfNull(selection);
+
+			if (!selection.IsActive)
+			{
+				return selection.MarkCollectionId;
+			}
+
+			IMarkCollection firstCollection = null;
+			IMarkCollection preferredCollection = null;
+			foreach (var markCollection in markCollections)
+			{
+				firstCollection ??= markCollection;
+				if (markCollection.Id == selection.MarkCollectionId && selection.MarkCollectionId != Guid.Empty)
+				{
+					return selection.MarkCollectionId;
+				}
+
+				if (preferredCollection == null && markCollection.CollectionType == selection.PreferredCollectionType)
+				{
+					preferredCollection = markCollection;
+				}
+			}
+
+			if (preferredCollection != null)
+			{
+				return preferredCollection.Id;
+			}
+
+			return selection.AllowsFirstCollectionFallback ? firstCollection?.Id ?? Guid.Empty : Guid.Empty;
+		}
+	}
+}

--- a/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionExportRowViewModel.cs
+++ b/src/Vixen.Modules/Editor/TimedSequenceEditor/Forms/WPF/MarksDocker/ViewModels/MarkCollectionExportRowViewModel.cs
@@ -11,7 +11,7 @@ namespace TimedSequenceEditor.Forms.WPF.MarksDocker.ViewModels
 			MarkCollection = markCollection;
 			IsIncluded = true;
 			//Default to including text on the types that have text
-			IsTextIncluded = markCollection.CollectionType is MarkCollectionType.Phrase or MarkCollectionType.Word or MarkCollectionType.Phoneme;
+			IsTextIncluded = markCollection.CollectionType is MarkCollectionType.Phrase or MarkCollectionType.Word or MarkCollectionType.Phoneme or MarkCollectionType.State;
 		}
 
 		#region MarkCollection property

--- a/src/Vixen.Modules/Effect/Alternating/Alternating.cs
+++ b/src/Vixen.Modules/Effect/Alternating/Alternating.cs
@@ -12,7 +12,7 @@ using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Alternating
 {
-	public class Alternating : BaseEffect
+	public class Alternating : BaseEffect, IMarkCollectionSelection
 	{
 		private EffectIntents _elementData;
 		private AlternatingData _data;
@@ -116,6 +116,17 @@ namespace VixenModules.Effect.Alternating
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => AlternatingMode == AlternatingMode.MarkCollection;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		#region Color
 

--- a/src/Vixen.Modules/Effect/Alternating/Alternating.cs
+++ b/src/Vixen.Modules/Effect/Alternating/Alternating.cs
@@ -153,6 +153,10 @@ namespace VixenModules.Effect.Alternating
 
 		#region Config
 
+		/// <summary>
+		/// Gets or sets the timing source used by the alternating effect.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the timing source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[DisplayName(@"Timing Source")]
@@ -170,6 +174,7 @@ namespace VixenModules.Effect.Alternating
 				{
 					_data.AlternatingMode = value;
 					UpdateAlternatingModeAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/Alternating/Alternating.cs
+++ b/src/Vixen.Modules/Effect/Alternating/Alternating.cs
@@ -476,7 +476,7 @@ namespace VixenModules.Effect.Alternating
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (AlternatingMode == AlternatingMode.MarkCollection)
 			{
@@ -486,7 +486,7 @@ namespace VixenModules.Effect.Alternating
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
+++ b/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
@@ -942,7 +942,7 @@ namespace VixenModules.Effect.Dissolve
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (DissolveMode == DissolveMode.MarkCollection)
 			{
@@ -952,7 +952,7 @@ namespace VixenModules.Effect.Dissolve
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
+++ b/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
@@ -266,6 +266,10 @@ namespace VixenModules.Effect.Dissolve
 
 		#region Config
 
+		/// <summary>
+		/// Gets or sets the timing source used by the dissolve effect.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the timing source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[ProviderDisplayName(@"TimingSource")]
@@ -283,6 +287,7 @@ namespace VixenModules.Effect.Dissolve
 				{
 					_data.DissolveMode = value;
 					UpdateDissolveModeAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
+++ b/src/Vixen.Modules/Effect/Dissolve/Dissolve.cs
@@ -13,7 +13,7 @@ using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Dissolve
 {
-	public class Dissolve : BaseEffect
+	public class Dissolve : BaseEffect, IMarkCollectionSelection
 	{
 		private EffectIntents _elementData;
 		private DissolveData _data;
@@ -181,6 +181,17 @@ namespace VixenModules.Effect.Dissolve
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => DissolveMode == DissolveMode.MarkCollection;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		#region Color
 

--- a/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
+++ b/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
@@ -17,6 +17,7 @@ namespace VixenModules.Effect.Effect
 	public abstract class BaseEffect : EffectModuleInstanceBase
 	{
 		private bool _hasDiscreteColors;
+		private static readonly MarkCollectionSelectionService MarkCollectionSelectionService = new();
 		protected int FrameTime;
 		protected TimeSpan FrameTimespan;
 
@@ -27,6 +28,77 @@ namespace VixenModules.Effect.Effect
 		}
 		
 		protected abstract EffectTypeModuleData EffectModuleData { get; }
+
+		/// <summary>
+		/// Gets the effect-local mark collection selections that participate in lifecycle normalization.
+		/// </summary>
+		/// <returns>The active and inactive selections owned by this effect.</returns>
+		protected virtual IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			return [];
+		}
+
+		/// <summary>
+		/// Handles effect-specific work after mark collection assignment or reset notifications are normalized.
+		/// </summary>
+		protected virtual void MarkCollectionsChangedCore()
+		{
+		}
+
+		/// <summary>
+		/// Handles effect-specific work after added mark collections are normalized.
+		/// </summary>
+		/// <param name="addedCollections">The collections added to the shared sequence collection.</param>
+		protected virtual void MarkCollectionsAddedCore(IList<IMarkCollection> addedCollections)
+		{
+		}
+
+		/// <summary>
+		/// Handles effect-specific work after removed mark collections are normalized.
+		/// </summary>
+		/// <param name="removedCollections">The collections removed from the shared sequence collection.</param>
+		protected virtual void MarkCollectionsRemovedCore(IList<IMarkCollection> removedCollections)
+		{
+		}
+
+		/// <inheritdoc />
+		protected sealed override void MarkCollectionsChanged()
+		{
+			NormalizeMarkCollectionSelections();
+			MarkCollectionsChangedCore();
+		}
+
+		/// <inheritdoc />
+		protected sealed override void MarkCollectionsAdded(IList<IMarkCollection> addedCollections)
+		{
+			NormalizeMarkCollectionSelections();
+			MarkCollectionsAddedCore(addedCollections);
+		}
+
+		/// <inheritdoc />
+		protected sealed override void MarkCollectionsRemoved(IList<IMarkCollection> removedCollections)
+		{
+			NormalizeMarkCollectionSelections();
+			MarkCollectionsRemovedCore(removedCollections);
+		}
+
+		private void NormalizeMarkCollectionSelections()
+		{
+			if (MarkCollections == null)
+			{
+				return;
+			}
+
+			foreach (var selection in GetMarkCollectionSelections())
+			{
+				var normalizedId = MarkCollectionSelectionService.Normalize(MarkCollections, selection);
+				if (selection.MarkCollectionId != normalizedId)
+				{
+					selection.MarkCollectionId = normalizedId;
+					MarkDirty();
+				}
+			}
+		}
 
 
 		/// <summary>

--- a/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
+++ b/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
@@ -124,6 +124,21 @@ namespace VixenModules.Effect.Effect
 
 			return selectionChanged;
 		}
+
+		/// <summary>
+		/// Normalizes active mark collection selections after an effect mode activates them.
+		/// </summary>
+		/// <remarks>
+		/// This also refreshes effect-specific mark collection listeners when a sequence collection list is available.
+		/// </remarks>
+		protected void ActivateMarkCollectionSelections()
+		{
+			NormalizeMarkCollectionSelections();
+			if (MarkCollections != null)
+			{
+				MarkCollectionsChangedCore();
+			}
+		}
 		/// <summary>
 		/// Indicates if there is any discrete colors assigned to any elements this effect targets. It does not mean all of the elements are discrete if true.
 		/// Each effect should set this if it can work on discrete elements

--- a/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
+++ b/src/Vixen.Modules/Effect/Effect/BaseEffect.cs
@@ -71,23 +71,45 @@ namespace VixenModules.Effect.Effect
 		/// <inheritdoc />
 		protected sealed override void MarkCollectionsAdded(IList<IMarkCollection> addedCollections)
 		{
-			NormalizeMarkCollectionSelections();
+			var selectionChanged = NormalizeMarkCollectionSelections();
 			MarkCollectionsAddedCore(addedCollections);
+			if (selectionChanged)
+			{
+				MarkCollectionsChangedCore();
+			}
 		}
 
 		/// <inheritdoc />
 		protected sealed override void MarkCollectionsRemoved(IList<IMarkCollection> removedCollections)
 		{
-			NormalizeMarkCollectionSelections();
+			foreach (var removedCollection in removedCollections)
+			{
+				RemoveMarkCollectionListeners(removedCollection);
+			}
+
+			var selectionChanged = NormalizeMarkCollectionSelections();
 			MarkCollectionsRemovedCore(removedCollections);
+			if (selectionChanged)
+			{
+				MarkCollectionsChangedCore();
+			}
 		}
 
-		private void NormalizeMarkCollectionSelections()
+		/// <summary>
+		/// Normalizes active effect-local mark collection selections against the current sequence collections.
+		/// </summary>
+		/// <remarks>
+		/// Derived effects use this when a mode change activates a selection outside of a collection lifecycle callback.
+		/// </remarks>
+		/// <returns><see langword="true" /> if one or more effect-local selections changed; otherwise, <see langword="false" />.</returns>
+		protected bool NormalizeMarkCollectionSelections()
 		{
 			if (MarkCollections == null)
 			{
-				return;
+				return false;
 			}
+
+			var selectionChanged = false;
 
 			foreach (var selection in GetMarkCollectionSelections())
 			{
@@ -96,11 +118,12 @@ namespace VixenModules.Effect.Effect
 				{
 					selection.MarkCollectionId = normalizedId;
 					MarkDirty();
+					selectionChanged = true;
 				}
 			}
+
+			return selectionChanged;
 		}
-
-
 		/// <summary>
 		/// Indicates if there is any discrete colors assigned to any elements this effect targets. It does not mean all of the elements are discrete if true.
 		/// Each effect should set this if it can work on discrete elements

--- a/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
+++ b/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
@@ -856,7 +856,7 @@ namespace VixenModules.Effect.Fireworks
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (FireworksSource == FireworksSource.MarkCollection)
 			{
@@ -866,7 +866,7 @@ namespace VixenModules.Effect.Fireworks
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
+++ b/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
@@ -14,7 +14,7 @@ using VixenModules.Media.Audio;
 
 namespace VixenModules.Effect.Fireworks
 {
-	public class Fireworks:PixelEffectBase
+	public class Fireworks:PixelEffectBase, IMarkCollectionSelection
 	{
 		private FireworksData _data;
 		private List<RgbFireworks> _fireworkBursts;
@@ -557,6 +557,17 @@ namespace VixenModules.Effect.Fireworks
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => FireworksSource == FireworksSource.MarkCollection;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		#region Update Attributes
 		private void UpdateAttributes()

--- a/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
+++ b/src/Vixen.Modules/Effect/Fireworks/Fireworks.cs
@@ -35,6 +35,10 @@ namespace VixenModules.Effect.Fireworks
 
 		#region Config
 
+		/// <summary>
+		/// Gets or sets the source used to trigger fireworks bursts.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the trigger source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[ProviderDisplayName(@"FireworksSource")]
@@ -52,6 +56,7 @@ namespace VixenModules.Effect.Fireworks
 				{
 					_data.FireworksSource = value;
 					UpdateAudioAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/LipSync/LipSync.cs
+++ b/src/Vixen.Modules/Effect/LipSync/LipSync.cs
@@ -427,11 +427,7 @@ namespace VixenModules.Effect.LipSync
 				{
 					_data.LipSyncMode = value;
 					SetLipsyncModeBrowsables();
-					NormalizeMarkCollectionSelections();
-					if (MarkCollections != null)
-					{
-						MarkCollectionsChangedCore();
-					}
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/LipSync/LipSync.cs
+++ b/src/Vixen.Modules/Effect/LipSync/LipSync.cs
@@ -428,7 +428,10 @@ namespace VixenModules.Effect.LipSync
 					_data.LipSyncMode = value;
 					SetLipsyncModeBrowsables();
 					NormalizeMarkCollectionSelections();
-					MarkCollectionsChangedCore();
+					if (MarkCollections != null)
+					{
+						MarkCollectionsChangedCore();
+					}
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/LipSync/LipSync.cs
+++ b/src/Vixen.Modules/Effect/LipSync/LipSync.cs
@@ -17,7 +17,7 @@ using VixenModules.Property.Face;
 namespace VixenModules.Effect.LipSync
 {
 
-	public class LipSync : BaseEffect
+	public class LipSync : BaseEffect, IMarkCollectionSelection
 	{
 		private static NLog.Logger Logging = NLog.LogManager.GetCurrentClassLogger();
 		private LipSyncData _data;
@@ -302,16 +302,6 @@ namespace VixenModules.Effect.LipSync
 				return;
 			}
 
-			if (string.IsNullOrEmpty(MarkCollectionId))
-			{
-				var dmc = MarkCollections.FirstOrDefault(x => x.CollectionType == MarkCollectionType.Phoneme);
-				if (dmc != null && string.IsNullOrEmpty(MarkCollectionId))
-				{
-					MarkCollectionId = dmc.Name;
-				}
-			}
-			
-			
 			IMarkCollection mc = MarkCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)
 			{
@@ -330,20 +320,8 @@ namespace VixenModules.Effect.LipSync
 		{
 			if (LipSyncMode == LipSyncMode.MarkCollection)
 			{
-				var markCollection = MarkCollections.FirstOrDefault(x => x.Name.Equals(MarkCollectionId));
+				var markCollection = MarkCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 				InitializeMarkCollectionListeners(markCollection);
-			}
-		}
-
-		/// <inheritdoc />
-		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
-		{
-			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
-			if(mc != null)
-			{
-				//Our collection is gone!!!!
-				RemoveMarkCollectionListeners(mc);
-				MarkCollectionId = String.Empty;
 			}
 		}
 
@@ -449,19 +427,10 @@ namespace VixenModules.Effect.LipSync
 				{
 					_data.LipSyncMode = value;
 					SetLipsyncModeBrowsables();
+					NormalizeMarkCollectionSelections();
+					MarkCollectionsChangedCore();
 					IsDirty = true;
 					OnPropertyChanged();
-					if (_data.LipSyncMode == LipSyncMode.MarkCollection && _data.MarkCollectionId == Guid.Empty)
-					{
-						if (MarkCollections.Any())
-						{
-							var mc = MarkCollections.FirstOrDefault(x => x.CollectionType == MarkCollectionType.Phoneme);
-							if (mc != null)
-							{
-								MarkCollectionId = mc.Name;
-							}
-						}
-					}
 				}
 			}
 		}
@@ -889,6 +858,24 @@ namespace VixenModules.Effect.LipSync
 
 		/// <inheritdoc />
 		protected override EffectTypeModuleData EffectModuleData => _data;
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => LipSyncMode == LipSyncMode.MarkCollection;
+
+		Guid IMarkCollectionSelection.MarkCollectionId
+		{
+			get => _data.MarkCollectionId;
+			set => _data.MarkCollectionId = value;
+		}
+
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => MarkCollectionType.Phoneme;
+
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => false;
 		
 		#region Information
 

--- a/src/Vixen.Modules/Effect/LipSync/LipSync.cs
+++ b/src/Vixen.Modules/Effect/LipSync/LipSync.cs
@@ -326,7 +326,7 @@ namespace VixenModules.Effect.LipSync
 		#region Overrides of EffectModuleInstanceBase
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (LipSyncMode == LipSyncMode.MarkCollection)
 			{
@@ -336,7 +336,7 @@ namespace VixenModules.Effect.LipSync
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if(mc != null)

--- a/src/Vixen.Modules/Effect/Liquid/Liquid/Emitter.cs
+++ b/src/Vixen.Modules/Effect/Liquid/Liquid/Emitter.cs
@@ -14,7 +14,7 @@ namespace VixenModules.Effect.Liquid
 	/// Maintains an emitter.
 	/// </summary>
 	[ExpandableObject]
-	public class Emitter : ExpandoObjectBase, IEmitter
+	public class Emitter : ExpandoObjectBase, IEmitter, IMarkCollectionSelection
 	{
 		#region Constructor
 
@@ -897,6 +897,12 @@ namespace VixenModules.Effect.Liquid
 				OnPropertyChanged("MarkCollectionName");
 			}
 		}
+
+		bool IMarkCollectionSelection.IsActive => FlowControl == FlowControl.UseMarks;
+
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 		
 		private int _onTime = 0;
 

--- a/src/Vixen.Modules/Effect/Liquid/Liquid/Liquid.cs
+++ b/src/Vixen.Modules/Effect/Liquid/Liquid/Liquid.cs
@@ -673,6 +673,12 @@ namespace VixenModules.Effect.Liquid
 			EmitterList.MarkNameCollection = _markCollectionNames;
 		}
 
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			return EmitterList.OfType<IMarkCollectionSelection>();
+		}
+
 		/// <summary>
 		/// Method for effects to manage mark collections changing.
 		/// </summary>

--- a/src/Vixen.Modules/Effect/Liquid/Liquid/Liquid.cs
+++ b/src/Vixen.Modules/Effect/Liquid/Liquid/Liquid.cs
@@ -653,7 +653,7 @@ namespace VixenModules.Effect.Liquid
 		/// <summary>
 		/// Virtualized event handler for when the mark collection changes.
 		/// </summary>
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			// Loop over the mark collections
 			foreach (IMarkCollection collection in MarkCollections)
@@ -676,7 +676,7 @@ namespace VixenModules.Effect.Liquid
 		/// <summary>
 		/// Method for effects to manage mark collections changing.
 		/// </summary>
-		protected override void MarkCollectionsAdded(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsAddedCore(IList<IMarkCollection> addedCollections)
 		{
 			// Loop over the added mark collections
 			foreach (IMarkCollection markCollection in addedCollections)
@@ -693,7 +693,7 @@ namespace VixenModules.Effect.Liquid
 		/// <summary>
 		/// Virtualized event handler for when a mark collection has been removed.
 		/// </summary>		
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> removedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> removedCollections)
 		{
 			// Make a copy of the emitters in a weak attempt to minimize thread exceptions
 			IEnumerable<IEmitter> emitters = EmitterList.ToList();

--- a/src/Vixen.Modules/Effect/Shapes/Shapes.cs
+++ b/src/Vixen.Modules/Effect/Shapes/Shapes.cs
@@ -82,6 +82,10 @@ namespace VixenModules.Effect.Shapes
 
 		#region Shape Effect properties
 
+		/// <summary>
+		/// Gets or sets the source used to determine the shapes to render.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the shape source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[DisplayName(@"Shape Source")]
@@ -99,6 +103,7 @@ namespace VixenModules.Effect.Shapes
 				{
 					_data.ShapeMode = value;
 					UpdateShapeModeAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/Shapes/Shapes.cs
+++ b/src/Vixen.Modules/Effect/Shapes/Shapes.cs
@@ -17,7 +17,7 @@ using Vixen.TypeConverters;
 
 namespace VixenModules.Effect.Shapes
 {
-	public class Shapes : PixelEffectBase
+	public class Shapes : PixelEffectBase, IMarkCollectionSelection
 	{
 		private ShapesData _data;
 		private List<ShapesClass> _shapes;
@@ -895,6 +895,17 @@ namespace VixenModules.Effect.Shapes
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => ShapeMode != ShapeMode.None;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		private void UpdateAllAttributes()
 		{

--- a/src/Vixen.Modules/Effect/Shapes/Shapes.cs
+++ b/src/Vixen.Modules/Effect/Shapes/Shapes.cs
@@ -1970,7 +1970,7 @@ namespace VixenModules.Effect.Shapes
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (ShapeMode != ShapeMode.None)
 			{
@@ -1980,7 +1980,7 @@ namespace VixenModules.Effect.Shapes
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/State/State.cs
+++ b/src/Vixen.Modules/Effect/State/State.cs
@@ -14,7 +14,7 @@ using VixenModules.Property.State;
 
 namespace VixenModules.Effect.State
 {
-	public sealed class State: BaseEffect
+	public sealed class State: BaseEffect, IMarkCollectionSelection
 	{
 		internal const string AllStateItemsLabel = "<All>";
 		internal const string NoneStateItemLabel = "<None>";
@@ -63,6 +63,24 @@ namespace VixenModules.Effect.State
 		#region Overrides of BaseEffect
 
 		protected override EffectTypeModuleData EffectModuleData => _data;
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => RenderSource == StateRenderSource.MarkCollection;
+
+		Guid IMarkCollectionSelection.MarkCollectionId
+		{
+			get => _data.MarkCollectionId;
+			set => _data.MarkCollectionId = value;
+		}
+
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => MarkCollectionType.State;
+
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		/// <inheritdoc />
 		public override string Information => "Visit the Vixen Lights website for more information on this effect.";
@@ -312,16 +330,10 @@ namespace VixenModules.Effect.State
 					_data.RenderSource = value;
 					EnsureCustomStateItemRequired();
 					SetRenderSourceBrowsables();
+					NormalizeMarkCollectionSelections();
+					MarkCollectionsChangedCore();
 					IsDirty = true;
 					OnPropertyChanged();
-					if (_data.RenderSource == StateRenderSource.MarkCollection && _data.MarkCollectionId == Guid.Empty)
-					{
-						var stateMarkCollection = GetFirstStateMarkCollection();
-						if (stateMarkCollection != null)
-						{
-							MarkCollectionId = stateMarkCollection.Name;
-						}
-					}
 				}
 			}
 		}
@@ -644,18 +656,6 @@ namespace VixenModules.Effect.State
 			{
 				var markCollection = GetSelectedMarkCollection();
 				InitializeMarkCollectionListeners(markCollection);
-			}
-		}
-
-		/// <inheritdoc />
-		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> removedCollections)
-		{
-			var markCollection = removedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
-			if (markCollection != null)
-			{
-				//Our collection is gone!!!!
-				RemoveMarkCollectionListeners(markCollection);
-				MarkCollectionId = String.Empty;
 			}
 		}
 
@@ -1081,7 +1081,6 @@ namespace VixenModules.Effect.State
 
 		private static string CreateMissingStateItemLabel(Guid stateItemId) =>
 			$"<Missing State Item: {StateDefinitionDiscovery.ToShortId(stateItemId)}>";
-
 		#endregion
 
 		#region Custom State Items
@@ -1287,15 +1286,6 @@ namespace VixenModules.Effect.State
 			return MarkCollections.FirstOrDefault(collection => collection.Id == _data.MarkCollectionId);
 		}
 
-		private IMarkCollection? GetFirstStateMarkCollection()
-		{
-			if (!Enum.TryParse<MarkCollectionType>("State", out var stateType))
-			{
-				return null;
-			}
-
-			return MarkCollections.FirstOrDefault(collection => collection.CollectionType == stateType);
-		}
 
 		#endregion
 

--- a/src/Vixen.Modules/Effect/State/State.cs
+++ b/src/Vixen.Modules/Effect/State/State.cs
@@ -330,11 +330,7 @@ namespace VixenModules.Effect.State
 					_data.RenderSource = value;
 					EnsureCustomStateItemRequired();
 					SetRenderSourceBrowsables();
-					NormalizeMarkCollectionSelections();
-					if (MarkCollections != null)
-					{
-						MarkCollectionsChangedCore();
-					}
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/State/State.cs
+++ b/src/Vixen.Modules/Effect/State/State.cs
@@ -331,7 +331,10 @@ namespace VixenModules.Effect.State
 					EnsureCustomStateItemRequired();
 					SetRenderSourceBrowsables();
 					NormalizeMarkCollectionSelections();
-					MarkCollectionsChangedCore();
+					if (MarkCollections != null)
+					{
+						MarkCollectionsChangedCore();
+					}
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/State/State.cs
+++ b/src/Vixen.Modules/Effect/State/State.cs
@@ -638,7 +638,7 @@ namespace VixenModules.Effect.State
 		#region Overrides of EffectModuleInstanceBase
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (RenderSource == StateRenderSource.MarkCollection)
 			{
@@ -648,7 +648,7 @@ namespace VixenModules.Effect.State
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> removedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> removedCollections)
 		{
 			var markCollection = removedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (markCollection != null)

--- a/src/Vixen.Modules/Effect/Strobe/Strobe.cs
+++ b/src/Vixen.Modules/Effect/Strobe/Strobe.cs
@@ -13,7 +13,7 @@ using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Strobe
 {
-	public class Strobe : BaseEffect
+	public class Strobe : BaseEffect, IMarkCollectionSelection
 	{
 		private EffectIntents _elementData;
 		private StrobeData _data;
@@ -94,6 +94,17 @@ namespace VixenModules.Effect.Strobe
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => StrobeSource != StrobeSource.TimeInterval;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		#region Config
 

--- a/src/Vixen.Modules/Effect/Strobe/Strobe.cs
+++ b/src/Vixen.Modules/Effect/Strobe/Strobe.cs
@@ -437,7 +437,7 @@ namespace VixenModules.Effect.Strobe
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (StrobeSource != StrobeSource.TimeInterval)
 			{
@@ -447,7 +447,7 @@ namespace VixenModules.Effect.Strobe
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/Strobe/Strobe.cs
+++ b/src/Vixen.Modules/Effect/Strobe/Strobe.cs
@@ -108,6 +108,10 @@ namespace VixenModules.Effect.Strobe
 
 		#region Config
 
+		/// <summary>
+		/// Gets or sets the timing source used by the strobe effect.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the timing source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[ProviderDisplayName(@"TimingSource")]
@@ -125,6 +129,7 @@ namespace VixenModules.Effect.Strobe
 				{
 					_data.StrobeSource = value;
 					UpdateStrobeModeAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/Text/Text.cs
+++ b/src/Vixen.Modules/Effect/Text/Text.cs
@@ -16,7 +16,7 @@ using VixenModules.EffectEditor.EffectDescriptorAttributes;
 
 namespace VixenModules.Effect.Text
 {
-	public class Text : PixelEffectBase
+	public class Text : PixelEffectBase, IMarkCollectionSelection
 	{
 		private TextData _data;
 		private static Color EmptyColor = Color.FromArgb(0, 0, 0, 0);
@@ -664,6 +664,17 @@ namespace VixenModules.Effect.Text
 		{
 			get { return _data; }
 		}
+
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			yield return this;
+		}
+
+		bool IMarkCollectionSelection.IsActive => TextSource != TextSource.None;
+		Guid IMarkCollectionSelection.MarkCollectionId { get => _data.MarkCollectionId; set => _data.MarkCollectionId = value; }
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 
 		private void UpdateAllAttributes()
 		{

--- a/src/Vixen.Modules/Effect/Text/Text.cs
+++ b/src/Vixen.Modules/Effect/Text/Text.cs
@@ -1614,7 +1614,7 @@ namespace VixenModules.Effect.Text
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			if (TextSource != TextSource.None)
 			{
@@ -1624,7 +1624,7 @@ namespace VixenModules.Effect.Text
 		}
 
 		/// <inheritdoc />
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> addedCollections)
 		{
 			var mc = addedCollections.FirstOrDefault(x => x.Id == _data.MarkCollectionId);
 			if (mc != null)

--- a/src/Vixen.Modules/Effect/Text/Text.cs
+++ b/src/Vixen.Modules/Effect/Text/Text.cs
@@ -74,6 +74,10 @@ namespace VixenModules.Effect.Text
 
 		#region Config properties
 
+		/// <summary>
+		/// Gets or sets the source used to trigger text rendering.
+		/// </summary>
+		/// <value>One of the enumeration values that specifies the text source.</value>
 		[Value]
 		[ProviderCategory("Config", 1)]
 		[ProviderDisplayName(@"TextTrigger")]
@@ -91,6 +95,7 @@ namespace VixenModules.Effect.Text
 				{
 					_data.TextSource = value;
 					UpdateTextModeAttributes();
+					ActivateMarkCollectionSelections();
 					IsDirty = true;
 					OnPropertyChanged();
 				}

--- a/src/Vixen.Modules/Effect/Wave/Wave/Wave.cs
+++ b/src/Vixen.Modules/Effect/Wave/Wave/Wave.cs
@@ -458,7 +458,7 @@ namespace VixenModules.Effect.Wave
 		/// <summary>
 		/// Virtualized event handler for when the mark collection changes.
 		/// </summary>
-		protected override void MarkCollectionsChanged()
+		protected override void MarkCollectionsChangedCore()
 		{
 			// Loop over the mark collections
 			foreach (IMarkCollection collection in MarkCollections)
@@ -478,7 +478,7 @@ namespace VixenModules.Effect.Wave
 		/// <summary>
 		/// Method for effects to manage mark collections changing.
 		/// </summary>
-		protected override void MarkCollectionsAdded(IList<IMarkCollection> addedCollections)
+		protected override void MarkCollectionsAddedCore(IList<IMarkCollection> addedCollections)
 		{
 			// Loop over the added mark collections
 			foreach (IMarkCollection markCollection in addedCollections)
@@ -495,7 +495,7 @@ namespace VixenModules.Effect.Wave
 		/// <summary>
 		/// Virtualized event handler for when a mark collection has been removed.
 		/// </summary>		
-		protected override void MarkCollectionsRemoved(IList<IMarkCollection> removedCollections)
+		protected override void MarkCollectionsRemovedCore(IList<IMarkCollection> removedCollections)
 		{
 			// Make a copy of the waves in an attempt to minimize thread exceptions
 			IEnumerable<IWaveform> waves = Waves.ToList();

--- a/src/Vixen.Modules/Effect/Wave/Wave/Wave.cs
+++ b/src/Vixen.Modules/Effect/Wave/Wave/Wave.cs
@@ -475,6 +475,12 @@ namespace VixenModules.Effect.Wave
 			Waves.MarkCollections = MarkCollections;
 		}
 
+		/// <inheritdoc />
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			return Waves.OfType<IMarkCollectionSelection>();
+		}
+
 		/// <summary>
 		/// Method for effects to manage mark collections changing.
 		/// </summary>

--- a/src/Vixen.Modules/Effect/Wave/Wave/Waveform.cs
+++ b/src/Vixen.Modules/Effect/Wave/Wave/Waveform.cs
@@ -14,7 +14,7 @@ namespace VixenModules.Effect.Wave
 	/// Maintains a waveform for the wave effect.
 	/// </summary>
 	[ExpandableObject]
-	public class Waveform : ExpandoObjectBase, IWaveform
+	public class Waveform : ExpandoObjectBase, IWaveform, IMarkCollectionSelection
 	{
 		#region Constructor
 
@@ -423,6 +423,12 @@ namespace VixenModules.Effect.Wave
 				OnPropertyChanged("MarkCollectionName");
 			}
 		}
+
+		bool IMarkCollectionSelection.IsActive => WaveType == WaveType.DecayingSine && UseMarks;
+
+		MarkCollectionType? IMarkCollectionSelection.PreferredCollectionType => null;
+
+		bool IMarkCollectionSelection.AllowsFirstCollectionFallback => true;
 		
 		private ObservableCollection<string> _markNameCollection = null;
 

--- a/src/Vixen.Tests/Effects/BaseEffectMarkCollectionSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/BaseEffectMarkCollectionSelectionTests.cs
@@ -17,9 +17,24 @@ public sealed class BaseEffectMarkCollectionSelectionTests
 		// Arrange
 		var first = new MarkCollection { Id = Guid.NewGuid(), Name = "First" };
 		var effect = new TestEffect();
+		effect.ActivateSelection();
 
 		// Act
 		effect.MarkCollections = new ObservableCollection<IMarkCollection> { first };
+
+		// Assert
+		Assert.Equal(first.Id, effect.SelectionIdObservedByChangeHook);
+	}
+
+	[Fact]
+	public void ModeActivation_NormalizesAnEmptySelection()
+	{
+		// Arrange
+		var first = new MarkCollection { Id = Guid.NewGuid(), Name = "First" };
+		var effect = new TestEffect { MarkCollections = new ObservableCollection<IMarkCollection> { first } };
+
+		// Act
+		effect.ActivateSelection();
 
 		// Assert
 		Assert.Equal(first.Id, effect.SelectionIdObservedByChangeHook);
@@ -31,6 +46,12 @@ public sealed class BaseEffectMarkCollectionSelectionTests
 		private readonly TestSelection _selection = new();
 
 		public Guid SelectionIdObservedByChangeHook { get; private set; }
+
+		public void ActivateSelection()
+		{
+			_selection.IsActive = true;
+			ActivateMarkCollectionSelections();
+		}
 
 		protected override EffectTypeModuleData EffectModuleData => _data;
 
@@ -60,7 +81,7 @@ public sealed class BaseEffectMarkCollectionSelectionTests
 
 	private sealed class TestSelection : IMarkCollectionSelection
 	{
-		public bool IsActive => true;
+		public bool IsActive { get; set; }
 		public Guid MarkCollectionId { get; set; }
 		public MarkCollectionType? PreferredCollectionType => null;
 		public bool AllowsFirstCollectionFallback => true;

--- a/src/Vixen.Tests/Effects/BaseEffectMarkCollectionSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/BaseEffectMarkCollectionSelectionTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.ObjectModel;
+using Vixen.Intent;
+using Vixen.Marks;
+using Vixen.Module.Effect;
+using Vixen.Sys;
+using VixenModules.App.Marks;
+using VixenModules.Effect.Effect;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+public sealed class BaseEffectMarkCollectionSelectionTests
+{
+	[Fact]
+	public void MarkCollectionsChanged_NormalizesBeforeInvokingEffectHook()
+	{
+		// Arrange
+		var first = new MarkCollection { Id = Guid.NewGuid(), Name = "First" };
+		var effect = new TestEffect();
+
+		// Act
+		effect.MarkCollections = new ObservableCollection<IMarkCollection> { first };
+
+		// Assert
+		Assert.Equal(first.Id, effect.SelectionIdObservedByChangeHook);
+	}
+
+	private sealed class TestEffect : BaseEffect
+	{
+		private readonly TestEffectData _data = new();
+		private readonly TestSelection _selection = new();
+
+		public Guid SelectionIdObservedByChangeHook { get; private set; }
+
+		protected override EffectTypeModuleData EffectModuleData => _data;
+
+		protected override IEnumerable<IMarkCollectionSelection> GetMarkCollectionSelections()
+		{
+			return [_selection];
+		}
+
+		protected override void MarkCollectionsChangedCore()
+		{
+			SelectionIdObservedByChangeHook = _selection.MarkCollectionId;
+		}
+
+		protected override void TargetNodesChanged()
+		{
+		}
+
+		protected override void _PreRender(CancellationTokenSource cancellationToken)
+		{
+		}
+
+		protected override EffectIntents _Render()
+		{
+			return new EffectIntents();
+		}
+	}
+
+	private sealed class TestSelection : IMarkCollectionSelection
+	{
+		public bool IsActive => true;
+		public Guid MarkCollectionId { get; set; }
+		public MarkCollectionType? PreferredCollectionType => null;
+		public bool AllowsFirstCollectionFallback => true;
+	}
+
+	private sealed class TestEffectData : EffectTypeModuleData
+	{
+		protected override EffectTypeModuleData CreateInstanceForClone()
+		{
+			return new TestEffectData { TargetPositioning = TargetPositioning };
+		}
+	}
+}

--- a/src/Vixen.Tests/Effects/DissolveMarkCollectionSelectionTests.cs
+++ b/src/Vixen.Tests/Effects/DissolveMarkCollectionSelectionTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.ObjectModel;
+using Vixen.Marks;
+using VixenModules.App.Marks;
+using VixenModules.Effect.Dissolve;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+/// <summary>
+/// Verifies Mark Collection selection behavior for the Dissolve effect.
+/// </summary>
+public sealed class DissolveMarkCollectionSelectionTests
+{
+	/// <summary>
+	/// Verifies that activating Mark Collection mode selects the first available collection when no selection exists.
+	/// </summary>
+	[Fact]
+	public void DissolveMode_MarkCollection_SelectsTheFirstCollectionWhenNoneIsSelected()
+	{
+		// Arrange
+		var first = new MarkCollection { Id = Guid.NewGuid(), Name = "First" };
+		var effect = new Dissolve
+		{
+			MarkCollections = new ObservableCollection<IMarkCollection> { first }
+		};
+
+		// Act
+		effect.DissolveMode = DissolveMode.MarkCollection;
+
+		// Assert
+		var data = Assert.IsType<DissolveData>(effect.ModuleData);
+		Assert.Equal(first.Id, data.MarkCollectionId);
+	}
+}

--- a/src/Vixen.Tests/Effects/MarkCollectionSelectionServiceTests.cs
+++ b/src/Vixen.Tests/Effects/MarkCollectionSelectionServiceTests.cs
@@ -1,0 +1,181 @@
+using System.Collections.ObjectModel;
+using Vixen.Marks;
+using VixenModules.App.Marks;
+using Xunit;
+
+namespace Vixen.Tests.Effects;
+
+public sealed class MarkCollectionSelectionServiceTests
+{
+	private readonly MarkCollectionSelectionService _service = new();
+
+	[Fact]
+	public void Normalize_OrdinaryActiveSelection_UsesFirstCollection()
+	{
+		// Arrange
+		var first = CreateCollection("First", MarkCollectionType.Generic);
+		var second = CreateCollection("Second", MarkCollectionType.State);
+		var selection = new TestSelection { IsActive = true, AllowsFirstCollectionFallback = true };
+
+		// Act
+		var result = _service.Normalize([first, second], selection);
+
+		// Assert
+		Assert.Equal(first.Id, result);
+	}
+
+	[Fact]
+	public void Normalize_StateSelection_PrefersFirstStateCollection()
+	{
+		// Arrange
+		var generic = CreateCollection("Generic", MarkCollectionType.Generic);
+		var firstState = CreateCollection("First State", MarkCollectionType.State);
+		var secondState = CreateCollection("Second State", MarkCollectionType.State);
+		var selection = new TestSelection
+		{
+			IsActive = true,
+			PreferredCollectionType = MarkCollectionType.State,
+			AllowsFirstCollectionFallback = true
+		};
+
+		// Act
+		var result = _service.Normalize([generic, firstState, secondState], selection);
+
+		// Assert
+		Assert.Equal(firstState.Id, result);
+	}
+
+	[Fact]
+	public void Normalize_PreferredSelectionWithoutMatch_UsesFirstCollectionWhenAllowed()
+	{
+		// Arrange
+		var first = CreateCollection("First", MarkCollectionType.Generic);
+		var selection = new TestSelection
+		{
+			IsActive = true,
+			PreferredCollectionType = MarkCollectionType.State,
+			AllowsFirstCollectionFallback = true
+		};
+
+		// Act
+		var result = _service.Normalize([first], selection);
+
+		// Assert
+		Assert.Equal(first.Id, result);
+	}
+
+	[Fact]
+	public void Normalize_PhonemeSelectionWithoutMatch_ReturnsEmpty()
+	{
+		// Arrange
+		var selection = new TestSelection
+		{
+			IsActive = true,
+			PreferredCollectionType = MarkCollectionType.Phoneme,
+			AllowsFirstCollectionFallback = false
+		};
+
+		// Act
+		var result = _service.Normalize([CreateCollection("Generic", MarkCollectionType.Generic)], selection);
+
+		// Assert
+		Assert.Equal(Guid.Empty, result);
+	}
+
+	[Theory]
+	[InlineData(null, true)]
+	[InlineData(MarkCollectionType.State, true)]
+	[InlineData(MarkCollectionType.Phoneme, false)]
+	public void Normalize_ValidSelection_PreservesIdRegardlessOfPolicy(MarkCollectionType? preferredCollectionType, bool allowsFirstCollectionFallback)
+	{
+		// Arrange
+		var selected = CreateCollection("Existing Generic", MarkCollectionType.Generic);
+		var preferred = CreateCollection("Preferred", MarkCollectionType.State);
+		var selection = new TestSelection
+		{
+			IsActive = true,
+			MarkCollectionId = selected.Id,
+			PreferredCollectionType = preferredCollectionType,
+			AllowsFirstCollectionFallback = allowsFirstCollectionFallback
+		};
+
+		// Act
+		var result = _service.Normalize([preferred, selected], selection);
+
+		// Assert
+		Assert.Equal(selected.Id, result);
+	}
+
+	[Fact]
+	public void Normalize_MissingNonEmptyId_RepairsSelection()
+	{
+		// Arrange
+		var first = CreateCollection("First", MarkCollectionType.Generic);
+		var selection = new TestSelection
+		{
+			IsActive = true,
+			MarkCollectionId = Guid.NewGuid(),
+			AllowsFirstCollectionFallback = true
+		};
+
+		// Act
+		var result = _service.Normalize([first], selection);
+
+		// Assert
+		Assert.Equal(first.Id, result);
+	}
+
+	[Fact]
+	public void Normalize_NoCollectionsOrInactiveSelection_RetainsRequiredResult()
+	{
+		// Arrange
+		var activeSelection = new TestSelection { IsActive = true, MarkCollectionId = Guid.NewGuid(), AllowsFirstCollectionFallback = true };
+		var inactiveId = Guid.NewGuid();
+		var inactiveSelection = new TestSelection { MarkCollectionId = inactiveId };
+
+		// Act
+		var activeResult = _service.Normalize([], activeSelection);
+		var inactiveResult = _service.Normalize([], inactiveSelection);
+
+		// Assert
+		Assert.Equal(Guid.Empty, activeResult);
+		Assert.Equal(inactiveId, inactiveResult);
+	}
+
+	[Fact]
+	public void Normalize_DoesNotModifySharedCollections()
+	{
+		// Arrange
+		var first = CreateCollection("First", MarkCollectionType.Generic);
+		first.LinkedMarkCollectionId = Guid.NewGuid();
+		var second = CreateCollection("Second", MarkCollectionType.State);
+		second.LinkedMarkCollectionId = Guid.NewGuid();
+		var collections = new ObservableCollection<IMarkCollection> { first, second };
+		var snapshot = collections.Select(collection => (collection.Id, collection.Name, collection.CollectionType, collection.LinkedMarkCollectionId, collection.Marks.Count)).ToArray();
+		var selection = new TestSelection { IsActive = true, PreferredCollectionType = MarkCollectionType.State, AllowsFirstCollectionFallback = true };
+
+		// Act
+		_ = _service.Normalize(collections, selection);
+
+		// Assert
+		Assert.Equal(snapshot, collections.Select(collection => (collection.Id, collection.Name, collection.CollectionType, collection.LinkedMarkCollectionId, collection.Marks.Count)).ToArray());
+	}
+
+	private static MarkCollection CreateCollection(string name, MarkCollectionType collectionType)
+	{
+		return new MarkCollection
+		{
+			Id = Guid.NewGuid(),
+			Name = name,
+			CollectionType = collectionType
+		};
+	}
+
+	private sealed class TestSelection : IMarkCollectionSelection
+	{
+		public bool IsActive { get; init; }
+		public Guid MarkCollectionId { get; set; }
+		public MarkCollectionType? PreferredCollectionType { get; init; }
+		public bool AllowsFirstCollectionFallback { get; init; }
+	}
+}

--- a/src/Vixen.Tests/Sequencer/MarkCollectionTypeTests.cs
+++ b/src/Vixen.Tests/Sequencer/MarkCollectionTypeTests.cs
@@ -1,0 +1,59 @@
+using System.Runtime.Serialization;
+using TimedSequenceEditor.Forms.WPF.MarksDocker.ViewModels;
+using Vixen.Marks;
+using VixenModules.App.Marks;
+using Xunit;
+
+namespace Vixen.Tests.Sequencer;
+
+public sealed class MarkCollectionTypeTests
+{
+	[Fact]
+	public void Values_PreserveExistingSerializedValuesAndAppendState()
+	{
+		Assert.Equal(0, (int)MarkCollectionType.Generic);
+		Assert.Equal(1, (int)MarkCollectionType.Phrase);
+		Assert.Equal(2, (int)MarkCollectionType.Word);
+		Assert.Equal(3, (int)MarkCollectionType.Phoneme);
+		Assert.Equal(4, (int)MarkCollectionType.State);
+	}
+
+	[Fact]
+	public void NativeMarkCollectionSerialization_RoundTripsStateType()
+	{
+		var collection = new MarkCollection
+		{
+			Name = "State labels",
+			CollectionType = MarkCollectionType.State
+		};
+		var serializer = new DataContractSerializer(typeof(MarkCollection));
+
+		using var stream = new MemoryStream();
+		serializer.WriteObject(stream, collection);
+		stream.Position = 0;
+
+		var roundTrip = Assert.IsType<MarkCollection>(serializer.ReadObject(stream));
+
+		Assert.Equal(MarkCollectionType.State, roundTrip.CollectionType);
+	}
+
+	[Fact]
+	public void DockerTypeMenu_ContainsStateAndStateIsNonLinkable()
+	{
+		var menuTypes = Enum.GetValues<MarkCollectionType>();
+
+		Assert.Contains(MarkCollectionType.State, menuTypes);
+		Assert.DoesNotContain(MarkCollectionType.State, new[] { MarkCollectionType.Phoneme, MarkCollectionType.Word });
+	}
+
+	[Fact]
+	public void ExportRow_StateCollectionIncludesTextByDefault()
+	{
+		var row = new MarkCollectionExportRowViewModel(new MarkCollection
+		{
+			CollectionType = MarkCollectionType.State
+		});
+
+		Assert.True(row.IsTextIncluded);
+	}
+}

--- a/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
+++ b/src/Vixen.Tests/Sequencer/PangolinBeyondMarkImportTests.cs
@@ -220,6 +220,7 @@ public sealed class PangolinBeyondMarkImportTests
 		// Assert
 		Assert.Equal(MarkCollectionImportStatus.Succeeded, result.Status);
 		Assert.Equal(["Voice - Phrase", "Voice - Word", "Voice - Phoneme"], result.Collections.Select(collection => collection.Name));
+		Assert.Equal([MarkCollectionType.Phrase, MarkCollectionType.Word, MarkCollectionType.Phoneme], result.Collections.Select(collection => collection.CollectionType));
 		Assert.Equal(result.Collections[0].Id, result.Collections[1].LinkedMarkCollectionId);
 		Assert.Equal(result.Collections[1].Id, result.Collections[2].LinkedMarkCollectionId);
 	}


### PR DESCRIPTION
## Summary

- Add `State` as a persisted Mark Collection type. It appears in the
  marks docker, remains non-linkable, and includes mark text by default
  when exported.
- Centralize Mark Collection selection normalization so active effects
  retain valid selections and repair only empty or deleted IDs.
- Apply the appropriate selection policy to ordinary mark-driven effects,
  State, LipSync, Wave, and Liquid. Switching an ordinary effect into
  Mark Collection mode now selects the first available collection.
- Preserve LipSync's Phoneme-only default behavior and State's preference
  for State collections before falling back to the first collection.

## Validation

- `msbuild Vixen.sln -m -t:Vixen_Tests -p:Configuration=Release -p:Platform=x64 -p:PlatformTarget=x64 -v:q`
  - Passed
- Focused BaseEffect activation tests: 2 passed
- Focused Dissolve Mark Collection activation test: 1 passed
- Manually verified Alternate and Dissolve now select the first Mark
  Collection when Mark Collection mode is enabled.

## Notes

- Selection is identity-based (`Guid`), never display-name-based.
- Existing valid selections are preserved even if a preferred collection
  type is subsequently added.
- Shared Mark Collection metadata and ordering are never modified.
- Additional State, LipSync, Wave, and Liquid lifecycle integration
  coverage remains documented as follow-up work in the ExecPlan.